### PR TITLE
Hex release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish on hex
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v3
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/src/etylizer.app.src
+++ b/src/etylizer.app.src
@@ -1,6 +1,6 @@
 {application, etylizer,
  [{description, "A type checker for Erlang based on set-theoretic types"},
-  {vsn, "0.1.0"},
+  {vsn, "0.0.1"},
   {env,[
     {providers, [etc_rebar_plug_prv]}
   ]},


### PR DESCRIPTION
I've added an additional step to the pipeline that publishes the project to [hex.pm](https://hex.pm) if a tag is created with the pattern `v*.*.*`, where the wildcards are numbers ranging from 0-9. For consistency this should correspond to the version number in [etylizer.app.src](src/etylizer.app.src).
For this to work there needs to be a hex API key `HEX_API_KEY` added to the repositories secrets.