### PR TITLE
improvements

### DIFF
--- a/src/ast.erl
+++ b/src/ast.erl
@@ -8,6 +8,7 @@
 % grep -o '^-type [a-zA-Z_0-9]*' src/ast.erl | sed 's/-type //g' | grep -v '^gen_' | grep -v '^list[0-9]' | sed 's/^/    /g; s|$|/0,|g'
 -export_type([
     global_ref/0,
+    global_ref_dyn/0,
     ty_varname/0,
     local_ref/0,
     any_ref/0,
@@ -140,6 +141,7 @@
 
 % General
 -type global_ref() :: {ref, atom(), arity()} | {qref, atom(), atom(), arity()}.
+-type global_ref_dyn() :: {qref_dyn, exp(), exp(), exp()}.
 -type ty_varname() :: atom().
 -type unique_tok() :: integer().
 -type local_varname() :: {atom(), unique_tok()}.
@@ -266,6 +268,7 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 -type gen_cons(T) :: {cons, loc(), Head::T, Tail::T}.
 -type exp_cons() :: gen_cons(exp()).
 -type exp_fun_ref() :: {fun_ref, loc(), global_ref()}.
+-type exp_fun_ref_dyn() :: {fun_ref_dyn, loc(), global_ref_dyn()}.
 -type rec_fun_name() :: no_name | local_bind().
 -type exp_fun() :: {'fun', loc(), Name::rec_fun_name(), [fun_clause()]}.
 -type gen_funcall(T) :: {call, loc(), Fun::T, Args::[T]}
@@ -303,8 +306,8 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 
 % There is no match expression, because match expressions are represented as case expressions.
 -type exp() :: atomic_lit() | exp_bitstring_compr() | exp_bitstring_constr() | exp_block()
-    | exp_case() | exp_catch() | exp_cons() | exp_fun_ref() | exp_fun() | exp_funcall()
-    | exp_if() | exp_list_compr() | exp_map_create() | exp_map_update()
+    | exp_case() | exp_catch() | exp_cons() | exp_fun_ref() | exp_fun_ref_dyn() | exp_fun()
+    | exp_funcall() | exp_if() | exp_list_compr() | exp_map_create() | exp_map_update()
     | exp_nil() | exp_binop() | exp_unop() | exp_recv() | exp_recv_after() | exp_record_create()
     | exp_record_access() | exp_record_index() | exp_record_update() | exp_tuple() | exp_try()
     | exp_var().

--- a/src/ast.erl
+++ b/src/ast.erl
@@ -60,6 +60,7 @@
     exp_list_compr/0,
     exp_map_create/0,
     exp_map_update/0,
+    exp_map_compr/0,
     exp_nil/0,
     exp_binop/0,
     exp_unop/0,
@@ -74,7 +75,8 @@
     exp_var/0,
     exp/0,
     exps/0,
-    qual_gen/0,
+    qual_list_gen/0,
+    qual_map_gen/0,
     qual_bitstring_gen/0,
     qualifier/0,
     bitstring_tyspec/0,
@@ -280,6 +282,7 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 -type exp_map_create() :: gen_map_create().
 -type gen_map_update(T) :: {map_update, loc(), T, [map_assoc()]}.
 -type exp_map_update() :: gen_map_update(exp()).
+-type exp_map_compr() :: {mc, loc(), Key::exp(), Val::exp(), [qualifier()]}.
 -type gen_nil() ::  {nil, loc()}.
 -type exp_nil() :: gen_nil().
 -type gen_binop(T) :: {op, loc(), Op::binop(), T, T}.
@@ -307,7 +310,8 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 % There is no match expression, because match expressions are represented as case expressions.
 -type exp() :: atomic_lit() | exp_bitstring_compr() | exp_bitstring_constr() | exp_block()
     | exp_case() | exp_catch() | exp_cons() | exp_fun_ref() | exp_fun_ref_dyn() | exp_fun()
-    | exp_funcall() | exp_if() | exp_list_compr() | exp_map_create() | exp_map_update()
+    | exp_funcall() | exp_if() | exp_list_compr()
+    | exp_map_create() | exp_map_update() | exp_map_compr()
     | exp_nil() | exp_binop() | exp_unop() | exp_recv() | exp_recv_after() | exp_record_create()
     | exp_record_access() | exp_record_index() | exp_record_update() | exp_tuple() | exp_try()
     | exp_var().
@@ -317,9 +321,10 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 -spec loc_exp(exp()) -> loc().
 loc_exp(X) -> element(2, X).
 
--type qual_gen() ::  {generate, loc(), pat(), exp()}.
+-type qual_list_gen() ::  {generate, loc(), pat(), exp()}.
 -type qual_bitstring_gen() ::  {b_generate, loc(), pat(), exp()}.
--type qualifier() :: exp() | qual_gen() | qual_bitstring_gen().
+-type qual_map_gen() ::  {m_generate, loc(), KeyPat::pat(), ValPath::pat(), exp()}.
+-type qualifier() :: exp() | qual_list_gen() | qual_bitstring_gen() | qual_map_gen().
 
 -type bitstring_tyspec() :: atom() | {atom(), Value::integer()}.
 -type bitstring_tyspec_list() :: [bitstring_tyspec()].

--- a/src/ast.erl
+++ b/src/ast.erl
@@ -292,7 +292,8 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 -type exp_recv() :: {'receive', loc(), [case_clause()]}.
 -type exp_recv_after() :: {receive_after, loc(), [case_clause()], exp(), [exp()]}.
 -type gen_record_create(T) :: {record_create, loc(), Name::atom(),
-                               [{record_field, loc(), Field::atom(), T}]}.
+                               [{record_field, loc(), Field::atom(), T} |
+                                {record_field_other, loc(), T}]}.
 -type exp_record_create() :: gen_record_create(exp()).
 -type gen_record_access(T) :: {record_field, loc(), T, Name::atom(), Field::atom()}.
 -type exp_record_access() :: gen_record_access(exp()).

--- a/src/ast_erl.erl
+++ b/src/ast_erl.erl
@@ -62,6 +62,7 @@
     exp_list_compr/0,
     exp_map_create/0,
     exp_map_update/0,
+    exp_map_compr/0,
     exp_match/0,
     exp_nil/0,
     exp_binop/0,
@@ -77,7 +78,8 @@
     exp_var/0,
     exp/0,
     exps/0,
-    qual_gen/0,
+    qual_list_gen/0,
+    qual_map_gen/0,
     qual_bitstring_gen/0,
     qualifier/0,
     bitstring_tyspec/0,
@@ -263,6 +265,7 @@
 -type exp_map_create() :: gen_map_create().
 -type gen_map_update(T) :: {map, anno(), T, [map_assoc()]}.
 -type exp_map_update() :: gen_map_update(exp()).
+-type exp_map_compr() :: {mc, anno(), map_assoc_opt(), [qualifier()]}.
 -type exp_match() :: {match, anno(), pat(), exp()}.
 -type gen_nil() ::  {nil, anno()}.
 -type exp_nil() :: gen_nil().
@@ -291,15 +294,17 @@
 -type exp() :: atomic_lit() | exp_bitstring_compr() | exp_bitstring_constr() | exp_block()
     | exp_case() | exp_catch() | exp_cons() | exp_fun_ref() | exp_fun_qref() | exp_fun()
     | exp_named_fun() | exp_funcall() | exp_funcall_q() | exp_if() | exp_list_compr()
-    | exp_map_create() | exp_map_update() | exp_match() | exp_nil() | exp_binop() | exp_unop()
+    | exp_map_create() | exp_map_update() | exp_map_compr()
+    | exp_match() | exp_nil() | exp_binop() | exp_unop()
     | exp_recv() | exp_recv_after() | exp_record_create() | exp_record_access()
     | exp_record_index() | exp_record_update() | exp_tuple() | exp_try() | exp_var().
 
 -type exps() :: [exp()].
 
--type qual_gen() ::  {generate, anno(), pat(), exp()}.
+-type qual_list_gen() ::  {generate, anno(), pat(), exp()}.
 -type qual_bitstring_gen() ::  {b_generate, anno(), pat(), exp()}.
--type qualifier() :: exp() | qual_gen() | qual_bitstring_gen().
+-type qual_map_gen() ::  {m_generate, anno(), {map_field_exact, anno(), pat(), pat()}, exp()}.
+-type qualifier() :: exp() | qual_list_gen() | qual_bitstring_gen() | qual_map_gen().
 
 -type bitstring_tyspec() :: atom() | {atom(), Value::integer()}.
 -type bitstring_tyspec_list() :: [bitstring_tyspec()].

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -545,9 +545,14 @@ trans_exp(Ctx, Env, Exp) ->
                 thread_through_env(
                   Env,
                   Fields,
-                  fun(Env, {record_field, Anno, {'atom', _, FieldName}, FieldExp}) ->
-                          {NewFieldExp, NewEnv} = trans_exp(Ctx, Env, FieldExp),
-                          {{record_field, to_loc(Ctx, Anno), FieldName, NewFieldExp}, NewEnv}
+                  fun(Env, {record_field, Anno, F, FieldExp}) ->
+                    {NewFieldExp, NewEnv} = trans_exp(Ctx, Env, FieldExp),
+                    case F of
+                        {'atom', _, FieldName} ->
+                            {{record_field, to_loc(Ctx, Anno), FieldName, NewFieldExp}, NewEnv};
+                        {'var', _, '_'} ->
+                            {{record_field_other, to_loc(Ctx, Anno), NewFieldExp}, NewEnv}
+                    end
                   end
                  ),
             {{record_create, to_loc(Ctx, Anno), Name, NewFields}, NewEnv};

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -671,9 +671,10 @@ trans_pat(Ctx, Env, Pat, BindMode) ->
             {NewFields, NewEnv} =
                 thread_through_env(
                   Env, Fields,
-                  fun(E0, {record_field, Anno, {'atom', _, FieldName}, FieldPat}) ->
-                          {NewPat, E1} = trans_pat(Ctx, E0, FieldPat, BindMode),
-                          {{record_field, to_loc(Ctx, Anno), FieldName, NewPat}, E1}
+                  fun(E0, {record_field, Anno,  {'atom', _, FieldName}, FieldPat}) ->
+                        {NewPat, E1} =
+                            trans_pat(Ctx, E0, FieldPat, BindMode),
+                                {{record_field, to_loc(Ctx, Anno), FieldName, NewPat}, E1}
                   end),
             {{record, to_loc(Ctx, Anno), Name, NewFields}, NewEnv};
         {record_index, Anno, RecName, {'atom', _, FieldName}} ->

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -264,7 +264,7 @@ trans_ty(Ctx, Env, Ty) ->
                     Fields),
             case maps:find(Name, Ctx#ctx.records) of
                 error ->
-                    errors:name_error("~s: record ~w not defined", [ast:format_loc(Loc), Name]);
+                    errors:name_error(Loc, "record ~w not defined", [Name]);
                 {ok, RecTy} ->
                     records:encode_record_ty(RecTy, Overrides)
             end;
@@ -862,7 +862,8 @@ trans_record_field(Ctx, TyEnv, Field) ->
             {record_field, to_loc(Ctx, Anno), Name, untyped, no_default};
         {record_field, Anno, {'atom', _, Name}, DefaultExp} ->
             {record_field, to_loc(Ctx, Anno), Name, untyped,
-             trans_exp_noenv(Ctx, varenv_local:empty(), DefaultExp)}
+             trans_exp_noenv(Ctx, varenv_local:empty(), DefaultExp)};
+        X -> errors:uncovered_case(?FILE, ?LINE, X)
     end.
 
 -spec arity(ast:loc(), [any()]) -> arity().

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -822,7 +822,7 @@ trans_qualifier(Ctx, Env, Q) ->
             {NewV, NewEnv2} = trans_pat(Ctx, NewEnv1, V, shadow),
             {{m_generate, to_loc(Ctx, Anno), NewK, NewV, NewExp}, NewEnv2};
         Exp -> % filter
