### PR TITLE
Unsound memoization

### DIFF
--- a/src/erlang_types/dnf_ty_function.erl
+++ b/src/erlang_types/dnf_ty_function.erl
@@ -94,6 +94,8 @@ normalize(Size, DnfTyFunction, PVar, NVar, Fixed, M) ->
   % ntlv rule
   ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:function(Size, dnf_var_ty_function:var(Var)) end, M).
 
+normalize_coclause([], [], T, _Fixed, _M) ->
+  case bdd_bool:empty() of T -> [[]]; _ -> [] end;
 normalize_coclause(Pos, Neg, T, Fixed, M) ->
   case bdd_bool:empty() of
     T -> [[]];

--- a/src/erlang_types/dnf_ty_list.erl
+++ b/src/erlang_types/dnf_ty_list.erl
@@ -58,6 +58,8 @@ normalize(DnfTyList, PVar, NVar, Fixed, M) ->
   ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:list(dnf_var_ty_list:var(Var)) end, M).
 
 
+normalize_coclause([], [], T, _Fixed, _M) ->
+  case bdd_bool:empty() of T -> [[]]; _ -> [] end;
 normalize_coclause(Pos, Neg, T, Fixed, M) ->
   case bdd_bool:empty() of
     T -> [[]];

--- a/src/erlang_types/dnf_ty_map.erl
+++ b/src/erlang_types/dnf_ty_map.erl
@@ -49,7 +49,11 @@ normalize(DnfTyMap, PVar, NVar, Fixed, M) ->
   % ntlv rule
   ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:map(dnf_var_ty_map:var(Var)) end, M).
 
-normalize_coclause(Fixed, M) -> fun(Pos, Neg, T) ->
+normalize_coclause(Fixed, M) -> 
+  fun
+    ([], [], T) -> 
+  case bdd_bool:empty() of T -> [[]]; _ -> [] end;
+    (Pos, Neg, T) ->
   case bdd_bool:empty() of
     T -> [[]];
     _ -> phi_norm(ty_map:big_intersect(Pos), Neg, Fixed, M)

--- a/src/erlang_types/dnf_ty_tuple.erl
+++ b/src/erlang_types/dnf_ty_tuple.erl
@@ -72,13 +72,16 @@ phi(BigS, [Ty | N]) ->
 
 normalize(Size, Ty, [], [], Fixed, M) ->
   dnf(Ty, {
-    fun(Pos, Neg, T) ->
-      case bdd_bool:empty() of
-        T -> [[]];
-        _ ->
-          BigS = ty_tuple:big_intersect(Pos),
-          phi_norm(Size, ty_tuple:components(BigS), Neg, Fixed, M)
-      end
+    fun
+      ([], [], T) ->
+        case bdd_bool:empty() of T -> [[]]; _ -> [] end;
+      (Pos, Neg, T) ->
+        case bdd_bool:empty() of
+          T -> [[]];
+          _ ->
+            BigS = ty_tuple:big_intersect(Pos),
+            phi_norm(Size, ty_tuple:components(BigS), Neg, Fixed, M)
+        end
     end,
     fun constraint_set:meet/2
   });

--- a/src/erlang_types/dnf_var_ty_function.erl
+++ b/src/erlang_types/dnf_var_ty_function.erl
@@ -33,13 +33,12 @@ normalize_coclause(Size, PVar, NVar, Function, Fixed, M) ->
   case dnf_ty_function:empty() of
     Function -> [[]];
     _ ->
-      case ty_ref:is_normalized_memoized(Function, Fixed, M) of
+      case ty_ref:is_normalized_memoized({PVar, NVar, Function}, Fixed, M) of
         true ->
           % TODO test case
           error({todo, extract_test_case, memoize_function}); %[[]];
         miss ->
-          % memoize only non-variable component t0
-          dnf_ty_function:normalize(Size, Function, PVar, NVar, Fixed, sets:union(M, sets:from_list([Function])))
+          dnf_ty_function:normalize(Size, Function, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Function}])))
       end
   end.
 

--- a/src/erlang_types/dnf_var_ty_list.erl
+++ b/src/erlang_types/dnf_var_ty_list.erl
@@ -25,13 +25,12 @@ normalize_coclause(PVar, NVar, List, Fixed, M) ->
   case dnf_ty_list:empty() of
     List -> [[]];
     _ ->
-      case ty_ref:is_normalized_memoized(List, Fixed, M) of
+      case ty_ref:is_normalized_memoized({PVar, NVar, List}, Fixed, M) of
         true ->
           % TODO test case
           error({todo, extract_test_case, memoize_function}); %[[]];
         miss ->
-          % memoize only non-variable component t0
-          dnf_ty_list:normalize(List, PVar, NVar, Fixed, sets:union(M, sets:from_list([List])))
+          dnf_ty_list:normalize(List, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, List}])))
       end
   end.
 

--- a/src/erlang_types/dnf_var_ty_map.erl
+++ b/src/erlang_types/dnf_var_ty_map.erl
@@ -24,12 +24,11 @@ normalize_coclause(PVar, NVar, Map, Fixed, M) ->
   case dnf_ty_map:empty() of
     Map -> [[]];
     _ ->
-      case ty_ref:is_normalized_memoized(Map, Fixed, M) of
+      case ty_ref:is_normalized_memoized({PVar, NVar, Map}, Fixed, M) of
         true ->
           error({todo, extract_test_case, memoize_function}); %[[]];
         miss ->
