### PR TITLE
Introduce equivalence constraints in constraint generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	check_syntax_antidote check_ast_trans_antidote check_types_antidote \
 	check_syntax_riak check_ast_trans_riak check_types_riak
 
-REBAR = ./rebar3
+REBAR = rebar3
 
 build:
 	$(REBAR) escriptize

--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -278,6 +278,7 @@ ast_to_erlang_ty({negation, Ty}) -> ty_rec:negate(ast_to_erlang_ty(Ty));
 ast_to_erlang_ty(T) ->
     erlang:error({"Norm not implemented or malformed type", T}).
 
+-spec ast_to_erlang_ty_var(ast:ty_var()) -> ty_variable:var().
 ast_to_erlang_ty_var({var, Name}) when is_atom(Name) ->
     maybe_new_variable(Name).
 

--- a/src/constr.erl
+++ b/src/constr.erl
@@ -29,7 +29,8 @@
 -type simp_constr() :: constr_subty() | constr_unsatisfiable().
 
 -type constr_subty() :: {csubty, locs(), ast:ty(), ast:ty()}.
--type constr_var() :: {cvar, locs(), ast:any_ref(), ast:ty()}.
+-type constr_var() :: {cvar, locs(), ast:any_ref(), ast:ty()}
+                    | {cvar_rev, locs(), ast:ty(), ast:any_ref()}.
 -type constr_op() :: {cop, locs(), atom(), arity(), ast:ty()}.
 -type constr_def() :: {cdef, locs(), constr_env(), constrs()}.
 -type constr_case() :: {ccase,

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -106,18 +106,6 @@ exps_constrs(Ctx, L, Es, T, Mode) ->
 
 -type exp_constrs_mode() :: subty | equiv.
 
--spec mk_constrs(constr:locs(), ast:ty(), ast:ty(), exp_constrs_mode()) -> constr:constrs().
-mk_constrs(Locs, Ty1, Ty2, subty) ->
-    single({csubty, Locs, Ty1, Ty2});
-mk_constrs(Locs, Ty1, Ty2, equiv) ->
-    sets:from_list([{csubty, Locs, Ty1, Ty2}, {csubty, Locs, Ty2, Ty1}]).
-
--spec mk_var_constrs(constr:locs(), ast:ty(), ast:ty(), exp_constrs_mode()) -> constr:constrs().
-mk_var_constrs(Locs, X, Ty, subty) ->
-    single({cvar, Locs, X, Ty});
-mk_var_constrs(Locs, X, Ty, equiv) ->
-    sets:from_list([{cvar, Locs, X, Ty}, {cvar_rev, Locs, Ty, X}]).
-
 -spec exp_constrs(ctx(), ast:exp(), ast:ty(), exp_constrs_mode()) -> constr:constrs().
 exp_constrs(Ctx, E, T, Mode) ->
     case E of
@@ -259,6 +247,18 @@ exp_constrs(Ctx, E, T, Mode) ->
             mk_var_constrs(mk_locs(Msg, L), AnyRef, T, Mode);
         X -> errors:uncovered_case(?FILE, ?LINE, X)
     end.
+
+-spec mk_constrs(constr:locs(), ast:ty(), ast:ty(), exp_constrs_mode()) -> constr:constrs().
+mk_constrs(Locs, Ty1, Ty2, subty) ->
+    single({csubty, Locs, Ty1, Ty2});
+mk_constrs(Locs, Ty1, Ty2, equiv) ->
+    sets:from_list([{csubty, Locs, Ty1, Ty2}, {csubty, Locs, Ty2, Ty1}]).
+
+-spec mk_var_constrs(constr:locs(), ast:any_ref(), ast:ty(), exp_constrs_mode()) -> constr:constrs().
+mk_var_constrs(Locs, X, Ty, subty) ->
+    single({cvar, Locs, X, Ty});
+mk_var_constrs(Locs, X, Ty, equiv) ->
+    sets:from_list([{cvar, Locs, X, Ty}, {cvar_rev, Locs, Ty, X}]).
 
 -spec ty_without(ast:ty(), ast:ty()) -> ast:ty().
 ty_without(T1, T2) -> ast_lib:mk_intersection([T1, ast_lib:mk_negation(T2)]).

--- a/src/erlang_types/ty_variable.erl
+++ b/src/erlang_types/ty_variable.erl
@@ -9,6 +9,8 @@
 
 -export([new/1, smallest/3, normalize/6, transform/2, get_new_id/0]).
 
+-export_type([var/0]).
+
 -record(var, {id, name}).
 -type var() :: #var{id :: integer(), name :: string()}.
 

--- a/src/errors.erl
+++ b/src/errors.erl
@@ -40,7 +40,7 @@ bug(Msg, Args) ->
 
 -spec uncovered_case(file:filename(), t:lineno(), any()) -> no_return().
 uncovered_case(File, Line, X) ->
-    bug("uncovered case in ~s:~w, unmatched value: ~w", [File, Line, X]).
+    bug("uncovered case in ~s:~w, unmatched value:~n~200p", [File, Line, X]).
 
 -spec ty_error(ast:loc(), string(), any()) -> no_return().
 ty_error(Loc, Msg, Args) ->

--- a/src/parse_cache.erl
+++ b/src/parse_cache.erl
@@ -63,7 +63,7 @@ really_parse_file(Kind, File, Opts) ->
             {extern, Includes} ->
                 #parse_opts{ verbose = false, includes = Includes, defines = Opts#opts.defines }
         end,
-    ?LOG_DEBUG("Parsing ~s with options ~p ...", File, ParseOpts),
+    ?LOG_DEBUG("Parsing ~s ...", File),
     RawForms = parse:parse_file_or_die(File, ParseOpts),
     if  Opts#opts.dump_raw -> ?LOG_NOTE("Raw forms in ~s:~n~p", File, RawForms);
         true -> ok

--- a/src/pretty.erl
+++ b/src/pretty.erl
@@ -290,6 +290,11 @@ constr(X) ->
                                        locs(Locs),
                                        ref(Ref),
                                        ty(T)]));
