### PR TITLE
Add missing new line characters

### DIFF
--- a/src/ety_main.erl
+++ b/src/ety_main.erl
@@ -59,7 +59,7 @@ parse_args(Args) ->
                     case O of
                         {log_level, S} ->
                             case log:parse_level(S) of
-                                bad_log_level -> utils:quit(1, "Invalid log level: ~s", S);
+                                bad_log_level -> utils:quit(1, "Invalid log level: ~s~n", S);
                                 L -> Opts#opts{ log_level = L }
                             end;
                         {define, S} ->
@@ -85,7 +85,7 @@ parse_args(Args) ->
     if
         Opts#opts.help ->
             getopt:usage(OptSpecList, "ety"),
-            utils:quit(1, "Aborting");
+            utils:quit(1, "Aborting~n");
         true -> ok
     end,
     Opts.

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -161,7 +161,7 @@ generate_input_file_list(Opts) ->
     case Opts#opts.src_paths of
         [] ->
             case Opts#opts.files of
-                [] -> utils:quit(1, "No input files given, aborting. Use -h to print help.\n");
+                [] -> utils:quit(1, "No input files given, aborting. Use -h to print help.~n");
                 Files -> Files
             end;
         Paths ->

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -161,7 +161,7 @@ generate_input_file_list(Opts) ->
     case Opts#opts.src_paths of
         [] ->
             case Opts#opts.files of
-                [] -> utils:quit(1, "No input files given, aborting. Use -h to print help.");
+                [] -> utils:quit(1, "No input files given, aborting. Use -h to print help.\n");
                 Files -> Files
             end;
         Paths ->


### PR DESCRIPTION
Presently the output is incomplete:
```bash
$ ./ety
No input files given, aborting. Use -h to print help.$
```