-          % memoize only non-variable component t0
-          dnf_ty_map:normalize(Map, PVar, NVar, Fixed, sets:union(M, sets:from_list([Map])))
+          dnf_ty_map:normalize(Map, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Map}])))
       end
   end.
 

--- a/src/erlang_types/dnf_var_ty_tuple.erl
+++ b/src/erlang_types/dnf_var_ty_tuple.erl
@@ -32,13 +32,12 @@ normalize_coclause(Size, PVar, NVar, Tuple, Fixed, M) ->
   case dnf_ty_tuple:empty() of
     Tuple -> [[]];
     _ ->
-      case ty_ref:is_normalized_memoized(Tuple, Fixed, M) of
+      case ty_ref:is_normalized_memoized({PVar, NVar, Tuple}, Fixed, M) of
         true ->
           % TODO test case
           error({todo, extract_test_case, memoize_tuple}); %[[]];
         miss ->
-          % memoize only non-variable component t0
-          dnf_ty_tuple:normalize(Size, Tuple, PVar, NVar, Fixed, sets:union(M, sets:from_list([Tuple])))
+          dnf_ty_tuple:normalize(Size, Tuple, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Tuple}])))
       end
   end.
 

--- a/test_files/tally/foo5.config
+++ b/test_files/tally/foo5.config
@@ -1,0 +1,7 @@
+[{{var,'Date'}, {var,'$1'}},{{intersection,[{var,'$0'},
+                {tuple,[{tuple,[{predef,any}]}]},
+                {tuple,[{predef,any}]}]}, {tuple,[{var,'$6'}]}},{{tuple,[{var,'$1'}]}, {var,'$0'}},{{intersection,[{var,'$0'},
+                {tuple,[{tuple,[{predef,any}]}]},
+                {tuple,[{predef,any}]}]}, {tuple,[{var,'$5'}]}},{{intersection,[{var,'$0'},
+                {tuple,[{tuple,[{predef,any}]}]},
+                {tuple,[{predef,any}]}]}, {tuple,[{var,'$3'}]}},{{var,'$3'}, {tuple,[{var,'$4'}]}}].

--- a/test_files/tally/foo5_2.config
+++ b/test_files/tally/foo5_2.config
@@ -1,0 +1,85 @@
+[
+    {
+        {intersection,[
+            {var,'$0'},
+            {tuple,[
+                {singleton, fill},
+                {tuple,[{predef,any},{predef,any}]}
+            ]}
+            ]}, 
+        {tuple,[
+            {singleton, fill},
+            {var,'$6'}
+        ]}
+    },
+    {
+        {singleton,ok}, 
+        {var,'$10'}
+    },
+    {
+        {var,'$0'}, 
+        {intersection,[
+            {tuple,[
+                {singleton, fill},
+                {tuple,[{predef,any},{predef,any}]}
+            ]}
+                    ]}
+    },
+    {
+        {intersection,[{var,'$0'},
+                {tuple,[
+                    {singleton, fill},
+                    {tuple,[{predef,any},{predef,any}]}
+                ]}
+            ]}, 
+        {tuple,[{var,'$3'}]}
+    },
+    {
+        {var,'$10'}, 
+        {singleton,ok}
+    },
+    {
+        {intersection,[
+            {var,'$0'},
+                {tuple,[
+                    {singleton, fill},
+                    {tuple,[{predef,any},{predef,any}]}
+                ]}
+            ]}, 
+                {tuple,[
+                    {singleton, fill},
+                    {var,'$2'}
+                ]}
+    },
+    {
+        {var,'$3'}, 
+        {tuple,[{var,'$4'},{var,'$5'}]}
+    },
+    {
+        {tuple,[{singleton, fill}, {var,'$1'}]}, 
+        {var,'$0'}
+    },
+    {
+        {intersection,[
+            {var,'Date'},
+            {tuple,[
+                {singleton, fill},
+                {predef_alias,non_neg_integer}
+            ]}
+        ]}, 
+        {var, '$1'}
+    },
+    {
+        {var,'$7'}, 
+        {tuple,[{var,'$8'},{var,'$9'}]}
+    },
+    {
+        {intersection,[
+            {var,'$0'},
+                {tuple,[
+                {singleton, fill},
+                    {tuple,[{predef,any},{predef,any}]}
+                ]}
+        ]}, 
+                {tuple,[{singleton, fill}, {var,'$7'}]}
+    }].

--- a/test_files/tycheck_simple.erl
+++ b/test_files/tycheck_simple.erl
@@ -694,8 +694,8 @@ foo4_b(X) ->
         _ -> X
     end.
 
--spec foo5(Foo) -> Foo.
-foo5({_}) -> ok.
+-spec foo5_fail(Foo) -> Foo.
+foo5_fail({_}) -> ok.
 
 -spec inter_with_guard_constraints_fail(any()) -> integer(); (any()) -> integer().
 inter_with_guard_constraints_fail(X) ->

--- a/test_files/tycheck_simple.erl
+++ b/test_files/tycheck_simple.erl
@@ -694,6 +694,9 @@ foo4_b(X) ->
         _ -> X
     end.
 
+-spec foo5(Foo) -> Foo.
+foo5({_}) -> ok.
+
 -spec inter_with_guard_constraints_fail(any()) -> integer(); (any()) -> integer().
 inter_with_guard_constraints_fail(X) ->
     case X of


### PR DESCRIPTION
* In some parts of the code, not all components of a type are memoized. When descending, all components need to be memoized.
* Added missing edge case for simple BDD structures consisting of no variables and only a `{terminal, 1}` terminal.