### PR TITLE
User-defined types and recursive types

### DIFF
--- a/src/ast.erl
+++ b/src/ast.erl
@@ -471,6 +471,9 @@ is_predef_alias_name(N) ->
 % later on.
 -type ty_named() :: {named, loc(), Name::global_ref(), Args::[ty()]}.
 
+% recursive type
+-type ty_mu() :: {mu, RecursiveVariable::ty_var(), MaybeRecursiveType::ty()}.
+
 -type ty_tuple_any() :: {tuple_any}.
 -type ty_tuple() :: {tuple, [ty()]}.
 
@@ -482,7 +485,7 @@ is_predef_alias_name(N) ->
 % We do not have an explicit type for records. We encode them as tuples instead.
 -type ty() :: ty_singleton() | ty_bitstring() | ty_some_list()
     | ty_fun() | ty_integer_range() | ty_map_any() | ty_map() | ty_predef() | ty_predef_alias()
-    | ty_named() | ty_tuple_any() | ty_tuple() | ty_var()
+    | ty_named() | ty_tuple_any() | ty_tuple() | ty_var() | ty_mu()
     | ty_union() | ty_intersection() | ty_negation().
 
 -type ty_constraint() :: {subty_constraint, loc(), ty_varname(), ty()}.

--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -4,7 +4,7 @@
 % heavily derived from the erlang ast (defined in ast_erl.erl). See the README for
 % a description of the properties of the internal AST.
 
--export([simplify/2, reset/0, ast_to_erlang_ty/1, ast_to_erlang_ty/2, erlang_ty_to_ast/2, ast_to_erlang_ty_var/1, erlang_ty_var_to_var/1]).
+-export([simplify/2, reset/0, ast_to_erlang_ty/1, ast_to_erlang_ty/2, erlang_ty_to_ast/1, erlang_ty_to_ast/2, ast_to_erlang_ty_var/1, erlang_ty_var_to_var/1]).
 -define(VAR_ETS, ast_norm_var_memo). % remember variable name -> variable ID to convert variables properly
 
 -export([
@@ -120,6 +120,9 @@ erlang_ty_var_to_var({var, Id, Name}) ->
         [] -> {var, list_to_atom("mu" ++ integer_to_list(Id))};
         [{_, _}] -> {var, Name}
     end.
+
+erlang_ty_to_ast(X) ->
+    erlang_ty_to_ast(X, #{}).
 
 erlang_ty_to_ast(X, M) ->
     case M of

--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -175,8 +175,7 @@ erlang_ty_to_ast(X, M) ->
     Vars = ast_utils:referenced_variables(NewTy),
     case lists:member(Var, Vars) of
         true -> 
-            {mu, Var, NewTy},
-            error(todo);
+            {mu, Var, NewTy};
         false -> 
             NewTy
     end
@@ -290,7 +289,7 @@ ast_to_erlang_ty({map, AssocList}, Sym, M) ->
 ast_to_erlang_ty(V = {var, A}, _Sym, M) ->
     % FIXME overloading of mu variables and normal variables
     case M of
-        #{V := Ref} -> error(todo_mu); % TODO
+        #{V := Ref} -> Ref;
         _ -> ty_rec:variable(maybe_new_variable(A))
     end;
 

--- a/src/ast_utils.erl
+++ b/src/ast_utils.erl
@@ -1,6 +1,6 @@
 -module(ast_utils).
 
--export([remove_locs/1, referenced_modules/1]).
+-export([remove_locs/1, referenced_modules/1, referenced_variables/1]).
 
 -export_type([ty_module_name/0]).
 
@@ -27,6 +27,17 @@ referenced_modules(Forms) ->
                         case T of
                             {attribute, _, import, {ModuleName, _}} -> {ok, ModuleName};
                             {qref, ModuleName, _, _} -> {ok, ModuleName};
+                            _ -> error
+                        end
+                end, Forms),
+    utils:list_uniq(Modules).
+
+-spec referenced_variables(ast:ty()) -> [ast:ty_var()].
+referenced_variables(Forms) ->
+    Modules = utils:everything(
+                fun(T) ->
+                        case T of
+                            {var, Name} -> {ok, {var, Name}};
                             _ -> error
                         end
                 end, Forms),

--- a/src/erlang_types/bdd.hrl
+++ b/src/erlang_types/bdd.hrl
@@ -13,7 +13,7 @@
 % hide built-in Erlang node function
 -compile({no_auto_import, [node/1]}).
 
--export([has_ref/2, get_dnf/1, any/0, empty/0, equal/2, node/1, terminal/1, compare/2, union/2, intersect/2, negate/1, diff/2]).
+-export([all_variables/1, has_ref/2, get_dnf/1, any/0, empty/0, equal/2, node/1, terminal/1, compare/2, union/2, intersect/2, negate/1, diff/2]).
 
 % these are defined here so the IDE does not complain
 -ifndef(ELEMENT).
@@ -186,13 +186,14 @@ has_ref(Ty, Ref) ->
     fun(F1, F2) -> F1() orelse F2() end
   }).
 