-            {trans_exp_noenv(Ctx, Env, Exp), Env}
+            trans_exp(Ctx, Env, Exp)
     end.
 
 -spec trans_map_assocs(ctx(), varenv_local:t(), [ast_erl:map_assoc()])

--- a/src/cm_check.erl
+++ b/src/cm_check.erl
@@ -4,20 +4,22 @@
 % updating the index.
 
 -export([
-    perform_type_checks/3,
+    perform_type_checks/4,
     perform_sanity_check/3
 ]).
 
 -include_lib("log.hrl").
 -include_lib("ety_main.hrl").
 
-
--spec perform_type_checks(paths:search_path(), cm_depgraph:dep_graph(), cmd_opts()) -> [file:filename()].
-perform_type_checks(SearchPath, DepGraph, Opts) ->
+-spec perform_type_checks(
+    paths:search_path(),
+    [file:filename()],
+    cm_depgraph:dep_graph(),
+    cmd_opts()) -> [file:filename()].
+perform_type_checks(SearchPath, SourceList, DepGraph, Opts) ->
     IndexFile = paths:index_file_name(Opts),
     RebarLockFile = paths:rebar_lock_file(Opts),
     Index = cm_index:load_index(RebarLockFile, IndexFile, Opts#opts.mode),
-    SourceList = cm_depgraph:all_sources(DepGraph),
     ?LOG_INFO("All sources: ~p", SourceList),
     {DepsChanged, NewIndex1} =
         cm_index:has_external_dep_changed(RebarLockFile, Index),

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -199,6 +199,8 @@ exp_constrs(Ctx, E, T) ->
             exp_constrs(Ctx, if_exp_to_case_exp(IfExp), T);
         {lc, L, _E, _Qs} ->
             errors:unsupported(L, "list comprehension: ~200p", [E]);
+        {mc, L, _E, _Qs} ->
+            errors:unsupported(L, "map comprehension: ~200p", [E]);
         {map_create, L, Assocs} ->
             KeyAlpha = fresh_tyvar(Ctx),
             ValAlpha = fresh_tyvar(Ctx),

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -276,6 +276,8 @@ exp_constrs(Ctx, E, T) ->
                     DefFields),
             DefFieldNames = sets:from_list(lists:map(fun ({N, _}) -> N end, DefFields)),
             GivenFieldNames =
