### PR TITLE
Adding SANITY macro to etally:saturate, fixing debug definition through rebar.config profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: build test check all clean gradualize check_ast_trans_ty \
+.PHONY: release build test check all clean gradualize check_ast_trans_ty \
 	check_syntax_antidote check_ast_trans_antidote check_types_antidote \
 	check_syntax_riak check_ast_trans_riak check_types_riak
 
 REBAR = ./rebar3
+
+release:
+	$(REBAR) as prod escriptize
 
 build:
 	$(REBAR) escriptize

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,3 @@
-{erl_opts, [debug_info]}.
 {deps, [
   {getopt, "1.0.2"}
 ]}.
@@ -13,10 +12,16 @@
 {escript_name, ety}.
 {escript_emu_args, "%%! -escript main ety_main -pz ety/ety/ebin\n"}.
 
-{profiles,
-  [{test, [
+{profiles, [
+  {test, [
+    {erl_opts, [{d, debug}, debug_info]},
     {deps, [{proper, "1.4.0"}, coveralls]},
-    {extra_src_dirs, [{"test", [{recursive, true}]}]}
+    {extra_src_dirs, [{"test", [{recursive, true}]}]}]},
+  {default, [
+    {erl_opts, [{d, debug}, debug_info]}
+  ]},
+  {prod, [
+    {erl_opts, [no_debug_info]}
   ]}
 ]}.
 

--- a/src/erlang_types/etally.erl
+++ b/src/erlang_types/etally.erl
@@ -5,10 +5,16 @@
   tally/2
 ]).
 
--define(debug, true).
+% Exports to silence debug warnings
+-export([
+  sanity_substitution/3,
+  is_valid_substitution/2
+]).
 
 -include_lib("../log.hrl").
 -include_lib("sanity.hrl").
+
+%-define(debug, true).
 
 tally(Constraints) -> tally(Constraints, sets:new()).
 
@@ -103,7 +109,7 @@ apply_substitution(Ty, Substitutions) ->
   SubstFun = fun({Var, To}, Tyy) ->
     Mapping = #{Var => To},
     Result = ty_rec:substitute(Tyy, Mapping),
-    sanity_substitution({Var, To}, Tyy, Result),
+    ?SANITY(substitution_sanity_check, sanity_substitution({Var, To}, Tyy, Result)),
     Result
              end,
   lists:foldl(SubstFun, Ty, Substitutions).

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -1,8 +1,8 @@
 -module(ty_rec).
 
--define(debug, true).
-
 -include_lib("sanity.hrl").
+
+%-define(debug, true).
 
 -define(F(Z), fun() -> Z end).
 


### PR DESCRIPTION
This fixes https://github.com/etylizer/etylizer/issues/93.

There are hard-coded `debug` macro definitions in the `etally.erl` and `ty_rec.erl` files. To make this configurable, two new `rebar3` profiles are added, `prod` and `default`. `default` and `test` both define the `debug` macro at compile time, while `prod` does not. `prod` builds have a new make target: `make release`. This has one down-side though, the `ety` script hard-codes the path to the `default` profile, while the `prod` release needs to be `_build/prod/bin/ety`, I'm not sure the best way forward with this.

Finally, the `prod` profile removes the debug info from the executable.