-all_variables(Ty) ->
+all_variables(Ty) -> all_variables(Ty, #{}).
+all_variables(Ty, M) ->
   dnf(Ty, {
     fun
       (P,N,T) ->
-        ?TERMINAL:all_variables(T) ++
-          lists:foldl(fun(L, Acc) -> Acc ++ ?ELEMENT:all_variables(L) end, [], P) ++
-          lists:foldl(fun(L, Acc) -> Acc ++ ?ELEMENT:all_variables(L) end, [], N)
+        ?TERMINAL:all_variables(T, M) ++
+          lists:foldl(fun(L, Acc) -> Acc ++ ?ELEMENT:all_variables(L, M) end, [], P) ++
+          lists:foldl(fun(L, Acc) -> Acc ++ ?ELEMENT:all_variables(L, M) end, [], N)
     end,
     fun(F1, F2) -> lists:usort(F1() ++ F2()) end
   }).

--- a/src/erlang_types/bdd_bool.erl
+++ b/src/erlang_types/bdd_bool.erl
@@ -6,7 +6,7 @@
 
 -export([empty/0, any/0]).
 -export([union/2, intersect/2, diff/2, negate/1, is_any/1]).
--export([is_empty/1, substitute/4, map_pi/1, has_ref/2, all_variables/1, transform/2]).
+-export([is_empty/1, substitute/4, map_pi/1, has_ref/2, all_variables/2, transform/2]).
 
 compare(0, 0) -> 0; compare(1, 1) -> 0; compare(1, 0) -> 1; compare(0, 1) -> -1.
 equal(X, Y) -> X =:= Y.
@@ -22,6 +22,6 @@ substitute(_,X,_,_) -> X.
 % there is nothing to substitute in a bdd_bool
 map_pi(_) -> #{}.
 has_ref(_,_) -> false.
-all_variables(_) -> [].
+all_variables(_, _) -> [].
 transform(0, #{empty := E}) -> E();
 transform(1, #{any := E}) -> E().

--- a/src/erlang_types/dnf_ty_function.erl
+++ b/src/erlang_types/dnf_ty_function.erl
@@ -12,7 +12,7 @@
 -export([apply_to_node/3]).
 -export([normalize/6, substitute/4, is_empty/1]).
 
--export([function/1, all_variables/1, transform/2]).
+-export([function/1, all_variables/2, transform/2]).
 
 -type ty_ref() :: {ty_ref, integer()}.
 -type dnf_function() :: term().

--- a/src/erlang_types/dnf_ty_list.erl
+++ b/src/erlang_types/dnf_ty_list.erl
@@ -6,7 +6,7 @@
 
 -export([apply_to_node/3]).
 -export([is_empty/1, normalize/5, substitute/4]).
--export([list/1, all_variables/1, transform/2]).
+-export([list/1, all_variables/2, transform/2]).
 
 -include("bdd_node.hrl").
 

--- a/src/erlang_types/dnf_ty_map.erl
+++ b/src/erlang_types/dnf_ty_map.erl
@@ -9,7 +9,7 @@
 -define(NORM, fun ty_rec:normalize/3).
 
 -export([is_empty/1, normalize/5, substitute/4, apply_to_node/3]).
--export([map/1, all_variables/1, transform/2]).
+-export([map/1, all_variables/2, transform/2]).
 
 -include("bdd_node.hrl").
 

--- a/src/erlang_types/dnf_ty_tuple.erl
+++ b/src/erlang_types/dnf_ty_tuple.erl
@@ -5,7 +5,7 @@
 -define(F(Z), fun() -> Z end).
 
 -export([is_empty/1, normalize/6, substitute/4, apply_to_node/3]).
--export([tuple/1, all_variables/1, transform/2, to_singletons/1]).
+-export([tuple/1, all_variables/2, transform/2, to_singletons/1]).
 
 -include("bdd_node.hrl").
 

--- a/src/erlang_types/dnf_var_int.erl
+++ b/src/erlang_types/dnf_var_int.erl
@@ -4,7 +4,7 @@
 -define(TERMINAL, ty_interval).
 
 -export([is_empty/1, normalize/3, substitute/4]).
--export([var/1, int/1, all_variables/1, transform/2, apply_to_node/3, to_singletons/1]).
+-export([var/1, int/1, all_variables/2, transform/2, apply_to_node/3, to_singletons/1]).
 
 -include("bdd_var.hrl").
 

--- a/src/erlang_types/dnf_var_predef.erl
+++ b/src/erlang_types/dnf_var_predef.erl
@@ -5,7 +5,7 @@
 
 -export([apply_to_node/3]).
 -export([is_empty/1, normalize/3, substitute/4]).
--export([var/1, predef/1,  all_variables/1, transform/2]).
+-export([var/1, predef/1,  all_variables/2, transform/2]).
 
 -include("bdd_var.hrl").
 

--- a/src/erlang_types/dnf_var_ty_atom.erl
+++ b/src/erlang_types/dnf_var_ty_atom.erl
@@ -6,7 +6,7 @@
 
 -export([apply_to_node/3]).
 -export([is_empty/1, normalize/3, substitute/4]).
--export([var/1, ty_atom/1, all_variables/1]).
+-export([var/1, ty_atom/1, all_variables/2]).
 -export([to_singletons/1, transform/2]).
 
 -include("bdd_var.hrl").

--- a/src/erlang_types/dnf_var_ty_function.erl
+++ b/src/erlang_types/dnf_var_ty_function.erl
@@ -7,19 +7,19 @@
 
 -export([is_empty/1]).
 -export([normalize/4, substitute/4]).
--export([var/1, function/1, all_variables/1, mall_variables/1, transform/2]).
+-export([var/1, function/1, all_variables/2, mall_variables/2, transform/2]).
 
 -include("bdd_var.hrl").
 
 function(Tuple) -> terminal(Tuple).
 var(Var) -> node(Var).
 
-mall_variables({Default, Others}) when is_map(Others) ->
+mall_variables({Default, Others}, M) when is_map(Others) ->
   lists:usort(lists:flatten(
-    all_variables(Default) ++
-    lists:map(fun({_K,V}) -> all_variables(V) end, maps:to_list(Others))
+    all_variables(Default, M) ++
+    lists:map(fun({_K,V}) -> all_variables(V, M) end, maps:to_list(Others))
   ));
-mall_variables(Ty) -> all_variables(Ty).
+mall_variables(Ty, M) -> all_variables(Ty, M).
 
 is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
 is_empty_coclause(_Pos, _Neg, T) -> dnf_ty_function:is_empty(T).

--- a/src/erlang_types/dnf_var_ty_function.erl
+++ b/src/erlang_types/dnf_var_ty_function.erl
@@ -35,8 +35,7 @@ normalize_coclause(Size, PVar, NVar, Function, Fixed, M) ->
     _ ->
       case ty_ref:is_normalized_memoized({PVar, NVar, Function}, Fixed, M) of
         true ->
-          % TODO test case
-          error({todo, extract_test_case, memoize_function}); %[[]];
+          [[]];
         miss ->
           dnf_ty_function:normalize(Size, Function, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Function}])))
       end

--- a/src/erlang_types/dnf_var_ty_list.erl
+++ b/src/erlang_types/dnf_var_ty_list.erl
@@ -27,8 +27,7 @@ normalize_coclause(PVar, NVar, List, Fixed, M) ->
     _ ->
       case ty_ref:is_normalized_memoized({PVar, NVar, List}, Fixed, M) of
         true ->
-          % TODO test case
-          error({todo, extract_test_case, memoize_function}); %[[]];
+          [[]];
         miss ->
           dnf_ty_list:normalize(List, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, List}])))
       end

--- a/src/erlang_types/dnf_var_ty_list.erl
+++ b/src/erlang_types/dnf_var_ty_list.erl
@@ -4,7 +4,7 @@
 -define(TERMINAL, dnf_ty_list).
 
 -export([is_empty/1,normalize/3, substitute/4]).
--export([var/1, list/1, all_variables/1, transform/2, apply_to_node/3]).
+-export([var/1, list/1, all_variables/2, transform/2, apply_to_node/3]).
 
 -include("bdd_var.hrl").
 

--- a/src/erlang_types/dnf_var_ty_map.erl
+++ b/src/erlang_types/dnf_var_ty_map.erl
@@ -4,7 +4,7 @@
 -define(TERMINAL, dnf_ty_map).
 
 -export([is_empty/1,normalize/3, substitute/4]).
--export([var/1, map/1, all_variables/1, transform/2, apply_to_node/3]).
+-export([var/1, map/1, all_variables/2, transform/2, apply_to_node/3]).
 
 % implementations provided by bdd_var.hrl
 -include("bdd_var.hrl").

--- a/src/erlang_types/dnf_var_ty_map.erl
+++ b/src/erlang_types/dnf_var_ty_map.erl
@@ -26,7 +26,7 @@ normalize_coclause(PVar, NVar, Map, Fixed, M) ->
     _ ->
       case ty_ref:is_normalized_memoized({PVar, NVar, Map}, Fixed, M) of
         true ->
-          error({todo, extract_test_case, memoize_function}); %[[]];
+          [[]];
         miss ->
           dnf_ty_map:normalize(Map, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Map}])))
       end

--- a/src/erlang_types/dnf_var_ty_tuple.erl
+++ b/src/erlang_types/dnf_var_ty_tuple.erl
@@ -34,8 +34,7 @@ normalize_coclause(Size, PVar, NVar, Tuple, Fixed, M) ->
     _ ->
       case ty_ref:is_normalized_memoized({PVar, NVar, Tuple}, Fixed, M) of
         true ->
-          % TODO test case
-          error({todo, extract_test_case, memoize_tuple}); %[[]];
+          [[]];
         miss ->
           dnf_ty_tuple:normalize(Size, Tuple, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Tuple}])))
       end

--- a/src/erlang_types/dnf_var_ty_tuple.erl
+++ b/src/erlang_types/dnf_var_ty_tuple.erl
@@ -5,7 +5,7 @@
 -define(F(Z), fun() -> Z end).
 
 -export([normalize/4, substitute/4]).
--export([var/1, tuple/1, all_variables/1, mall_variables/1, transform/2, is_empty/1, apply_to_node/3, to_singletons/1]).
+-export([var/1, tuple/1, all_variables/2, mall_variables/2, transform/2, is_empty/1, apply_to_node/3, to_singletons/1]).
 
 % implementations provided by bdd_var.hrl
 -include("bdd_var.hrl").
@@ -16,12 +16,12 @@ var(Var) -> node(Var).
 is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
 is_empty_coclause(_Pos, _Neg, T) -> dnf_ty_tuple:is_empty(T).
 
-mall_variables({Default, Others}) when is_map(Others) ->
+mall_variables({Default, Others}, M) when is_map(Others) ->
   lists:usort(lists:flatten(
-    all_variables(Default) ++
-    lists:map(fun({_K,V}) -> all_variables(V) end, maps:to_list(Others))
+    all_variables(Default, M) ++
+    lists:map(fun({_K,V}) -> all_variables(V, M) end, maps:to_list(Others))
   ));