+                % FIXME: deal with record_field_other, which assigns a value to all fields
+                % not mentioned explicitly
                 sets:from_list(lists:map(fun ({record_field, _L, N, _Exp}) -> N end, GivenFields)),
             case sets:is_subset(GivenFieldNames, DefFieldNames) of
                 false -> errors:ty_error(L, "too many record fields given", []);

--- a/src/constr_solve.erl
+++ b/src/constr_solve.erl
@@ -93,7 +93,13 @@ check_simp_constrs(Tab, FixedTyvars, Ds, What) ->
             Blocks = constr_error_locs:simp_constrs_to_blocks(Ds),
             ?LOG_DEBUG("Constraints are not satisfiable, now locating source of errors. Blocks:~n~s",
                 pretty:render_list(fun pretty:constr_block/1, Blocks)),
-            locate_tyerror(Tab, FixedTyvars, Blocks)
+            Timeout = 2000,
+            case utils:timeout(Timeout, fun () -> locate_tyerror(Tab, FixedTyvars, Blocks) end) of
+                {ok, Res} -> Res;
+                timeout ->
+                    ?LOG_INFO("Locating type error timed out after ~wms", Timeout),
+                    {error, none}
+            end
     end.
 
 % search_failing_prefix(L, F, Pred, Acc).

