### PR TITLE
Introduce caching for erlang_ty_to_ast to prevent unnecessary transformations

### DIFF
--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -11,7 +11,7 @@
 
 reset() ->
     catch ets:delete(?VAR_ETS),
-    erlang:put(ty_asy_cache, #{}),
+    erlang:put(ty_ast_cache, #{}),
     ets:new(?VAR_ETS, [public, named_table]).
 
 unfold_intersection([], All) -> All;


### PR DESCRIPTION
When running this tool locally it takes a very long time to complete, for a single file (146 lines) it was taking 18-20 seconds to run. Using the linux `perf` tool I tracked the most expensive operations to `erlang_ty_to_ast`, which calls `ty_rec:transform` regardless of if it was already calculated. I added a process dictionary cache here, which reduced the time to ~7 seconds.

The 'regular' test suite doesn't look faster, but I am pretty sure that all tests are passing. The advanced suite still takes a long time.