### PR TITLE
Uncommented one slow advanced test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ test: build testtest
 advtest: build
 	@echo "Running advanced tests for type checker ..."
 	rm -rf _etylizer #TODO --force flag?
-	./ety -l debug test_files/tycheck/check_if.erl -o foo -o bar
+	# TODO slow
+	# ./ety -l debug test_files/tycheck/check_if.erl -o foo -o bar
 	! ./ety -l debug test_files/tycheck/check_if_fail.erl -o foo -o bar
 	./ety -l debug test_files/tycheck/concat.erl
 	! ./ety -l debug test_files/tycheck/concat_fail.erl


### PR DESCRIPTION
One advanced test is stalling the pipeline after #38 . Removed that test and added tracking for all slow tests in #66 .