--- a/src/errors.erl
+++ b/src/errors.erl
@@ -3,7 +3,7 @@
 -export([
     unsupported/3, unsupported/2,
     name_error/3, name_error/2,
-    uncovered_case/3, bug/2, bug/1,
+    uncovered_case/3, uncovered_case/4, bug/2, bug/1,
     ty_error/2, ty_error/3, ty_error/1, not_implemented/1, parse_error/1
 ]).
 
@@ -41,6 +41,10 @@ bug(Msg, Args) ->
 -spec uncovered_case(file:filename(), t:lineno(), any()) -> no_return().
 uncovered_case(File, Line, X) ->
     bug("uncovered case in ~s:~w, unmatched value: ~w", [File, Line, X]).
+
+-spec uncovered_case(file:filename(), t:lineno(), string(), any()) -> no_return().
+uncovered_case(File, Line, InputFile, X) ->
+    bug("uncovered case in ~s:~w, input file ~s, unmatched value: ~w", [File, Line, InputFile, X]).
 
 -spec ty_error(ast:loc(), string(), any()) -> no_return().
 ty_error(Loc, Msg, Args) ->

--- a/src/errors.erl
+++ b/src/errors.erl
@@ -2,7 +2,7 @@
 
 -export([
     unsupported/3, unsupported/2,
-    name_error/3, name_error/2,
+    name_error/3, name_error/2, name_error_no_loc/2,
     uncovered_case/3, uncovered_case/4, bug/2, bug/1,
     ty_error/2, ty_error/3, ty_error/1, not_implemented/1, parse_error/1
 ]).