-mall_variables(Ty) -> all_variables(Ty).
+mall_variables(Ty, M) -> all_variables(Ty, M).
 
 normalize(Size, Ty, Fixed, M) -> dnf(Ty, {
   fun(Pos, Neg, DnfTy) -> normalize_coclause(Size, Pos, Neg, DnfTy, Fixed, M) end,

--- a/src/erlang_types/etally.erl
+++ b/src/erlang_types/etally.erl
@@ -13,9 +13,13 @@
 tally(Constraints) -> tally(Constraints, sets:new()).
 
 tally(Constraints, FixedVars) ->
+  io:format(user,"TALLY~n", []),
   Normalized = ?TIME(tally_normalize, tally_normalize(Constraints, FixedVars)),
+  io:format(user,"NORM~n", []),
   Saturated = ?TIME(tally_saturate, tally_saturate(Normalized, FixedVars)),
+  io:format(user,"SAT~n", []),
   Solved = ?TIME(tally_solve, tally_solve(Saturated, FixedVars)),
+  io:format(user,"SOLV~n", []),
   % sanity: every substitution satisfies all given constraints, if no error
   ?SANITY(substitutions_solve_input_constraints, case Solved of {error, _} -> ok; _ -> [ true = is_valid_substitution(Constraints, Subst) || Subst <- Solved] end),
   Solved.

--- a/src/erlang_types/etally.erl
+++ b/src/erlang_types/etally.erl
@@ -17,9 +17,8 @@ tally(Constraints, FixedVars) ->
   Normalized = ?TIME(tally_normalize, tally_normalize(Constraints, FixedVars)),
   io:format(user,"NORM~n", []),
   Saturated = ?TIME(tally_saturate, tally_saturate(Normalized, FixedVars)),
-  io:format(user,"SAT~n", []),
+  io:format(user,"SAT~n~p~n", [Saturated]),
   Solved = ?TIME(tally_solve, tally_solve(Saturated, FixedVars)),
-  io:format(user,"SOLV~n", []),
   % sanity: every substitution satisfies all given constraints, if no error
   ?SANITY(substitutions_solve_input_constraints, case Solved of {error, _} -> ok; _ -> [ true = is_valid_substitution(Constraints, Subst) || Subst <- Solved] end),
   Solved.
@@ -46,6 +45,7 @@ tally_saturate(Normalized, FixedVars) ->
 
 tally_solve([], _FixedVars) -> {error, []};
 tally_solve(Saturated, FixedVars) ->
+  io:format(user, "Solve...", []),
   Solved = solve(Saturated, FixedVars),
   [ maps:from_list(Subst) || Subst <- Solved].
 
@@ -55,6 +55,7 @@ solve(SaturatedSetOfConstraintSets, FixedVariables) ->
 
 solve_single([], Equations, _) -> Equations;
 solve_single([{SmallestVar, Left, Right} | Cons], Equations, Fix) ->
+  io:format(user, "Solve...", []),
   % constraints are already sorted by variable ordering
   % smallest variable first
   % also TODO: why are variable names atoms?
@@ -70,7 +71,10 @@ unify(EquationList) ->
   % sort to smallest variable
   % select in E the equation α = tα for smallest α
   [Eq = {eq, Var, TA} | _Tail] = lists:usort(fun({_, Var, _}, {_, Var2, _}) -> ty_variable:compare(Var, Var2) =< 0 end, EquationList),
+  
+  io:format(user, "Check all vars...", []),
   Vars = ty_rec:all_variables(TA),
+  io:format(user, "Done...", []),
   NewTA = case length([Z || Z <- Vars, Z == Var]) of
             0 ->
               TA;

--- a/src/erlang_types/etally.erl
+++ b/src/erlang_types/etally.erl
@@ -13,11 +13,11 @@
 tally(Constraints) -> tally(Constraints, sets:new()).
 
 tally(Constraints, FixedVars) ->
-  io:format(user,"TALLY~n", []),
+  % io:format(user,"TALLY~n", []),
   Normalized = ?TIME(tally_normalize, tally_normalize(Constraints, FixedVars)),
-  io:format(user,"NORM~n", []),
+  % io:format(user,"NORM~n", []),
   Saturated = ?TIME(tally_saturate, tally_saturate(Normalized, FixedVars)),
-  io:format(user,"SAT~n~p~n", [Saturated]),
+  % io:format(user,"SAT~n~p~n", [Saturated]),
   Solved = ?TIME(tally_solve, tally_solve(Saturated, FixedVars)),
   % sanity: every substitution satisfies all given constraints, if no error
   ?SANITY(substitutions_solve_input_constraints, case Solved of {error, _} -> ok; _ -> [ true = is_valid_substitution(Constraints, Subst) || Subst <- Solved] end),
@@ -45,7 +45,6 @@ tally_saturate(Normalized, FixedVars) ->
 
 tally_solve([], _FixedVars) -> {error, []};
 tally_solve(Saturated, FixedVars) ->
-  io:format(user, "Solve...", []),
   Solved = solve(Saturated, FixedVars),
   [ maps:from_list(Subst) || Subst <- Solved].
 
@@ -55,7 +54,6 @@ solve(SaturatedSetOfConstraintSets, FixedVariables) ->
 
 solve_single([], Equations, _) -> Equations;
 solve_single([{SmallestVar, Left, Right} | Cons], Equations, Fix) ->
-  io:format(user, "Solve...", []),
   % constraints are already sorted by variable ordering
   % smallest variable first
   % also TODO: why are variable names atoms?
@@ -72,9 +70,7 @@ unify(EquationList) ->
   % select in E the equation α = tα for smallest α
   [Eq = {eq, Var, TA} | _Tail] = lists:usort(fun({_, Var, _}, {_, Var2, _}) -> ty_variable:compare(Var, Var2) =< 0 end, EquationList),
   
-  io:format(user, "Check all vars...", []),
   Vars = ty_rec:all_variables(TA),
-  io:format(user, "Done...", []),
   NewTA = case length([Z || Z <- Vars, Z == Var]) of
             0 ->
               TA;

--- a/src/erlang_types/ty_atom.erl
+++ b/src/erlang_types/ty_atom.erl
@@ -7,10 +7,10 @@
 -export([is_empty/1]).
 -export([transform/2]).
 -export([finite/1, cofinite/1]).
--export([has_ref/2, to_singletons/1, normalize/5, substitute/4, all_variables/1]).
+-export([has_ref/2, to_singletons/1, normalize/5, substitute/4, all_variables/2]).
 
 has_ref(_, _) -> false.
-all_variables(_) -> [].
+all_variables(_, _) -> [].
 substitute(_, Ty, _, _) -> Ty.
 
 to_singletons({Atoms, finite}) -> [ty_rec:atom(dnf_var_ty_atom:ty_atom(finite([A]))) || A <- gb_sets:to_list(Atoms)];

--- a/src/erlang_types/ty_function.erl
+++ b/src/erlang_types/ty_function.erl
@@ -1,7 +1,7 @@
 -module(ty_function).
 
 %% domain -> co-domain function representation
--export([compare/2, equal/2, all_variables/1, substitute/3]).
+-export([compare/2, equal/2, all_variables/2, substitute/3]).
 -export([function/2, domains/1, codomain/1, codomains_intersect/1, has_ref/2, transform/2]).
 
 compare(A, B) when A < B -> -1;
@@ -39,9 +39,9 @@ substitute({ty_function, Refs, B}, Map, Memo) ->
         ty_rec:substitute(B, Map, Memo)
     }.
 
-all_variables({ty_function, Domain, Codomain}) ->
-  ty_rec:all_variables(domains_to_tuple(Domain))
-    ++ ty_rec:all_variables(Codomain).
+all_variables({ty_function, Domain, Codomain}, M) ->
+  ty_rec:all_variables(domains_to_tuple(Domain), M)
+    ++ ty_rec:all_variables(Codomain, M).
 
 domains_to_tuple(Domains) ->
     ty_rec:tuple(length(Domains), dnf_var_ty_tuple:tuple(dnf_ty_tuple:tuple(ty_tuple:tuple(Domains)))).

--- a/src/erlang_types/ty_interval.erl
+++ b/src/erlang_types/ty_interval.erl
@@ -8,7 +8,7 @@
 
 -export([empty/0, any/0]).
 -export([union/2, intersect/2, diff/2, negate/1, is_any/1]).
--export([is_empty/1, eval/1, normalize/5, substitute/4, all_variables/1, to_singletons/1]).
+-export([is_empty/1, eval/1, normalize/5, substitute/4, all_variables/2, to_singletons/1]).
 
 
 -export([interval/2, cointerval/2]).
@@ -163,7 +163,7 @@ normalize(TyInterval, PVar, NVar, Fixed, M) ->
 substitute(_, Ty, _, _) -> Ty.
 % there is nothing to substitute in a ty_interval
 map_pi(_) -> #{}.
-all_variables(_) -> [].
+all_variables(_, _) -> [].
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/erlang_types/ty_list.erl
+++ b/src/erlang_types/ty_list.erl
@@ -1,7 +1,7 @@
 -module(ty_list).
 
 -export([compare/2, equal/2]).
--export([list/2, pi1/1, pi2/1, has_ref/2, transform/2, big_intersect/1, all_variables/1, substitute/3]).
+-export([list/2, pi1/1, pi2/1, has_ref/2, transform/2, big_intersect/1, all_variables/2, substitute/3]).
 
 compare(A, B) when A < B -> -1;
 compare(A, B) when A > B -> 1;
@@ -32,6 +32,6 @@ substitute({ty_list, A, B}, Map, Memo) ->
     ty_rec:substitute(B, Map, Memo)
   }.
 