+               {cvar_rev, Locs, T, Ref} ->
+                   brackets(comma_sep([text("cvar_rev"),
+                                       locs(Locs),
+                                       ty(T),
+                                       ref(Ref)]));
                {cop, Locs, Name, Arity, T} ->
                    brackets(comma_sep([text("cop"),
                                        locs(Locs),

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -144,9 +144,8 @@ traverse_module_list(SearchPath, Symtab, [CurrentModule | RemainingModules]) ->
     Entry = paths:find_module_path(SearchPath, CurrentModule),
     Forms = retrieve_forms_for_source(Entry),
     NewSymtab = extend_symtab(Forms, CurrentModule, Symtab),
-    NewSymbols = symbols_for_module(CurrentModule, NewSymtab),
-    ?LOG_DEBUG("Extended symtab with entries from ~p: ~s", CurrentModule,
-        pretty:render_list(fun pretty:ref/1, NewSymbols)),
+    % NewSymbols = symbols_for_module(CurrentModule, NewSymtab),
+    ?LOG_DEBUG("Extended symtab with entries from ~p", CurrentModule),
     traverse_module_list(SearchPath, NewSymtab, RemainingModules);
 
 traverse_module_list(_, Symtab, []) ->

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -144,8 +144,10 @@ traverse_module_list(SearchPath, Symtab, [CurrentModule | RemainingModules]) ->
     Entry = paths:find_module_path(SearchPath, CurrentModule),
     Forms = retrieve_forms_for_source(Entry),
     NewSymtab = extend_symtab(Forms, CurrentModule, Symtab),
-    % NewSymbols = symbols_for_module(CurrentModule, NewSymtab),
     ?LOG_DEBUG("Extended symtab with entries from ~p", CurrentModule),
+    NewSymbols = symbols_for_module(CurrentModule, NewSymtab),
+    ?LOG_TRACE("New symbols from module ~p: ~s", CurrentModule,
+        pretty:render_list(fun pretty:ref/1, NewSymbols)),
     traverse_module_list(SearchPath, NewSymtab, RemainingModules);
 
 traverse_module_list(_, Symtab, []) ->

--- a/src/typing.erl
+++ b/src/typing.erl
@@ -338,7 +338,7 @@ check_alt(Ctx, Decl = {function, Loc, Name, Arity, _}, FunTy, BranchMode) ->
                                     Delta, [pretty:render_subst(S)]),
                                 {true, Idx + 1};
                             L ->
-                                ?LOG_DEBUG("Tally time: ~pms, ~w substitutions: ~200p",
+                                ?LOG_DEBUG("Tally time: ~pms, ~w substitutions:~n~s",
                                     Delta, length(L), pretty:render_substs(L)),
                                 {true, Idx + 1}
                         end

--- a/test/tycheck_tests.erl
+++ b/test/tycheck_tests.erl
@@ -107,17 +107,19 @@ tycheck_test_() ->
                     [];
                 ok_test ->
                     [
-                        fun() ->
+                        {"tycheck_ok " ++ File,
+                         fun() ->
                             ?LOG_NOTE("Checking that ~s typechecks successfully", File),
                             run_ok_test(File)
-                        end
+                         end}
                     ];
                 {fail_test, Err} ->
                     [
-                        fun() ->
-                            ?LOG_NOTE("Checking that ~s fails typechecking", File),
-                            run_failing_test(File, Err)
-                        end
+                        {"tycheck_fail " ++ File,
+                         fun() ->
+                             ?LOG_NOTE("Checking that ~s fails typechecking", File),
+                             run_failing_test(File, Err)
+                         end}
                     ]
             end
         end, Files).

--- a/test_files/tycheck_simple.erl
+++ b/test_files/tycheck_simple.erl
@@ -535,6 +535,7 @@ foo(L) ->
 foo2(a) -> 1;
 foo2(b) -> 2.
 
+% See #36
 -spec foo2_case(a) -> 1; (b) -> 2.
 foo2_case(X) ->
     case X of
@@ -564,6 +565,13 @@ foo4_b(X) ->
         3 -> 3;
         _ -> X
     end.
+
+-spec foo5(integer()) -> 1.
+foo5(X) ->
+       case X of
+           1 -> X;
+           _ -> 1
+       end.
 
 % same as fun_local_02 but transformed
 % such that there are no n-tuples and n-functions anymore

--- a/test_files/tycheck_simple.erl
+++ b/test_files/tycheck_simple.erl
@@ -424,6 +424,16 @@ fun_local_05_fail(X) ->
     F = fun(Y) -> X + Y end,
     F("foo").
 
+-spec fun_local_06() -> foobar.
+fun_local_06() ->
+  F = fun(X) ->
+        case X of
+            spam -> foobar;
+            _ -> foobar
+        end
+      end,
+  F(spam).
+
 % if
 -spec if_01(integer()) -> integer().
 if_01(X) ->
@@ -524,6 +534,13 @@ foo(L) ->
 -spec foo2(a) -> 1; (b) -> 2.
 foo2(a) -> 1;
 foo2(b) -> 2.
+
+-spec foo2_case(a) -> 1; (b) -> 2.
+foo2_case(X) ->
+    case X of
+        a -> 1;
+        b -> 2
+    end.
 
 -spec foo3(a|b) -> 1|true.
 foo3(a) -> 1;

--- a/test_files/tycheck_simple.erl
+++ b/test_files/tycheck_simple.erl
@@ -546,6 +546,25 @@ foo2_case(X) ->
 foo3(a) -> 1;
 foo3(b) -> true.
 
+% See #56
+-spec foo4
+    (integer()) -> integer();
+    (1) -> 2.
+foo4(X) ->
+    case X of
+        1 -> 2;
+        _ -> X
+    end.
+-spec foo4_b
+    (integer()) -> integer();
+    (1) -> 2.
+foo4_b(X) ->
+    case X of
+        1 -> 2;
+        3 -> 3;
+        _ -> X
+    end.
+
 % same as fun_local_02 but transformed
 % such that there are no n-tuples and n-functions anymore
 -spec fun_local_02_plus() -> integer().


### PR DESCRIPTION
This PR fixes #36 and #56. The problem of both bugs was that in a `case` expression

~~~erlang
case exp of ...
~~~

the scrutiny was assigned some fresh type variable `Alpha` and the real type of `exp` was required to be a subtype of `Alpha`. But the requirement to be just a subtype of `Alpha` was not strong enough because `Alpha` was then used in various constraints for checking the branches of the `case`.

As an example, consider the following function from #36:

~~~erlang
-spec f (a) -> 1; (b) -> 2.
f(X) ->
    case X of
        a -> 1;
        b -> 2
    end.
~~~

Now imagine we check the definition of `f` against type `(b) -> 2`. Then X has type `b`. During constraint generation, the scrutiny `X` gets assigned type `Alpha` with the constraint `b <= Alpha`. But this constraint is not strong enough for detecting that branch `a -> 1` is impossible. Essentially, tally assigns `Alpha` the type `b \/ Mu`, where `Mu` is some fresh type variable. To exclude the branch `a -> 1`, we would then need `(b \/ Mu) /\ a <= none()`, but clearly this does not hold.

This PR introduces an equivalence constraint for the scrutiny of a `case` (instead of just a subtype constraint). So for the example above, scrutiny `X` gets assigned type `Alpha` with the constraint `b ~ Alpha` (`b ~ Alpha` is just shorthand for `b <= Alpha` and `Alpha <= b`). Then tally assigns `Alpha` the type `b`, so `b /\ a <= none()` holds, so the branch is excluded from type checking.