@@ -29,6 +29,10 @@ name_error(Loc, Msg, Args) ->
 
 -spec name_error(ast:loc(), string()) -> no_return().
 name_error(Loc, Msg) -> name_error(Loc, Msg, []).
+
+-spec name_error_no_loc(string(), any()) -> no_return().
+name_error_no_loc(Msg, Args) ->
+    generic_error(name_error, utils:sformat("Name error: ~s", utils:sformat(Msg, Args))).
 
 -spec bug(string()) -> no_return().
 bug(Msg) ->

--- a/src/ety_main.erl
+++ b/src/ety_main.erl
@@ -20,11 +20,15 @@ parse_args(Args) ->
     OptSpecList =
         [
          {project_root, $P,    "project-root",  string,
-             "Path to the root of the project"},
+             "Path to the root of the project. Etylizer stores persistent information in " ++
+             "$PROJECT_DIR/_etylizer."},
          {src_path,    $S,    "src-path",       string,
-             "Path to a directory containing source files (ending with .erl) to be checked"},
+             "Path to a directory containing source files. All .erl files within this " ++
+             "directory are type checked, but the directory is not search recursively for " ++
+             ".erl files. May be given multiple times. Source files explicitly given " ++
+             "on the commandline are added to files found via --source-path."},
          {include,    $I,   "include",   string,
-             "Where to search for include files"  },
+             "Where to search for include files (.hrl). May be given multiple times."  },
          {define,     $D,   "define",    string,
              "Define macro (either '-D NAME' or '-D NAME=VALUE')"},
          {load_start, $a,   "pa",        string,
@@ -48,8 +52,9 @@ parse_args(Args) ->
          {only, $o, "only", string,
             "Only typecheck these functions (given as name/arity or just the name)"},
          {no_deps, undefined, "no-deps", undefined,
-            "Only typecheck files explicitly specified on the commandline (incompatible with " ++
-            "-S/--source-path)"},
+            "Only typecheck files specified on the commandline (either via --source-path or " ++
+            "FILES arguments). The default behavior is to also check the dependencies of these " ++
+            "files."},
          {log_level,  $l,   "level",    string,
             "Minimal log level (trace2,trace,debug,info,note,warn)"}
         ],

--- a/src/ety_main.hrl
+++ b/src/ety_main.hrl
@@ -7,6 +7,7 @@
                sanity = false :: boolean(),
                force = false :: boolean(),
                no_type_checking = false :: boolean(),
+               no_deps = false :: boolean(),
                type_check_only = [] :: [string()],
                ast_file = empty :: empty | string(),
                project_root = empty :: empty | string(),

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -161,11 +161,19 @@ generate_input_file_list(Opts) ->
     case Opts#opts.src_paths of
         [] ->
             case Opts#opts.files of
-                [] -> utils:quit(1, "No input files given, aborting. Use -h to print help.~n");
+                [] -> utils:quit(1, "No input files given, aborting. Use --help to print help.~n");
                 Files -> Files
             end;
         Paths ->
-            lists:foldl(fun(Path, FileList) -> FileList ++ add_dir_to_list(Path) end, [], Paths)
+            case Opts#opts.no_deps of
+                true ->
+                    utils:quit(1, "Both options --no-deps and --source-path specified.~n");
+                false ->
+                    lists:foldl(
+                        fun(Path, FileList) -> FileList ++ add_dir_to_list(Path) end,
+                        Opts#opts.files,
+                        Paths)
+            end
     end.
 
 -spec add_dir_to_list(file:filename()) -> [file:filename()].

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -246,5 +246,7 @@ really_find_module_path(SearchPath, Module) ->
             {Kind, File, Includes};
         false ->
             Dirs = lists:map(fun({_, P, _}) -> P end, SearchPath),
