### PR TITLE
Erlang 27 support. Fixes #130.

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erlang: [ 25,26 ]
+        erlang: [ 25,26,27 ]
 
     container:
       image: erlang:${{ matrix.erlang }}
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erlang: [ 25,26 ]
+        erlang: [ 25,26,27 ]
 
     container:
       image: erlang:${{ matrix.erlang }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erlang: [ 25,26 ]
+        erlang: [ 25,26,27 ]
 
     container:
       image: erlang:${{ matrix.erlang }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erlang: [ 25,26 ]
+        erlang: [ 25,26,27 ]
 
     container:
       image: erlang:${{ matrix.erlang }}

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -101,6 +101,7 @@ trans_form(Ctx, Form, Mode) ->
             {attribute, Anno, Other, _} ->
                 ?LOG_DEBUG("Ignoring attribute ~w at ~s", Other, ast:format_loc(to_loc(Ctx, Anno))),
                 error;
+            {warning, _} -> error;
             {eof, _} -> error;
             X -> errors:uncovered_case(?FILE, ?LINE, X)
         end,


### PR DESCRIPTION
Skipping the new `{warning, _}` AST constructs in our parse transformation. Enables full Erlang 27 Support.

* [x] ~~Test case missing~~ Already covered by a cm test