-all_variables({ty_list, A, B}) ->
-  ty_rec:all_variables(A) ++
-  ty_rec:all_variables(B).
+all_variables({ty_list, A, B}, M) ->
+  ty_rec:all_variables(A, M) ++
+  ty_rec:all_variables(B, M).

--- a/src/erlang_types/ty_map.erl
+++ b/src/erlang_types/ty_map.erl
@@ -8,7 +8,7 @@
 -define(ASSOC_DIFF, fun(_, ?OPT) -> ?MAN; (A, _) -> A end).
 -define(ASSOC_INT, fun(A, ?OPT) -> A; (_, ?MAN) -> ?MAN end).
 
--export([compare/2, equal/2, has_ref/2, substitute/3, transform/2, all_variables/1]).
+-export([compare/2, equal/2, has_ref/2, substitute/3, transform/2, all_variables/2]).
 -export([map/2, big_intersect/1, intersect/2, diff_labels/2, diff_steps/2, diff_w1/2, key_variable_suite/1, step_names/0, key_domain/0]).
 -import(maps, [to_list/1, keys/1, values/1]).
 -export_type([l/0]).
@@ -202,13 +202,13 @@ transform(Map, #{to_map := ToMap}) ->
   ToMap(ManAssoc, OptAssoc).
 
 
-all_variables(Map) ->
+all_variables(Map, M) ->
   #ty_map{ labels = Labels, steps = Steps, omegas = {_, _, W1}, key_variables = {ManU, OptU} } = Map,
-  LabelVars = lists:map(fun ty_rec:all_variables/1, values(Labels)),
-  StepVars = lists:map(fun ty_rec:all_variables/1, values(Steps)),
-  ty_rec:all_variables(W1)
-  ++ ty_rec:all_variables(ManU)
-    ++ ty_rec:all_variables(OptU)
+  LabelVars = lists:map(fun(E) -> ty_rec:all_variables(E, M) end, values(Labels)),
+  StepVars = lists:map(fun(E) -> ty_rec:all_variables(E, M) end, values(Steps)),
+  ty_rec:all_variables(W1, M)
+  ++ ty_rec:all_variables(ManU, M)
+    ++ ty_rec:all_variables(OptU, M)
     ++ lists:flatten(LabelVars ++ StepVars).
 
 

--- a/src/erlang_types/ty_predef.erl
+++ b/src/erlang_types/ty_predef.erl
@@ -10,13 +10,13 @@
 -export([union/2, intersect/2, diff/2, negate/1, is_any/1]).
 -export([is_empty/1, eval/1, normalize/5, substitute/4]).
 
--export([has_ref/2, predef/1, transform/2, all_variables/1]).
+-export([has_ref/2, predef/1, transform/2, all_variables/2]).
 
 has_ref(_, _) -> false.
 
 substitute(_, Ty, _, _) ->  Ty.
 
-all_variables(_) -> [].
+all_variables(_, _) -> [].
 predef(Predef) ->
     false = is_list(Predef),
     [Predef].

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -118,7 +118,8 @@ transform_p(TyRef, Ops =
 
   Ety = Union(maps:values(Mapped)),
 %%  io:format(user,"<~p> Result: ~p~n", [Ref, Ety]),
-  Sanity = ast_lib:ast_to_erlang_ty(Ety),
+% TODO is it always the case that once we are in the semantic world, when we go back we dont need the symtab?
+  Sanity = ast_lib:ast_to_erlang_ty(Ety, symtab:empty()), 
 %%  io:format(user,"<~p> Sanity: ~p~n", [Ref, Sanity]),
   % leave this sanity check for a while
   case is_equivalent(TyRef, Sanity) of

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -20,7 +20,7 @@
 
 -export([is_equivalent/2, is_subtype/2, normalize/3]).
 
--export([substitute/2, substitute/3, pi/2, all_variables/1]).
+-export([substitute/2, substitute/3, pi/2, all_variables/1, all_variables/2]).
 
 -export([transform/2, print/1, to_labels/1]).
 
@@ -821,27 +821,33 @@ to_labels(TyRef) ->
   end.
 
 
-all_variables(TyRef) ->
-  #ty{
-    predef = Predefs,
-    atom = Atoms,
-    interval = Ints,
-    list = Lists,
-    tuple = Tuples,
-    function = Functions,
-    map = Maps
-  } = ty_ref:load(TyRef),
+all_variables(TyRef) -> all_variables(TyRef, #{}).
+all_variables(TyRef, M) ->
+  case M of
+    #{TyRef := _} -> [];
+    _ ->
+      #ty{
+        predef = Predefs,
+        atom = Atoms,
+        interval = Ints,
+        list = Lists,
+        tuple = Tuples,
+        function = Functions,
+        map = Maps
+      } = ty_ref:load(TyRef),
 
 
-  lists:usort(
-    dnf_var_predef:all_variables(Predefs)
-  ++  dnf_var_ty_atom:all_variables(Atoms)
-  ++ dnf_var_int:all_variables(Ints)
-  ++ dnf_var_ty_list:all_variables(Lists)
-  ++ dnf_var_ty_tuple:mall_variables(Tuples)
-  ++ dnf_var_ty_function:mall_variables(Functions)
-  ++ dnf_var_ty_map:all_variables(Maps)
-  ).
+      Mp = M#{TyRef => ok},
+      lists:usort(
+        dnf_var_predef:all_variables(Predefs, M)
+      ++  dnf_var_ty_atom:all_variables(Atoms, M)
+      ++ dnf_var_int:all_variables(Ints, M)
+      ++ dnf_var_ty_list:all_variables(Lists, Mp)
+      ++ dnf_var_ty_tuple:mall_variables(Tuples, Mp)
+      ++ dnf_var_ty_function:mall_variables(Functions, Mp)
+      ++ dnf_var_ty_map:all_variables(Maps, Mp)
+      )
+  end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -75,6 +75,7 @@ transform(TyRef, Ops) ->
       end
   end.
 
+% ty_rec:ty() -> ast_erl:ty()
 transform_p(TyRef, Ops =
   #{
     any_list := Lists,
@@ -90,6 +91,7 @@ transform_p(TyRef, Ops =
     var := Var
   }) ->
 %%  io:format(user,"<~p> Transforming: ~p~n~p~n", [Ref = make_ref(), TyRef, ty_ref:load(TyRef)]),
+%% OK
   DnfMap = prepare(TyRef),
 %%  io:format(user, "<~p> Prepared: ~n~p~n", [Ref, DnfMap]),
 

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -118,21 +118,7 @@ transform_p(TyRef, Ops =
     end
            end, DnfMap),
 
-  Ety = Union(maps:values(Mapped)),
-%%  io:format(user,"<~p> Result: ~p~n", [Ref, Ety]),
-% TODO is it always the case that once we are in the semantic world, when we go back we dont need the symtab?
-  % Sanity = ast_lib:ast_to_erlang_ty(Ety, symtab:empty()), 
-%%  io:format(user,"<~p> Sanity: ~p~n", [Ref, Sanity]),
-  % leave this sanity check for a while
- % case is_equivalent(TyRef, Sanity) of
- %   true -> ok;
- %   false ->
- %     io:format(user, "--------~n", []),
- %     io:format(user, "~p~n", [ty_ref:load(TyRef)]),
- %     io:format(user, "~p~n", [Ety]),
- %     error(todo)
- % end,
-  Ety.
+  Union(maps:values(Mapped)).
 
 % TODO refactor this properly it's ugly
 prepare(TyRef) ->

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -321,8 +321,8 @@ extract_variables(Ty = #ty{ predef = P, atom = A, interval = I, list = L, tuple 
       dnf_var_ty_atom:all_variables(A),
       dnf_var_int:all_variables(I),
       dnf_var_ty_list:all_variables(L),
-      dnf_var_ty_tuple:mall_variables(T),
-      dnf_var_ty_function:mall_variables(F),
+      dnf_var_ty_tuple:mall_variables(T, #{}),
+      dnf_var_ty_function:mall_variables(F, #{}),
       dnf_var_ty_map:all_variables(M)
     ]),
 

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -121,17 +121,17 @@ transform_p(TyRef, Ops =
   Ety = Union(maps:values(Mapped)),
 %%  io:format(user,"<~p> Result: ~p~n", [Ref, Ety]),
 % TODO is it always the case that once we are in the semantic world, when we go back we dont need the symtab?
-  Sanity = ast_lib:ast_to_erlang_ty(Ety, symtab:empty()), 
+  % Sanity = ast_lib:ast_to_erlang_ty(Ety, symtab:empty()), 
 %%  io:format(user,"<~p> Sanity: ~p~n", [Ref, Sanity]),
   % leave this sanity check for a while
-  case is_equivalent(TyRef, Sanity) of
-    true -> ok;
-    false ->
-      io:format(user, "--------~n", []),
-      io:format(user, "~p~n", [ty_ref:load(TyRef)]),
-      io:format(user, "~p~n", [Ety]),
-      error(todo)
-  end,
+ % case is_equivalent(TyRef, Sanity) of
+ %   true -> ok;
+ %   false ->
+ %     io:format(user, "--------~n", []),
+ %     io:format(user, "~p~n", [ty_ref:load(TyRef)]),
+ %     io:format(user, "~p~n", [Ety]),
+ %     error(todo)
+ % end,
   Ety.
 
 % TODO refactor this properly it's ugly

--- a/src/erlang_types/ty_tuple.erl
+++ b/src/erlang_types/ty_tuple.erl
@@ -1,7 +1,7 @@
 -module(ty_tuple).
 
 %% n-tuple representation
--export([compare/2, equal/2, substitute/3, all_variables/1]).
+-export([compare/2, equal/2, substitute/3, all_variables/2]).
 
 -export([tuple/1, pi/2, has_ref/2, components/1, transform/2, any/1, empty/1, big_intersect/1, is_empty/1]).
 
@@ -37,8 +37,8 @@ big_intersect([X | Y]) ->
 substitute({ty_tuple, Dim, Refs}, Map, Memo) ->
     {ty_tuple, Dim, [ ty_rec:substitute(B, Map, Memo) || B <- Refs ] }.
 
-all_variables({ty_tuple, _, Refs}) ->
-    lists:flatten([ty_rec:all_variables(E) || E <- Refs]).
+all_variables({ty_tuple, _, Refs}, M) ->
+    lists:flatten([ty_rec:all_variables(E, M) || E <- Refs]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/erlang_types/ty_variable.erl
+++ b/src/erlang_types/ty_variable.erl
@@ -4,7 +4,7 @@
 -export([setup_all/0, reset/0]).
 -define(VAR_ETS, variable_counter_ets_table).
 
--export([equal/2, compare/2, substitute/4, has_ref/2, all_variables/1, name/1]).
+-export([equal/2, compare/2, substitute/4, has_ref/2, all_variables/2, name/1]).
 
 
 -export([new/1, smallest/3, normalize/6, transform/2, get_new_id/0]).
@@ -92,7 +92,7 @@ substitute(MkTy, Var, Map, _Memo) ->
   X = maps:get(Var, Map, ty_rec:variable(Var)),
   MkTy(X).
 
-all_variables(Var) -> [Var].
+all_variables(Var, _) -> [Var].
 transform(Ty, #{var := ToVar}) -> ToVar(Ty).
 
 -ifdef(TEST).

--- a/src/pretty.erl
+++ b/src/pretty.erl
@@ -206,6 +206,8 @@ ty(Prec, T) ->
                   end,
                   Fields),
             beside(text("#" ++ atom_to_list(Name)), brackets(comma_sep(FieldsP)));
+        {mu, Var, Ty} ->
+            beside(text("mu "), ty(Var), text("."), ty(Ty));
         {named, _Loc, Ref, Args} ->
             RefP =
                 case Ref of

--- a/src/subty.erl
+++ b/src/subty.erl
@@ -10,10 +10,9 @@
 is_equivalent(SymTab, S, T) -> is_subty(SymTab, S,T) andalso is_subty(SymTab, T,S).
 
 -spec is_subty(symtab:t(), ast:ty(), ast:ty()) -> boolean().
-is_subty(_Symtab, T1, T2) ->
-  % TODO use symtab
-  H1 = ast_lib:ast_to_erlang_ty(T1),
-  H2 = ast_lib:ast_to_erlang_ty(T2),
+is_subty(Symtab, T1, T2) ->
+  H1 = ast_lib:ast_to_erlang_ty(T1, Symtab),
+  H2 = ast_lib:ast_to_erlang_ty(T2, Symtab),
 
   ty_rec:is_subtype(H1, H2).
 

--- a/src/tally.erl
+++ b/src/tally.erl
@@ -28,7 +28,7 @@ tally(SymTab, Constraints, FixedVars) ->
   tally(SymTab, Constraints, FixedVars, fun() -> noop end).
 
 -spec tally(symtab:t(), constr:subty_constrs(), sets:set(ast:ty_varname()), fun(() -> any())) -> [subst:t()] | {error, [{error, string()}]}.
-tally(_SymTab, Constraints, FixedVars, Order) ->
+tally(SymTab, Constraints, FixedVars, Order) ->
   % reset the global cache, will be fixed in the future
   ty_ref:reset(),
   ty_variable:reset(),
@@ -41,14 +41,14 @@ tally(_SymTab, Constraints, FixedVars, Order) ->
   % io:format(user, "~s~n", [test_utils:format_tally_config(sets:to_list(Constraints), FixedVars)]),
 
   InternalConstraints = lists:map(
-    fun({scsubty, _, S, T}) -> {ast_lib:ast_to_erlang_ty(S), ast_lib:ast_to_erlang_ty(T)} end,
+    fun({scsubty, _, S, T}) -> {ast_lib:ast_to_erlang_ty(S, SymTab), ast_lib:ast_to_erlang_ty(T, SymTab)} end,
     lists:sort(fun({scsubty, _, S, T}, {scsubty, _, X, Y}) -> ({S, T}) < ({X, Y}) end,
       sets:to_list(Constraints))
   ),
   FixedTallyTyvars =
     [ast_lib:ast_to_erlang_ty_var({var, Var}) || Var <- lists:sort(sets:to_list(FixedVars))],
   InternalResult = etally:tally(InternalConstraints, sets:from_list(FixedTallyTyvars)),
-%%  io:format(user, "Got Constraints ~n~p~n~p~n", [InternalConstraints, InternalResult]),
+%  io:format(user, "Got Constraints ~n~p~n~p~n", [InternalConstraints, InternalResult]),
 
   Free = tyutils:free_in_subty_constrs(Constraints),
 

--- a/src/tally.erl
+++ b/src/tally.erl
@@ -48,7 +48,7 @@ tally(SymTab, Constraints, FixedVars, Order) ->
   FixedTallyTyvars =
     [ast_lib:ast_to_erlang_ty_var({var, Var}) || Var <- lists:sort(sets:to_list(FixedVars))],
   InternalResult = etally:tally(InternalConstraints, sets:from_list(FixedTallyTyvars)),
-%  io:format(user, "Got Constraints ~n~p~n~p~n", [InternalConstraints, InternalResult]),
+ io:format(user, "Got Constraints ~n~p~n~p~n", [InternalConstraints, InternalResult]),
 
   Free = tyutils:free_in_subty_constrs(Constraints),
 

--- a/src/tally.erl
+++ b/src/tally.erl
@@ -48,7 +48,7 @@ tally(SymTab, Constraints, FixedVars, Order) ->
   FixedTallyTyvars =
     [ast_lib:ast_to_erlang_ty_var({var, Var}) || Var <- lists:sort(sets:to_list(FixedVars))],
   InternalResult = etally:tally(InternalConstraints, sets:from_list(FixedTallyTyvars)),
- io:format(user, "Got Constraints ~n~p~n~p~n", [InternalConstraints, InternalResult]),
+ %io:format(user, "Got Constraints ~n~p~n~p~n", [InternalConstraints, InternalResult]),
 
   Free = tyutils:free_in_subty_constrs(Constraints),
 
@@ -60,7 +60,7 @@ tally(SymTab, Constraints, FixedVars, Order) ->
           % TODO sanity variable Id == variable name
           [subst:mk_tally_subst(
             sets:union(FixedVars, Free),
-            maps:from_list([{VarName, ast_lib:erlang_ty_to_ast(Ty)}
+            maps:from_list([{VarName, ast_lib:erlang_ty_to_ast(Ty, #{})}
                           || {{var, _, VarName}, Ty} <- maps:to_list(Subst)]))
           || Subst <- InternalResult]
 

--- a/src/test_utils.erl
+++ b/src/test_utils.erl
@@ -128,9 +128,13 @@ to_cduce({predef, none}) -> "Empty";
 to_cduce({predef, integer}) -> "Int";
 % floats are treated to tags in CDuce
 to_cduce({predef, float}) -> "`float";
+to_cduce({predef_alias, non_neg_integer}) -> "(0--*)";
 to_cduce({singleton, float}) -> "`float";
+to_cduce({mu, _, _}) -> "RECTYPE";
+to_cduce({range, X, Y}) -> io_lib:format("(~s--~s)",[erlang:integer_to_list(X), erlang:integer_to_list(Y)]);
 to_cduce({range, X, Y}) -> io_lib:format("(~s--~s)",[erlang:integer_to_list(X), erlang:integer_to_list(Y)]);
 to_cduce({singleton, I}) when is_integer(I) -> erlang:integer_to_list(I);
+to_cduce({singleton, A}) when is_atom(A) -> io_lib:format("`~s", [erlang:atom_to_list(A)]);
 to_cduce({negation, X}) -> io_lib:format("(Any \\ ~s)", [to_cduce(X)]);
 to_cduce({tuple, [A, B]}) -> io_lib:format("(~s, ~s)", [to_cduce(A), to_cduce(B)]);
 to_cduce({intersection, X}) -> "(" ++ lists:join(" & ", [to_cduce(Z) || Z <- X]) ++ ")";

--- a/test/pretty_tests.erl
+++ b/test/pretty_tests.erl
@@ -13,7 +13,7 @@
 
 empty_tuple_test() ->
   ecache:reset_all(),
-  A = ast_lib:erlang_ty_to_ast(ast_lib:ast_to_erlang_ty(stdtypes:ttuple2(stdtypes:tint(), tnone()))),
+  A = ast_lib:erlang_ty_to_ast(ast_lib:ast_to_erlang_ty(stdtypes:ttuple2(stdtypes:tint(), tnone()), symtab:empty()), #{}),
   A = tnone(),
   ok.
 
@@ -21,10 +21,28 @@ any_empty_test() ->
   ecache:reset_all(),
   % syntactically same none and any representations
   A = stdtypes:tnone(),
-  A = ast_lib:erlang_ty_to_ast(ast_lib:ast_to_erlang_ty(A)),
+  A = ast_lib:erlang_ty_to_ast(ast_lib:ast_to_erlang_ty(A, symtab:empty()), #{}),
 
   B = stdtypes:tany(),
-  B = ast_lib:erlang_ty_to_ast(ast_lib:ast_to_erlang_ty(B)),
+  B = ast_lib:erlang_ty_to_ast(ast_lib:ast_to_erlang_ty(B, symtab:empty()), #{}),
+  ok.
+
+simple_singleton_test() ->
+  ecache:reset_all(),
+  A = tatom(foo),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("foo", pretty:render_ty(Pretty)),
+  ok.
+
+variable_union_test() ->
+  ecache:reset_all(),
+  A = tunion([tvar(a), tatom(foo)]),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("foo | a", pretty:render_ty(Pretty)),
   ok.
 
 var_inter_test() ->
@@ -33,8 +51,8 @@ var_inter_test() ->
     tintersect([ tvar(mu5), tvar(mu6) ]),
     tintersect([ tnegate(tvar(mu6)), tatom(bool) ])
   ]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("not(mu6) /\\ bool | mu5 /\\ bool | mu6 /\\ mu5", pretty:render_ty(Pretty)),
   ok.
@@ -47,8 +65,8 @@ var_inter2_test() ->
       tintersect([ tnegate(tvar(mu6)), tatom(bool) ]),
       tintersect([ tnegate(tvar(mu5)), tatom(bool) ])
     ]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("bool | mu6 /\\ mu5", pretty:render_ty(Pretty)),
   ok.
@@ -62,8 +80,8 @@ var_neg_dnf_test() ->
       tintersect([tnegate(tvar(mu6)), (tatom(bool))]),
       tintersect([tvar(mu5), tnegate(tvar(mu6)), (tatom(bool))])
     ]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("not(mu6) /\\ bool | not(mu5) /\\ bool", pretty:render_ty(Pretty)),
   ok.
@@ -76,8 +94,8 @@ var_neg_inter_test() ->
       tintersect([ tnegate(tvar(mu6)), tatom(bool) ]),
       tintersect([ tnegate(tvar(mu5)), tatom(bool) ])
     ])),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("not(bool | mu6 /\\ mu5)", pretty:render_ty(Pretty)),
 
@@ -86,8 +104,8 @@ var_neg_inter_test() ->
 worth_negate_test() ->
   ecache:reset_all(),
   A = tnegate(tatom(a)) ,
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("not(a)", pretty:render_ty(Pretty)),
   ok.
@@ -95,8 +113,8 @@ worth_negate_test() ->
 worth_negate2_test() ->
   ecache:reset_all(),
   A = tintersect([tnegate(tatom(a)), tnegate(tatom(b))]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("not(a | b)", pretty:render_ty(Pretty)),
   ok.
@@ -108,8 +126,8 @@ ex1_test() ->
       {negation, {tuple,[{singleton,a}, {singleton, tag}]} },
       {tuple,[{singleton,b}, {singleton, tag}]}
     ]},
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("$0 /\\ {b, tag} /\\ not({a, tag})", pretty:render_ty(Pretty)),
 
@@ -118,27 +136,18 @@ ex1_test() ->
 variable_simple_union_test() ->
   ecache:reset_all(),
   A = tunion([tvar(a), tvar(b)]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("a | b", pretty:render_ty(Pretty)),
 
   ok.
 
-variable_union_test() ->
-  ecache:reset_all(),
-  A = tunion([tvar(a), tatom(foo)]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
-  true = subty:is_equivalent(none, A, Pretty),
-  ?assertEqual("foo | a", pretty:render_ty(Pretty)),
-  ok.
-
 variable_union2_test() ->
   ecache:reset_all(),
   A = tunion([tvar(a), tvar(b), tatom(foo)]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A,symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("foo | a | b", pretty:render_ty(Pretty)),
   ok.
@@ -146,8 +155,8 @@ variable_union2_test() ->
 variable_union3_test() ->
   ecache:reset_all(),
   A = tunion([tvar(a), tvar(b), tvar(c), tatom(foo)]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("foo | a | b | c", pretty:render_ty(Pretty)),
   ok.
@@ -155,8 +164,8 @@ variable_union3_test() ->
 variable_union4_test() ->
   ecache:reset_all(),
   A = tunion([tvar(a),tatom()]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("atom() | a", pretty:render_ty(Pretty)),
   ok.
@@ -164,8 +173,8 @@ variable_union4_test() ->
 variable_union5_test() ->
   ecache:reset_all(),
   A = tunion([tvar(a),tatom(), trange(2,4)]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("atom() | 2..4 | a", pretty:render_ty(Pretty)),
   ok.
@@ -173,8 +182,8 @@ variable_union5_test() ->
 variable_union6_test() ->
   ecache:reset_all(),
   A = tunion([tvar(a), tvar(b), tvar(c), tvar(d), tatom(foo), trange(4,9)]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
   ?assertEqual("foo | 4..9 | a | b | c | d", pretty:render_ty(Pretty)),
   ok.
@@ -193,8 +202,8 @@ other_test() ->
       tvar(a0a0)
     ])
   ]),
-  B = ast_lib:ast_to_erlang_ty(V0),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(V0, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
 
   true = subty:is_equivalent(none, V0, Pretty),
   ?assertEqual("{a5 /\\ b, int} | {a, int}", pretty:render_ty(Pretty)),
@@ -207,8 +216,8 @@ var_condition_test() ->
     tintersect([tnegate(tvar(a)), tvar(c)]),
     tintersect([tnegate(tvar(b)), tnegate(tvar(c))])
   ]),
-  B = ast_lib:ast_to_erlang_ty(A),
-  Pretty = ast_lib:erlang_ty_to_ast(B),
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
 %%  ?assertEqual("{a5 /\\ b, int} | {a, int}", pretty:render_ty(Pretty)),
 

--- a/test/pretty_tests.erl
+++ b/test/pretty_tests.erl
@@ -222,3 +222,23 @@ var_condition_test() ->
 %%  ?assertEqual("{a5 /\\ b, int} | {a, int}", pretty:render_ty(Pretty)),
 
   ok.
+
+
+recursive_test() ->
+  ecache:reset_all(),
+  X = tvar(x),
+  L = tunion([
+    tatom(nil),
+    ttuple([tvar(alpha), X])
+  ]),
+  A = {mu, X, L},
+
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
+  true = subty:is_equivalent(none, A, Pretty),
+  
+  % TODO how to test this with string output?
+  {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
+  %?assertEqual("mu X . nil | {alpha, mu X}", pretty:render_ty(Pretty)),
+
+  ok.

--- a/test/tally_tests.erl
+++ b/test/tally_tests.erl
@@ -487,7 +487,7 @@ pretty_printing_bug_test() ->
     [{#{}, #{}}]).
 
 fun_local_own_test_() ->
-  {timeout, 15000, {"fun_local_02_plus", fun() ->
+  {timeout, 15, {"fun_local_02_plus", fun() ->
     ecache:reset_all(),
     {ok, [Cons]} = file:consult("test_files/tally/fun_local_02_plus.config"),
     Vars = lists:foldl(fun({S, T}, Acc) -> (ty_rec:all_variables(ast_lib:ast_to_erlang_ty(S)) ++ ty_rec:all_variables(ast_lib:ast_to_erlang_ty(T)) ++ Acc) end, [], Cons),
@@ -505,6 +505,26 @@ fun_local_own_test_() ->
     ok
                                          end}}
 .
+
+% TODO timeout
+%recursive_test_() ->
+%  {timeout, 15, {"user_07", fun() ->
+%    ecache:reset_all(),
+%    {ok, [Cons]} = file:consult("test_files/tally/user_07.config"),
+%    Vars = lists:foldl(fun({S, T}, Acc) -> (ty_rec:all_variables(ast_lib:ast_to_erlang_ty(S)) ++ ty_rec:all_variables(ast_lib:ast_to_erlang_ty(T)) ++ Acc) end, [], Cons),
+%    VarOrder = lists:map(fun(V) -> {var, Name} = ast_lib:erlang_ty_var_to_var(V), Name end,lists:sort(lists:flatten(Vars))),
+%
+%    % to print out cduce command
+%    % io:format(user, "~s~n", [test_utils:ety_to_cduce_tally(Cons, VarOrder)]),
+%
+%    test_tally(
+%      VarOrder,
+%      Cons,
+%      % TODO CDuce has 50 solutions, order is not used properly, see #72
+%      solutions(58)
+%    ),
+%    ok
+%                                         end}}.
 
 % =====
 % Map Normalization

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -143,14 +143,18 @@ simple_test_() ->
   % The following functions are currently excluded from being tested.
   WhatNot = [
     % Redundancy check for lists is not powerful enough, see #108
-    "list_pattern_08_fail"
+    "list_pattern_08_fail",
+    % #115 slow
+    "user_07"
   ],
 
   NoInfer = [
     % slow, see #62
     "foo3",
     % buggy, see #101
-    "poly"
+    "poly",
+    % TODO recursive inference
+    "user_06", "user_07"
   ],
 
   %What = ["atom_03_fail"],

--- a/test_files/tally/user_07.config
+++ b/test_files/tally/user_07.config
@@ -1,43 +1,82 @@
+% issue
+%-type user_t_07(X) :: nil | {X, user_t_07(X)}.
+%[
+% {$0 /\ {nil} /\ {any()}, {$5}},
+% {$0 /\ {nil} /\ {any()}, {$4}},
+% {$6, integer()},
+% {$0 /\ {nil} /\ {any()}, {$3}},
+% {$0 /\ {nil} /\ {any()}, {$2}},
+% {$0 /\ not({nil} /\ {any()}) /\ {{foo, any()}} /\ {any()}, {$9}},
+% {{$1}, $0},
+% {$0 /\ not({nil} /\ {any()}) /\ {{foo, any()}} /\ {any()}, {$8}},
+% {user_t_07(foo), $1},
+% {$18, $16},
+% {fun((user_t_07(foo)) -> integer()), fun(($17) -> $18)},
+% {$16, integer()},
+% {$0, {nil} /\ {any()} | {{foo, any()}} /\ {any()}},
+% {$9, {$10, $11}},
+% {$0 /\ not({nil} /\ {any()}) /\ {{foo, any()}} /\ {any()}, {$13}},
+% {$11, $17},
+% {$0 /\ not({nil} /\ {any()}) /\ {{foo, any()}} /\ {any()}, {$12}},
+% {$13, {$14, $15}},
+% {1, $6}
+%]
 [
     {
         {intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, 
         {tuple, [{var, '$5'}]}
     },
-
-    {{intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, {tuple,
-                                                                                [{var,
-                                                                                  '$4'}]}},{{var,'$6'}, {predef,integer}},{{intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, {tuple,
-                                                                                [{var,
-                                                                                  '$3'}]}},{{intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, {tuple,
-                                                                                [{var,
-                                                                                  '$2'}]}},{{intersection,
-     [{var,'$0'},
-      {negation,
-          {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}},
-      {tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
-      {tuple,[{predef,any}]}]}, {tuple,[{var,'$9'}]}},{{tuple,[{var,'$1'}]}, {var,'$0'}},{{intersection,
-     [{var,'$0'},
-      {negation,
-          {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}},
-      {tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
-      {tuple,[{predef,any}]}]}, {tuple,[{var,'$8'}]}},{
-        
+    {
+        {intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, 
+        {tuple, [{var, '$4'}]}
+    },
+    {
+        {var,'$6'}, 
+        {predef,integer}
+    },
+    {
+        {intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, 
+        {tuple, [{var, '$3'}]}
+    },
+    {
+        {intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, 
+        {tuple, [{var, '$2'}]}
+    },
+    {
+        {intersection, [{var,'$0'}, {negation, {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}}, {tuple,[{tuple,[{singleton,foo},{predef,any}]}]}, {tuple,[{predef,any}]}]}, 
+        {tuple,[{var,'$9'}]}
+    },
+    {
+        {tuple,[{var,'$1'}]}, 
+        {var,'$0'}
+    },
+    {
+        {intersection, [{var,'$0'}, {negation, {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}}, {tuple,[{tuple,[{singleton,foo},{predef,any}]}]}, {tuple,[{predef,any}]}]},
+        {tuple,[{var,'$8'}]}
+    },
+    {
         %{named,{loc,"test_files/tycheck_simple.erl",864,15}, {ref,user_t_07,1}, [{singleton,foo}]}
-        {mu, {var, x}, {union, [{singleton, nil}, {tuple, [{singleton, foo}, {var, x}]}]}}
-
-    , 
-    {var,'$1'}},{{var,'$18'}, {var,'$16'}},{{fun_full,[
-        
+        {mu, {var, x}, {union, [{singleton, nil}, {tuple, [{singleton, foo}, {var, x}]}]}}, 
+        {var,'$1'}
+    },
+    {
+        {var,'$18'}, 
+        {var,'$16'}
+    },
+    {
         %{named,{loc,"test_files/tycheck_simple.erl",864,15}, {ref,user_t_07,1}, [{singleton,foo}]}
-        {mu, {var, x}, {union, [{singleton, nil}, {tuple, [{singleton, foo}, {var, x}]}]}}
-                
-                ],
-           {predef,integer}}, {fun_full,[{var,'$17'}],{var,'$18'}}},{{var,'$16'}, {predef,integer}},{{var,'$0'}, {union,
-                 [{intersection,
-                      [{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]},
-                  {intersection,
-                      [{tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
-                       {tuple,[{predef,any}]}]}]}},{{var,'$9'}, {tuple,[{var,'$10'},{var,'$11'}]}},{{intersection,
+        {fun_full,[ {mu, {var, x}, {union, [{singleton, nil}, {tuple, [{singleton, foo}, {var, x}]}]}} ], {predef,integer}}, 
+        {fun_full,[{var,'$17'}],{var,'$18'}}
+    },
+    {
+        {var,'$16'}, 
+        {predef,integer}
+    },
+    {
+        {var,'$0'}, 
+        {union, [{intersection, [{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, {intersection, [{tuple,[{tuple,[{singleton,foo},{predef,any}]}]}, {tuple,[{predef,any}]}]}]}
+    },
+    {{var,'$9'}, {tuple,[{var,'$10'},{var,'$11'}]}},{{intersection,
      [{var,'$0'},
       {negation,
           {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}},

--- a/test_files/tally/user_07.config
+++ b/test_files/tally/user_07.config
@@ -1,0 +1,50 @@
+[
+    {
+        {intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, 
+        {tuple, [{var, '$5'}]}
+    },
+
+    {{intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, {tuple,
+                                                                                [{var,
+                                                                                  '$4'}]}},{{var,'$6'}, {predef,integer}},{{intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, {tuple,
+                                                                                [{var,
+                                                                                  '$3'}]}},{{intersection,[{var,'$0'},{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}, {tuple,
+                                                                                [{var,
+                                                                                  '$2'}]}},{{intersection,
+     [{var,'$0'},
+      {negation,
+          {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}},
+      {tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
+      {tuple,[{predef,any}]}]}, {tuple,[{var,'$9'}]}},{{tuple,[{var,'$1'}]}, {var,'$0'}},{{intersection,
+     [{var,'$0'},
+      {negation,
+          {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}},
+      {tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
+      {tuple,[{predef,any}]}]}, {tuple,[{var,'$8'}]}},{
+        
+        %{named,{loc,"test_files/tycheck_simple.erl",864,15}, {ref,user_t_07,1}, [{singleton,foo}]}
+        {mu, {var, x}, {union, [{singleton, nil}, {tuple, [{singleton, foo}, {var, x}]}]}}
+
+    , 
+    {var,'$1'}},{{var,'$18'}, {var,'$16'}},{{fun_full,[
+        
+        %{named,{loc,"test_files/tycheck_simple.erl",864,15}, {ref,user_t_07,1}, [{singleton,foo}]}
+        {mu, {var, x}, {union, [{singleton, nil}, {tuple, [{singleton, foo}, {var, x}]}]}}
+                
+                ],
+           {predef,integer}}, {fun_full,[{var,'$17'}],{var,'$18'}}},{{var,'$16'}, {predef,integer}},{{var,'$0'}, {union,
+                 [{intersection,
+                      [{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]},
+                  {intersection,
+                      [{tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
+                       {tuple,[{predef,any}]}]}]}},{{var,'$9'}, {tuple,[{var,'$10'},{var,'$11'}]}},{{intersection,
+     [{var,'$0'},
+      {negation,
+          {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}},
+      {tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
+      {tuple,[{predef,any}]}]}, {tuple,[{var,'$13'}]}},{{var,'$11'}, {var,'$17'}},{{intersection,
+     [{var,'$0'},
+      {negation,
+          {intersection,[{tuple,[{singleton,nil}]},{tuple,[{predef,any}]}]}},
+      {tuple,[{tuple,[{singleton,foo},{predef,any}]}]},
+      {tuple,[{predef,any}]}]}, {tuple,[{var,'$12'}]}},{{var,'$13'}, {tuple,[{var,'$14'},{var,'$15'}]}},{{singleton,1}, {var,'$6'}}].

--- a/test_files/tycheck_simple/user.erl
+++ b/test_files/tycheck_simple/user.erl
@@ -1,0 +1,52 @@
+-module(user).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+% Each top-level definition of this module is typechecked in isolation
+% against its spec, inference is also tested.
+% If the name ends with _fail, the test must fail.
+
+%%%%%%%%%%%%%%%%%%%%%%%% USER-DEFINED TYPES %%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%% RECURSIVE TYPES    %%%%%%%%%%%%%%%%%%%%%%%%
+ 
+% user-defined type
+-type user_t_01() :: foobar.
+-spec user_01() -> user_t_01().
+user_01() -> foobar.
+
+% argument
+-type user_t_02(X) :: X.
+-spec user_02() -> user_t_02(foobar).
+user_02() -> foobar.
+
+% recursive type, unfold static 1
+-type user_t_03a(X) :: nil | {X, user_t_03a(X)}.
+-spec user_03a() -> user_t_03a(foo).
+user_03a() -> {foo, nil}.
+
+% recursive type, unfold static 1
+-type user_t_03(X) :: nil | {X, user_t_03(X)}.
+-spec user_03(pos_integer()) -> user_t_03(foo).
+user_03(0) -> nil;
+user_03(_) -> {foo, nil}.
+
+% recursive type, unfold static 2
+-type user_t_04(X) :: nil | {X, user_t_04(X)}.
+-spec user_04(pos_integer()) -> user_t_04(foo).
+user_04(0) -> nil;
+user_04(1) -> {foo, nil};
+user_04(_) -> {foo, {foo, nil}}.
+
+% recursive type, unfold recursive
+-type user_t_05(X) :: nil | {X, user_t_05(X)}.
+-spec user_05(pos_integer()) -> user_t_05(foo).
+user_05(0) -> nil;
+user_05(I) -> {foo, user_05(I-i)}.
+
+% recursive type fail 
+-type user_t_06(X) :: nil | {X, user_t_06(X)}.
+-spec user_06_fail(integer()) -> user_t_06(foo).
+user_06_fail(0) -> nil;
+user_06_fail(I) -> {foo, user_06_fail(I-1)}.
+

--- a/test_files/tycheck_simple/user.erl
+++ b/test_files/tycheck_simple/user.erl
@@ -27,26 +27,38 @@ user_03a() -> {foo, nil}.
 
 % recursive type, unfold static 1
 -type user_t_03(X) :: nil | {X, user_t_03(X)}.
--spec user_03(pos_integer()) -> user_t_03(foo).
+-spec user_03(non_neg_integer()) -> user_t_03(foo).
 user_03(0) -> nil;
 user_03(_) -> {foo, nil}.
 
 % recursive type, unfold static 2
 -type user_t_04(X) :: nil | {X, user_t_04(X)}.
--spec user_04(pos_integer()) -> user_t_04(foo).
+-spec user_04(non_neg_integer()) -> user_t_04(foo).
 user_04(0) -> nil;
 user_04(1) -> {foo, nil};
 user_04(_) -> {foo, {foo, nil}}.
 
+-spec user_04_fail(non_neg_integer()) -> user_t_04(foo).
+user_04_fail(0) -> nil;
+user_04_fail(1) -> {foo, nil};
+user_04_fail(_) -> {foo, {fo, nil}}.
+
+% TODO we can't check this 
+% '-' operation does not ensure that I-1 is still a non_neg_integer()
 % recursive type, unfold recursive
--type user_t_05(X) :: nil | {X, user_t_05(X)}.
--spec user_05(pos_integer()) -> user_t_05(foo).
-user_05(0) -> nil;
-user_05(I) -> {foo, user_05(I-i)}.
+%-type user_t_05(X) :: nil | {X, user_t_05(X)}.
+%-spec user_05(non_neg_integer()) -> user_t_05(foo).
+%user_05(0) -> nil;
+%user_05(I) -> {foo, user_05(I-1)}.
 
-% recursive type fail 
+% recursive type apply once
 -type user_t_06(X) :: nil | {X, user_t_06(X)}.
--spec user_06_fail(integer()) -> user_t_06(foo).
-user_06_fail(0) -> nil;
-user_06_fail(I) -> {foo, user_06_fail(I-1)}.
+-spec user_06(boolean()) -> user_t_06(foo).
+user_06(true) -> nil;
+user_06(false) -> {foo, user_06(true)}.
 
+% recursive type descend recursive
+-type user_t_07(X) :: nil | {X, user_t_07(X)}.
+-spec user_07(user_t_07(foo)) -> integer().
+user_07(nil) -> 1;
+user_07({foo, X}) -> user_07(X).


### PR DESCRIPTION
`-type` annotation support and recursive types.

* Modified every method accessing the coinductively-defined `ty_rec` such that corecursion works properly
* Moved `ast:ty() <-> ty_rec` sanity check to the appropriate place
* Added recursive ast node `ty_mu()` to `ast.erl`
* Hacky way of ensuring uniqueness for recursive variables with `erlang:unique_integer()`
* [x] Blocked by #101 