-            ?ABORT("Module ~p not found, search path: ~p", Module, Dirs)
+            ?LOG_WARN("Module ~p not found, search path: ~s",
+                Module, string:join(Dirs, ":")),
+            errors:name_error_no_loc("Module ~p not found", [Module])
     end.

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -167,18 +167,13 @@ generate_input_file_list(Opts) ->
                     Files
             end;
         Paths ->
-            case Opts#opts.no_deps of
-                true ->
-                    utils:quit(1, "Both options --no-deps and --source-path specified.~n");
-                false ->
-                    ?LOG_INFO(
-                        "Searching for input files in ~200p and using explicitly specified files as input files: ~200p",
-                        Paths, Opts#opts.files),
-                    lists:foldl(
-                        fun(Path, FileList) -> FileList ++ add_dir_to_list(Path) end,
-                        Opts#opts.files,
-                        Paths)
-            end
+            ?LOG_INFO(
+                "Searching for input files in ~200p and using explicitly specified files as input files: ~200p",
+                Paths, Opts#opts.files),
+            lists:foldl(
+                fun(Path, FileList) -> FileList ++ add_dir_to_list(Path) end,
+                Opts#opts.files,
+                Paths)
     end.
 
 -spec add_dir_to_list(file:filename()) -> [file:filename()].

--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -23,10 +23,10 @@ check_all(Ctx, FileName, Env, Decls) ->
           fun({Decl, Ty}) -> check(ExtCtx, Decl, Ty) end,
           Decls
          ),
-        ?LOG_INFO("Successfully checked functions in ~s against their specs", FileName),
+        ?LOG_NOTE("Successfully checked functions in ~s against their specs", FileName),
         ok
     catch throw:{ety, ty_error, Msg} ->
-            ?LOG_INFO("Checking failed: ~s", Msg),
+            ?LOG_NOTE("Checking failed: ~s", Msg),
             {error, Msg}
     end.
 

--- a/test_files/tycheck_simple/comprehension.erl
+++ b/test_files/tycheck_simple/comprehension.erl
@@ -1,0 +1,13 @@
+-module(maps).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+% Each top-level definition of this module is typechecked in isolation
+% against its spec, inference is also tested.
+% If the name ends with _fail, the test must fail.
+
+% Test for a scoping bug
+% Currently deactivated because we have no support for list comprehension #151
+% -spec foo(list(T)) -> list({T, T}).
+% foo(Alts) -> [{S, A} || A <- Alts, S=A].

--- a/test_files/tycheck_simple/records.erl
+++ b/test_files/tycheck_simple/records.erl
@@ -135,3 +135,14 @@ get_name_from_invoice_02(X) -> X#invoice.person#person.name.
 
 -spec get_name_from_invoice_02_fail(#invoice{ person :: #person { name :: integer() }}) -> string().
 get_name_from_invoice_02_fail(X) -> X#invoice.person#person.name.
+
+%% recursive
+
+% Deactived because of #152
+%-record(rr, {name :: string(), recursive :: [#rr{}] }).
+%
+%-spec add1(string(), #rr{}) -> #rr{}.
+%add1(Name, R) -> #rr{name=Name, recursive=[R]}.
+%
+%-spec add2(string(), #rr{}) -> #rr{}.
+%add2(Name, R) -> R#rr{ recursive = [#rr{name=Name, recursive=[]} | R#rr.recursive]}.


### PR DESCRIPTION
* Added flag `--no-deps` to typecheck single source files
* Ast extension for dynamic fun refs `Mod:Name/Arity` 
* Ast extension for map qualifiers and [map comprehensions](https://www.erlang.org/eeps/eep-0058)
* Fixed a scoping bug in list filter comprehensions
* Added a timeout for constraint solving of 2000 ms
* Preliminary support for #153 
* Test cases for #151 and #152 