### PR TITLE
Fix co-recursion for subtyping and tallying

### DIFF
--- a/src/erlang_types/bdd.hrl
+++ b/src/erlang_types/bdd.hrl
@@ -153,7 +153,6 @@ get_dnf(Bdd) ->
     dnf(Bdd, {fun(P, N, T) -> [{P, N, T}] end, fun(C1, C2) -> C1() ++ C2() end})
   ).
 
-
 dnf(Bdd, {ProcessCoclause, CombineResults}) ->
   do_dnf(Bdd, {ProcessCoclause, CombineResults}, _Pos = [], _Neg = []).
 

--- a/src/erlang_types/bdd.hrl
+++ b/src/erlang_types/bdd.hrl
@@ -153,6 +153,7 @@ get_dnf(Bdd) ->
     dnf(Bdd, {fun(P, N, T) -> [{P, N, T}] end, fun(C1, C2) -> C1() ++ C2() end})
   ).
 
+
 dnf(Bdd, {ProcessCoclause, CombineResults}) ->
   do_dnf(Bdd, {ProcessCoclause, CombineResults}, _Pos = [], _Neg = []).
 

--- a/src/erlang_types/constraint_set.erl
+++ b/src/erlang_types/constraint_set.erl
@@ -12,7 +12,7 @@ saturate(C, FixedVariables, Memo) ->
   case pick_bounds_in_c(C, Memo) of
     {_Var, S, T} ->
       SnT = ty_rec:intersect(S, ty_rec:negate(T)),
-      Normed = fun() -> ty_rec:normalize(SnT, FixedVariables, sets:new()) end,
+      Normed = fun() -> ty_rec:normalize_start(SnT, FixedVariables) end,
       NewS = meet(fun() -> [C] end, Normed),
       lists:foldl(fun(NewC, AllS) ->
         NewMerged = fun() -> saturate(NewC, FixedVariables, sets:union(Memo, sets:from_list([SnT]))) end,

--- a/src/erlang_types/dnf_ty_list.erl
+++ b/src/erlang_types/dnf_ty_list.erl
@@ -5,7 +5,7 @@
 -define(F(Z), fun() -> Z end).
 
 -export([apply_to_node/3]).
--export([is_empty_corec/2, normalize/5, substitute/4]).
+-export([is_empty_corec/2, normalize_corec/5, substitute/4]).
 -export([list/1, all_variables/2, transform/2]).
 
 -include("bdd_node.hrl").
@@ -45,45 +45,45 @@ phi_corec(S1, S2, [Ty | N], M) ->
       end
   ).
 
-normalize(TyList, [], [], Fixed, M) ->
+normalize_corec(TyList, [], [], Fixed, M) ->
   dnf(TyList, {
     fun(Pos, Neg, DnfTyList) ->
-      normalize_coclause(Pos, Neg, DnfTyList, Fixed, M)
+      normalize_coclause_corec(Pos, Neg, DnfTyList, Fixed, M)
                                  end,
     fun constraint_set:meet/2
   });
-normalize(DnfTyList, PVar, NVar, Fixed, M) ->
+normalize_corec(DnfTyList, PVar, NVar, Fixed, M) ->
   Ty = ty_rec:list(dnf_var_ty_list:list(DnfTyList)),
   % ntlv rule
-  ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:list(dnf_var_ty_list:var(Var)) end, M).
+  ty_variable:normalize_corec(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:list(dnf_var_ty_list:var(Var)) end, M).
 
 
-normalize_coclause([], [], T, _Fixed, _M) ->
+normalize_coclause_corec([], [], T, _Fixed, _M) ->
   case bdd_bool:empty() of T -> [[]]; _ -> [] end;
-normalize_coclause(Pos, Neg, T, Fixed, M) ->
+normalize_coclause_corec(Pos, Neg, T, Fixed, M) ->
   case bdd_bool:empty() of
     T -> [[]];
     _ ->
       Big = ty_list:big_intersect(Pos),
       S1 = ty_list:pi1(Big),
       S2 = ty_list:pi2(Big),
-      phi_norm(S1, S2, Neg, Fixed, M)
+      phi_norm_corec(S1, S2, Neg, Fixed, M)
   end.
 
-phi_norm(S1, S2, [], Fixed, M) ->
-  T1 = ?F(ty_rec:normalize(S1, Fixed, M)),
-  T2 = ?F(ty_rec:normalize(S2, Fixed, M)),
+phi_norm_corec(S1, S2, [], Fixed, M) ->
+  T1 = ?F(ty_rec:normalize_corec(S1, Fixed, M)),
+  T2 = ?F(ty_rec:normalize_corec(S2, Fixed, M)),
   constraint_set:join(T1, T2);
-phi_norm(S1, S2, [Ty | N], Fixed, M) ->
-  T1 = ?F(ty_rec:normalize(S1, Fixed, M)),
-  T2 = ?F(ty_rec:normalize(S2, Fixed, M)),
+phi_norm_corec(S1, S2, [Ty | N], Fixed, M) ->
+  T1 = ?F(ty_rec:normalize_corec(S1, Fixed, M)),
+  T2 = ?F(ty_rec:normalize_corec(S2, Fixed, M)),
 
   T3 =
     ?F(begin
       TT1 = ty_list:pi1(Ty),
       TT2 = ty_list:pi2(Ty),
-      X1 = ?F(phi_norm(ty_rec:diff(S1, TT1), S2, N, Fixed, M)),
-      X2 = ?F(phi_norm(S1, ty_rec:diff(S2, TT2), N, Fixed, M)),
+      X1 = ?F(phi_norm_corec(ty_rec:diff(S1, TT1), S2, N, Fixed, M)),
+      X2 = ?F(phi_norm_corec(S1, ty_rec:diff(S2, TT2), N, Fixed, M)),
       constraint_set:meet(X1, X2)
     end),
 

--- a/src/erlang_types/dnf_ty_list.erl
+++ b/src/erlang_types/dnf_ty_list.erl
@@ -5,7 +5,7 @@
 -define(F(Z), fun() -> Z end).
 
 -export([apply_to_node/3]).
--export([is_empty/1, normalize/5, substitute/4]).
+-export([is_empty_corec/2, normalize/5, substitute/4]).
 -export([list/1, all_variables/2, transform/2]).
 
 -include("bdd_node.hrl").
@@ -13,35 +13,35 @@
 list(TyList) -> node(TyList).
 
 % partially generic
-is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
+is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T, M) end, fun is_empty_union/2}).
 
 % module specific implementations
-is_empty_coclause(Pos, Neg, T) ->
+is_empty_coclause_corec(Pos, Neg, T, M) ->
   case bdd_bool:empty() of
     T -> true;
     _ ->
       Big = ty_list:big_intersect(Pos),
       S1 = ty_list:pi1(Big),
       S2 = ty_list:pi2(Big),
-      ty_rec:is_empty(S1) orelse
-        ty_rec:is_empty(S2) orelse
-        phi(S1, S2, Neg)
+      ty_rec:is_empty_corec(S1, M) orelse
+        ty_rec:is_empty_corec(S2, M) orelse
+        phi_corec(S1, S2, Neg, M)
   end.
 
-phi(S1, S2, []) ->
-  ty_rec:is_empty(S1)
+phi_corec(S1, S2, [], M) ->
+  ty_rec:is_empty_corec(S1, M)
     orelse
-    ty_rec:is_empty(S2);
-phi(S1, S2, [Ty | N]) ->
-  ty_rec:is_empty(S1)
-    orelse ty_rec:is_empty(S2)
+    ty_rec:is_empty_corec(S2, M);
+phi_corec(S1, S2, [Ty | N], M) ->
+  ty_rec:is_empty_corec(S1, M)
+    orelse ty_rec:is_empty_corec(S2, M)
     orelse (
       begin
         T1 = ty_list:pi1(Ty),
         T2 = ty_list:pi2(Ty),
-        phi(ty_rec:diff(S1, T1), S2, N)
+        phi_corec(ty_rec:diff(S1, T1), S2, N, M)
           andalso
-          phi(S1, ty_rec:diff(S2, T2), N)
+          phi_corec(S1, ty_rec:diff(S2, T2), N, M)
       end
   ).
 

--- a/src/erlang_types/dnf_ty_map.erl
+++ b/src/erlang_types/dnf_ty_map.erl
@@ -8,18 +8,18 @@
 -define(F(Z), fun() -> Z end).
 -define(NORM, fun ty_rec:normalize/3).
 
--export([is_empty/1, normalize/5, substitute/4, apply_to_node/3]).
+-export([is_empty_corec/2, normalize/5, substitute/4, apply_to_node/3]).
 -export([map/1, all_variables/2, transform/2]).
 
 -include("bdd_node.hrl").
 
 map(TyMap) -> node(TyMap).
 
-is_empty(TyBDD) ->
-  dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
+is_empty_corec(TyBDD, M) ->
+  dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T, M) end, fun is_empty_union/2}).
 
 % module specific implementations
-is_empty_coclause(Pos, Neg, T) ->
+is_empty_coclause_corec(Pos, Neg, T, M) ->
   case {Pos, Neg, bdd_bool:empty()} of
     {_, _, T} -> true;
     {[], [], _} -> false;
@@ -28,10 +28,10 @@ is_empty_coclause(Pos, Neg, T) ->
       P2 = ty_rec:function(2, dnf_var_ty_function:any()),
       PPos = ty_tuple:tuple([P1, P2]),
       BigS = ty_tuple:big_intersect([PPos]),
-      dnf_ty_tuple:phi(ty_tuple:components(BigS), Neg);
+      dnf_ty_tuple:phi_corec(ty_tuple:components(BigS), Neg, M);
     {Pos, Neg, _} ->
       BigS = ty_tuple:big_intersect(Pos),
-      dnf_ty_tuple:phi(ty_tuple:components(BigS), Neg)
+      dnf_ty_tuple:phi_corec(ty_tuple:components(BigS), Neg, M)
   end.
 
 normalize(TyMap, [], [], Fixed, M) ->

--- a/src/erlang_types/dnf_ty_map.erl
+++ b/src/erlang_types/dnf_ty_map.erl
@@ -6,9 +6,8 @@
 -define(OPT, optional).
 -define(MAN, mandatory).
 -define(F(Z), fun() -> Z end).
--define(NORM, fun ty_rec:normalize/3).
 
--export([is_empty_corec/2, normalize/5, substitute/4, apply_to_node/3]).
+-export([is_empty_corec/2, normalize_corec/5, substitute/4, apply_to_node/3]).
 -export([map/1, all_variables/2, transform/2]).
 
 -include("bdd_node.hrl").
@@ -34,7 +33,7 @@ is_empty_coclause_corec(Pos, Neg, T, M) ->
       dnf_ty_tuple:phi_corec(ty_tuple:components(BigS), Neg, M)
   end.
 
-normalize(TyMap, [], [], Fixed, M) ->
+normalize_corec(TyMap, [], [], Fixed, M) ->
   % nmap rule
   dnf(TyMap, {
     fun
@@ -48,21 +47,21 @@ normalize(TyMap, [], [], Fixed, M) ->
             P2 = ty_rec:function(2, dnf_var_ty_function:any()),
             PPos = ty_tuple:tuple([P1, P2]),
             BigS = ty_tuple:big_intersect([PPos]),
-            dnf_ty_tuple:phi_norm(2, ty_tuple:components(BigS), Neg, Fixed, M)
+            dnf_ty_tuple:phi_norm_corec(2, ty_tuple:components(BigS), Neg, Fixed, M)
         end;
       (Pos, Neg, T) ->
         case bdd_bool:empty() of
           T -> [[]];
           _ ->
             BigS = ty_tuple:big_intersect(Pos),
-            dnf_ty_tuple:phi_norm(2, ty_tuple:components(BigS), Neg, Fixed, M)
+            dnf_ty_tuple:phi_norm_corec(2, ty_tuple:components(BigS), Neg, Fixed, M)
         end
     end,
     fun constraint_set:meet/2});
-normalize(DnfTyMap, PVar, NVar, Fixed, M) ->
+normalize_corec(DnfTyMap, PVar, NVar, Fixed, M) ->
   Ty = ty_rec:map(dnf_var_ty_map:map(DnfTyMap)),
   % ntlv rule
-  ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:map(dnf_var_ty_map:var(Var)) end, M).
+  ty_variable:normalize_corec(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:map(dnf_var_ty_map:var(Var)) end, M).
 
 
 apply_to_node(Node, SubstituteMap, Memo) ->

--- a/src/erlang_types/dnf_var_int.erl
+++ b/src/erlang_types/dnf_var_int.erl
@@ -3,7 +3,7 @@
 -define(ELEMENT, ty_variable).
 -define(TERMINAL, ty_interval).
 
--export([is_empty/1, normalize/3, substitute/4]).
+-export([is_empty/1, normalize_corec/3, substitute/4]).
 -export([var/1, int/1, all_variables/2, transform/2, apply_to_node/3, to_singletons/1]).
 
 -include("bdd_var.hrl").
@@ -15,8 +15,8 @@ var(Var) -> node(Var).
 is_empty(TyBDD) -> dnf( TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
 is_empty_coclause(_Pos, _Neg, T) -> ty_interval:is_empty(T).
 
-normalize(Ty, Fixed, M) -> dnf(Ty, {
-  fun(Pos, Neg, Atom) -> ty_interval:normalize(Atom, Pos, Neg, Fixed, M) end,
+normalize_corec(Ty, Fixed, M) -> dnf(Ty, {
+  fun(Pos, Neg, Atom) -> ty_interval:normalize_corec(Atom, Pos, Neg, Fixed, M) end,
   fun constraint_set:meet/2
 }).
 

--- a/src/erlang_types/dnf_var_predef.erl
+++ b/src/erlang_types/dnf_var_predef.erl
@@ -4,7 +4,7 @@
 -define(TERMINAL, ty_predef).
 
 -export([apply_to_node/3]).
--export([is_empty/1, normalize/3, substitute/4]).
+-export([is_empty/1, normalize_corec/3, substitute/4]).
 -export([var/1, predef/1,  all_variables/2, transform/2]).
 
 -include("bdd_var.hrl").
@@ -17,8 +17,8 @@ var(Var) -> node(Var).
 is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
 is_empty_coclause(_Pos, _Neg, T) -> ty_predef:is_empty(T).
 
-normalize(Ty, Fixed, M) -> dnf(Ty, {
-  fun(Pos, Neg, Atom) -> ty_predef:normalize(Atom, Pos, Neg, Fixed, M) end,
+normalize_corec(Ty, Fixed, M) -> dnf(Ty, {
+  fun(Pos, Neg, Atom) -> ty_predef:normalize_corec(Atom, Pos, Neg, Fixed, M) end,
   fun constraint_set:meet/2
 }).
 

--- a/src/erlang_types/dnf_var_ty_atom.erl
+++ b/src/erlang_types/dnf_var_ty_atom.erl
@@ -5,7 +5,7 @@
 -define(TERMINAL, ty_atom).
 
 -export([apply_to_node/3]).
--export([is_empty/1, normalize/3, substitute/4]).
+-export([is_empty/1, normalize_corec/3, substitute/4]).
 -export([var/1, ty_atom/1, all_variables/2]).
 -export([to_singletons/1, transform/2]).
 
@@ -19,8 +19,8 @@ is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
 
 is_empty_coclause(_Pos, _Neg, T) -> ty_atom:is_empty(T).
 
-normalize(Ty, Fixed, M) -> dnf(Ty, {
-  fun(Pos, Neg, Atom) -> ty_atom:normalize(Atom, Pos, Neg, Fixed, M) end,
+normalize_corec(Ty, Fixed, M) -> dnf(Ty, {
+  fun(Pos, Neg, Atom) -> ty_atom:normalize_corec(Atom, Pos, Neg, Fixed, M) end,
   fun constraint_set:meet/2
 }).
 

--- a/src/erlang_types/dnf_var_ty_function.erl
+++ b/src/erlang_types/dnf_var_ty_function.erl
@@ -5,7 +5,7 @@
 -define(F(Z), fun() -> Z end).
 
 
--export([is_empty/1]).
+-export([is_empty_corec/2]).
 -export([normalize/4, substitute/4]).
 -export([var/1, function/1, all_variables/2, mall_variables/2, transform/2]).
 
@@ -21,8 +21,8 @@ mall_variables({Default, Others}, M) when is_map(Others) ->
   ));
 mall_variables(Ty, M) -> all_variables(Ty, M).
 
-is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
-is_empty_coclause(_Pos, _Neg, T) -> dnf_ty_function:is_empty(T).
+is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T, M) end, fun is_empty_union/2}).
+is_empty_coclause_corec(_Pos, _Neg, T, M) -> dnf_ty_function:is_empty_corec(T, M).
 
 normalize(Size, Ty, Fixed, M) -> dnf(Ty, {
   fun(Pos, Neg, DnfTy) -> normalize_coclause(Size, Pos, Neg, DnfTy, Fixed, M) end,

--- a/src/erlang_types/dnf_var_ty_function.erl
+++ b/src/erlang_types/dnf_var_ty_function.erl
@@ -6,7 +6,7 @@
 
 
 -export([is_empty_corec/2]).
--export([normalize/4, substitute/4]).
+-export([normalize_corec/4, substitute/4]).
 -export([var/1, function/1, all_variables/2, mall_variables/2, transform/2]).
 
 -include("bdd_var.hrl").
@@ -24,23 +24,10 @@ mall_variables(Ty, M) -> all_variables(Ty, M).
 is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T, M) end, fun is_empty_union/2}).
 is_empty_coclause_corec(_Pos, _Neg, T, M) -> dnf_ty_function:is_empty_corec(T, M).
 
-normalize(Size, Ty, Fixed, M) -> dnf(Ty, {
-  fun(Pos, Neg, DnfTy) -> normalize_coclause(Size, Pos, Neg, DnfTy, Fixed, M) end,
+normalize_corec(Size, Ty, Fixed, M) -> dnf(Ty, {
+  fun(PVar, NVar, DnfTy) -> dnf_ty_function:normalize_corec(Size, DnfTy, PVar, NVar, Fixed, M) end,
   fun constraint_set:meet/2
 }).
-
-normalize_coclause(Size, PVar, NVar, Function, Fixed, M) ->
-  case dnf_ty_function:empty() of
-    Function -> [[]];
-    _ ->
-      case ty_ref:is_normalized_memoized({PVar, NVar, Function}, Fixed, M) of
-        true ->
-          [[]];
-        miss ->
-          dnf_ty_function:normalize(Size, Function, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Function}])))
-      end
-  end.
-
 
 % substitution delegates to dnf_ty_tuple substitution
 apply_to_node(Node, Map, Memo) ->

--- a/src/erlang_types/dnf_var_ty_list.erl
+++ b/src/erlang_types/dnf_var_ty_list.erl
@@ -3,7 +3,7 @@
 -define(ELEMENT, ty_variable).
 -define(TERMINAL, dnf_ty_list).
 
--export([is_empty_corec/2, normalize/3, substitute/4]).
+-export([is_empty_corec/2, normalize_corec/3, substitute/4]).
 -export([var/1, list/1, all_variables/2, transform/2, apply_to_node/3]).
 
 -include("bdd_var.hrl").
@@ -15,25 +15,10 @@ var(Var) -> node(Var).
 % partially generic
 is_empty_coclause_corec(_Pos, _Neg, T, M) -> dnf_ty_list:is_empty_corec(T, M).
 is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T, M) end, fun is_empty_union/2}).
-normalize(Ty, Fixed, M) -> dnf(Ty, {
-  fun(Pos, Neg, DnfTyList) -> normalize_coclause(Pos, Neg, DnfTyList, Fixed, M) end,
+normalize_corec(Ty, Fixed, M) -> dnf(Ty, {
+  fun(PVar, NVar, DnfTy) -> dnf_ty_list:normalize_corec(DnfTy, PVar, NVar, Fixed, M) end,
   fun constraint_set:meet/2
 }).
-
-% module specific implementations
-normalize_coclause(PVar, NVar, List, Fixed, M) ->
-  case dnf_ty_list:empty() of
-    List -> [[]];
-    _ ->
-      case ty_ref:is_normalized_memoized({PVar, NVar, List}, Fixed, M) of
-        true ->
-          [[]];
-        miss ->
-          dnf_ty_list:normalize(List, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, List}])))
-      end
-  end.
-
-
 
 % substitution delegates to dnf_ty_tuple substitution
 apply_to_node(Node, Map, Memo) ->

--- a/src/erlang_types/dnf_var_ty_list.erl
+++ b/src/erlang_types/dnf_var_ty_list.erl
@@ -3,7 +3,7 @@
 -define(ELEMENT, ty_variable).
 -define(TERMINAL, dnf_ty_list).
 
--export([is_empty/1,normalize/3, substitute/4]).
+-export([is_empty_corec/2, normalize/3, substitute/4]).
 -export([var/1, list/1, all_variables/2, transform/2, apply_to_node/3]).
 
 -include("bdd_var.hrl").
@@ -13,8 +13,8 @@ list(List) -> terminal(List).
 var(Var) -> node(Var).
 
 % partially generic
-is_empty_coclause(_Pos, _Neg, T) -> dnf_ty_list:is_empty(T).
-is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
+is_empty_coclause_corec(_Pos, _Neg, T, M) -> dnf_ty_list:is_empty_corec(T, M).
+is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T, M) end, fun is_empty_union/2}).
 normalize(Ty, Fixed, M) -> dnf(Ty, {
   fun(Pos, Neg, DnfTyList) -> normalize_coclause(Pos, Neg, DnfTyList, Fixed, M) end,
   fun constraint_set:meet/2

--- a/src/erlang_types/dnf_var_ty_map.erl
+++ b/src/erlang_types/dnf_var_ty_map.erl
@@ -3,7 +3,7 @@
 -define(ELEMENT, ty_variable).
 -define(TERMINAL, dnf_ty_map).
 
--export([is_empty/1,normalize/3, substitute/4]).
+-export([is_empty_corec/2,normalize/3, substitute/4]).
 -export([var/1, map/1, all_variables/2, transform/2, apply_to_node/3]).
 
 % implementations provided by bdd_var.hrl
@@ -12,8 +12,8 @@
 map(Map) -> terminal(Map).
 var(Var) -> node(Var).
 
-is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
-is_empty_coclause(_Pos, _Neg, T) -> dnf_ty_map:is_empty(T).
+is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T,M) end, fun is_empty_union/2}).
+is_empty_coclause_corec(_Pos, _Neg, T, M) -> dnf_ty_map:is_empty_corec(T, M).
 
 normalize(Ty, Fixed, M) -> dnf(Ty, {
   fun(Pos, Neg, DnfTyMap) -> normalize_coclause(Pos, Neg, DnfTyMap, Fixed, M) end,

--- a/src/erlang_types/dnf_var_ty_map.erl
+++ b/src/erlang_types/dnf_var_ty_map.erl
@@ -3,7 +3,7 @@
 -define(ELEMENT, ty_variable).
 -define(TERMINAL, dnf_ty_map).
 
--export([is_empty_corec/2,normalize/3, substitute/4]).
+-export([is_empty_corec/2, normalize_corec/3, substitute/4]).
 -export([var/1, map/1, all_variables/2, transform/2, apply_to_node/3]).
 
 % implementations provided by bdd_var.hrl
@@ -15,23 +15,10 @@ var(Var) -> node(Var).
 is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T) -> is_empty_coclause_corec(P, N, T,M) end, fun is_empty_union/2}).
 is_empty_coclause_corec(_Pos, _Neg, T, M) -> dnf_ty_map:is_empty_corec(T, M).
 
-normalize(Ty, Fixed, M) -> dnf(Ty, {
-  fun(Pos, Neg, DnfTyMap) -> normalize_coclause(Pos, Neg, DnfTyMap, Fixed, M) end,
+normalize_corec(Ty, Fixed, M) -> dnf(Ty, {
+  fun(Pos, Neg, DnfTyMap) -> dnf_ty_map:normalize_corec(DnfTyMap, Pos, Neg, Fixed, M) end,
   fun constraint_set:meet/2
 }).
-
-normalize_coclause(PVar, NVar, Map, Fixed, M) ->
-  case dnf_ty_map:empty() of
-    Map -> [[]];
-    _ ->
-      case ty_ref:is_normalized_memoized({PVar, NVar, Map}, Fixed, M) of
-        true ->
-          [[]];
-        miss ->
-          dnf_ty_map:normalize(Map, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Map}])))
-      end
-  end.
-
 
 % substitution delegates to dnf_ty_map substitution
 apply_to_node(Node, Map, Memo) ->

--- a/src/erlang_types/dnf_var_ty_tuple.erl
+++ b/src/erlang_types/dnf_var_ty_tuple.erl
@@ -4,8 +4,8 @@
 -define(TERMINAL, dnf_ty_tuple).
 -define(F(Z), fun() -> Z end).
 
--export([normalize/4, substitute/4]).
--export([var/1, tuple/1, all_variables/2, mall_variables/2, transform/2, is_empty_corec/2, apply_to_node/3, to_singletons/1]).
+-export([normalize_corec/4, substitute/4]).
+-export([var/1, tuple/1, all_variables/2, mall_variables/2, transform/2, is_empty_corec/2, apply_to_node/3]).
 
 % implementations provided by bdd_var.hrl
 -include("bdd_var.hrl").
@@ -23,28 +23,11 @@ mall_variables({Default, Others}, M) when is_map(Others) ->
   ));
 mall_variables(Ty, M) -> all_variables(Ty, M).
 
-normalize(Size, Ty, Fixed, M) -> dnf(Ty, {
-  fun(Pos, Neg, DnfTy) -> normalize_coclause(Size, Pos, Neg, DnfTy, Fixed, M) end,
+normalize_corec(Size, Ty, Fixed, M) -> dnf(Ty, {
+  fun(Pos, Neg, DnfTy) -> dnf_ty_tuple:normalize_corec(Size, DnfTy, Pos, Neg, Fixed, M) end,
   fun constraint_set:meet/2
 }).
-
-normalize_coclause(Size, PVar, NVar, Tuple, Fixed, M) ->
-  case dnf_ty_tuple:empty() of
-    Tuple -> [[]];
-    _ ->
-      case ty_ref:is_normalized_memoized({PVar, NVar, Tuple}, Fixed, M) of
-        true ->
-          [[]];
-        miss ->
-          dnf_ty_tuple:normalize(Size, Tuple, PVar, NVar, Fixed, sets:union(M, sets:from_list([{PVar, NVar, Tuple}])))
-      end
-  end.
 
 % substitution delegates to dnf_ty_tuple substitution
 apply_to_node(Node, Map, Memo) ->
   dnf_ty_tuple:substitute(Node, Map, Memo, fun(N, Subst, M) -> ty_tuple:substitute(N, Subst, M) end).
-
-to_singletons(TyBDD) -> dnf(TyBDD, {
-  fun(_Pos = [], _Neg = [], T) -> dnf_ty_tuple:to_singletons(T); (_, _, _) -> [] end,
-  fun(F1, F2) -> F1() ++ F2() end
-}).

--- a/src/erlang_types/dnf_var_ty_tuple.erl
+++ b/src/erlang_types/dnf_var_ty_tuple.erl
@@ -5,7 +5,7 @@
 -define(F(Z), fun() -> Z end).
 
 -export([normalize/4, substitute/4]).
--export([var/1, tuple/1, all_variables/2, mall_variables/2, transform/2, is_empty/1, apply_to_node/3, to_singletons/1]).
+-export([var/1, tuple/1, all_variables/2, mall_variables/2, transform/2, is_empty_corec/2, apply_to_node/3, to_singletons/1]).
 
 % implementations provided by bdd_var.hrl
 -include("bdd_var.hrl").
@@ -13,8 +13,8 @@
 tuple(Tuple) -> terminal(Tuple).
 var(Var) -> node(Var).
 
-is_empty(TyBDD) -> dnf(TyBDD, {fun is_empty_coclause/3, fun is_empty_union/2}).
-is_empty_coclause(_Pos, _Neg, T) -> dnf_ty_tuple:is_empty(T).
+is_empty_corec(TyBDD, M) -> dnf(TyBDD, {fun(P, N, T)  -> is_empty_coclause_corec(P, N, T, M) end, fun is_empty_union/2}).
+is_empty_coclause_corec(_Pos, _Neg, T, M) -> dnf_ty_tuple:is_empty_corec(T, M).
 
 mall_variables({Default, Others}, M) when is_map(Others) ->
   lists:usort(lists:flatten(

--- a/src/erlang_types/etally.erl
+++ b/src/erlang_types/etally.erl
@@ -27,7 +27,7 @@ tally_normalize(Constraints, FixedVars) ->
       fun() -> A end,
       fun() ->
         SnT = ty_rec:diff(S, T),
-        ty_rec:normalize(SnT, FixedVars, sets:new())
+        ty_rec:normalize_start(SnT, FixedVars)
       end
     )
               end, [[]], Constraints).

--- a/src/erlang_types/ty_atom.erl
+++ b/src/erlang_types/ty_atom.erl
@@ -7,7 +7,7 @@
 -export([is_empty/1]).
 -export([transform/2]).
 -export([finite/1, cofinite/1]).
--export([has_ref/2, to_singletons/1, normalize/5, substitute/4, all_variables/2]).
+-export([has_ref/2, to_singletons/1, normalize_corec/5, substitute/4, all_variables/2]).
 
 has_ref(_, _) -> false.
 all_variables(_, _) -> [].
@@ -68,15 +68,15 @@ is_any(Rep) ->
 % using erlang total ordering for now
 compare(R1, R2) -> case R1 < R2 of true -> -1; _ -> case R1 > R2 of true -> 1; _ -> 0 end end.
 
-normalize(TyAtom, [], [], _Fixed, _) ->
+normalize_corec(TyAtom, [], [], _Fixed, _) ->
   % Fig. 3 Line 3
   case is_empty(TyAtom) of
     true -> [[]];
     false -> []
   end;
-normalize(TyAtom, PVar, NVar, Fixed, M) ->
+normalize_corec(TyAtom, PVar, NVar, Fixed, M) ->
   Ty = ty_rec:atom(dnf_var_ty_atom:ty_atom(TyAtom)),
   % ntlv rule
-  ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:atom(dnf_var_ty_atom:var(Var)) end, M).
+  ty_variable:normalize_corec(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:atom(dnf_var_ty_atom:var(Var)) end, M).
 
 

--- a/src/erlang_types/ty_interval.erl
+++ b/src/erlang_types/ty_interval.erl
@@ -8,7 +8,7 @@
 
 -export([empty/0, any/0]).
 -export([union/2, intersect/2, diff/2, negate/1, is_any/1]).
--export([is_empty/1, eval/1, normalize/5, substitute/4, all_variables/2, to_singletons/1]).
+-export([is_empty/1, eval/1, normalize_corec/5, substitute/4, all_variables/2, to_singletons/1]).
 
 
 -export([interval/2, cointerval/2]).
@@ -149,16 +149,16 @@ add_range([{left, B1} | Xs], _A, B) ->
 add_range([{right, A1} | _], A, _B) -> [{right, min(A, A1)}];
 add_range([any_int | _], _A, _B) -> any().
 
-normalize(TyInterval, [], [], _Fixed, _) ->
+normalize_corec(TyInterval, [], [], _Fixed, _) ->
     % Fig. 3 Line 3
     case is_empty(TyInterval) of
         true -> [[]];
         false -> []
     end;
-normalize(TyInterval, PVar, NVar, Fixed, M) ->
+normalize_corec(TyInterval, PVar, NVar, Fixed, M) ->
     Ty = ty_rec:interval(dnf_var_int:int(TyInterval)),
     % ntlv rule
-    ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:interval(dnf_var_int:var(Var)) end, M).
+    ty_variable:normalize_corec(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:interval(dnf_var_int:var(Var)) end, M).
 
 substitute(_, Ty, _, _) -> Ty.
 % there is nothing to substitute in a ty_interval

--- a/src/erlang_types/ty_predef.erl
+++ b/src/erlang_types/ty_predef.erl
@@ -8,7 +8,7 @@
 
 -export([empty/0, any/0]).
 -export([union/2, intersect/2, diff/2, negate/1, is_any/1]).
--export([is_empty/1, eval/1, normalize/5, substitute/4]).
+-export([is_empty/1, eval/1, normalize_corec/5, substitute/4]).
 
 -export([has_ref/2, predef/1, transform/2, all_variables/2]).
 
@@ -60,13 +60,13 @@ intersect(P1, P2) ->
 diff(I1, I2) ->
     intersect(I1, negate(I2)).
 
-normalize(TyPredef, [], [], _Fixed, _) ->
+normalize_corec(TyPredef, [], [], _Fixed, _) ->
     % Fig. 3 Line 3
     case is_empty(TyPredef) of
         true -> [[]];
         false -> []
     end;
-normalize(TyPredef, PVar, NVar, Fixed, M) ->
+normalize_corec(TyPredef, PVar, NVar, Fixed, M) ->
     Ty = ty_rec:predef(dnf_var_predef:predef(TyPredef)),
     % ntlv rule
-    ty_variable:normalize(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:predef(dnf_var_predef:var(Var)) end, M).
+    ty_variable:normalize_corec(Ty, PVar, NVar, Fixed, fun(Var) -> ty_rec:predef(dnf_var_predef:var(Var)) end, M).

--- a/src/erlang_types/ty_ref.erl
+++ b/src/erlang_types/ty_ref.erl
@@ -1,14 +1,13 @@
 -module(ty_ref).
 
 -export([setup_ets/0, any/0, store/1, load/1, new_ty_ref/0, define_ty_ref/2, is_empty_cached/1, store_is_empty_cached/2, store_recursive_variable/2, check_recursive_variable/1]).
--export([memoize/1, is_empty_memoized/1, reset/0, is_normalized_memoized/3]).
+-export([reset/0, is_normalized_memoized/3]).
 -export([op_cache/3, memoize_norm/2, normalized_memoized/1, setup_all/0]).
 
 -define(TY_UTIL, ty_counter).        % counter store
 -define(TY_MEMORY, ty_mem).          % id -> ty
 -define(TY_UNIQUE_TABLE, ty_unique). % ty -> id
 
--define(EMPTY_MEMO, memoize_ty_ets).                            % ty_ref -> true
 
 -define(EMPTY_CACHE, is_empty_memoize_ets). % ty_rec -> true/false
 -define(NORMALIZE_CACHE, normalize_cache_ets). % ty_ref -> SoCS
@@ -29,7 +28,7 @@ op_cache(Op, K, Fun) ->
   end.
 
 all_tables() ->
-  [?TY_UNIQUE_TABLE, ?TY_MEMORY, ?TY_UTIL, ?EMPTY_MEMO, ?EMPTY_CACHE, ?RECURSIVE_TABLE, ?NORMALIZE_CACHE].
+  [?TY_UNIQUE_TABLE, ?TY_MEMORY, ?TY_UTIL, ?EMPTY_CACHE, ?RECURSIVE_TABLE, ?NORMALIZE_CACHE].
 
 reset() ->
   erase(),
@@ -138,18 +137,6 @@ store(Ty) ->
       {ty_ref, Id};
     [{_, Id}] ->
       {ty_ref, Id}
-  end.
-
-memoize({ty_ref, Id}) ->
-  ets:insert(?EMPTY_MEMO, {Id, true}),
-  ok.
-
-
-is_empty_memoized({ty_ref, Id}) ->
-  Object = ets:lookup(?EMPTY_MEMO, Id),
-  case Object of
-    [] -> miss;
-    [{_, true}] -> true
   end.
 
 memoize_norm({{ty_ref, Id}, Fixed}, Sol) ->

--- a/src/erlang_types/ty_ref.erl
+++ b/src/erlang_types/ty_ref.erl
@@ -1,6 +1,11 @@
 -module(ty_ref).
 
--export([setup_ets/0, any/0, store/1, load/1, new_ty_ref/0, define_ty_ref/2, is_empty_cached/1, store_is_empty_cached/2, store_recursive_variable/2, check_recursive_variable/1]).
+-export([
+  setup_ets/0, any/0, store/1, load/1, new_ty_ref/0, define_ty_ref/2, 
+  is_empty_cached/1, store_is_empty_cached/2, 
+  normalize_cached/1, store_normalize_cached/2, 
+  store_recursive_variable/2, 
+  check_recursive_variable/1]).
 -export([reset/0, is_normalized_memoized/3]).
 -export([op_cache/3, memoize_norm/2, normalized_memoized/1, setup_all/0]).
 
@@ -168,6 +173,19 @@ is_empty_cached({ty_ref, Id}) ->
 
 store_is_empty_cached({ty_ref, Id}, Result) ->
   ets:insert(?EMPTY_CACHE, {Id, Result}),
+  Result.
+
+normalize_cached(Id) ->
+  Object = ets:lookup(?NORMALIZE_CACHE, Id),
+  case Object of
+    [] -> miss;
+    [{_, Result}] ->
+%%      io:format(user, "x", []),
+      Result
+  end.
+
+store_normalize_cached(Id, Result) ->
+  ets:insert(?NORMALIZE_CACHE, {Id, Result}),
   Result.
 
 store_recursive_variable(Variable, Ty) ->

--- a/src/erlang_types/ty_tuple.erl
+++ b/src/erlang_types/ty_tuple.erl
@@ -3,7 +3,7 @@
 %% n-tuple representation
 -export([compare/2, equal/2, substitute/3, all_variables/2]).
 
--export([tuple/1, pi/2, has_ref/2, components/1, transform/2, any/1, empty/1, big_intersect/1, is_empty/1]).
+-export([tuple/1, pi/2, has_ref/2, components/1, transform/2, any/1, empty/1, big_intersect/1]).
 
 empty(Size) -> {ty_tuple, Size, [ty_rec:empty() || _ <- lists:seq(1, Size)]}.
 any(Size) -> {ty_tuple, Size, [ty_rec:any() || _ <- lists:seq(1, Size)]}.
@@ -19,9 +19,6 @@ tuple(Refs) -> {ty_tuple, length(Refs), Refs}.
 components({ty_tuple, _, Refs}) -> Refs.
 pi(I, {ty_tuple, _, Refs}) -> lists:nth(I, Refs).
 has_ref({ty_tuple, _, Refs}, Ref) -> length([X || X <- Refs, X == Ref]) > 0.
-
-is_empty({ty_tuple, _, Refs}) ->
-    lists:any(fun(T) -> ty_rec:is_empty(T) end, Refs).
 
 transform({ty_tuple, _, Refs}, #{to_tuple := ToTuple}) ->
     ToTuple(Refs).

--- a/src/erlang_types/ty_variable.erl
+++ b/src/erlang_types/ty_variable.erl
@@ -7,7 +7,7 @@
 -export([equal/2, compare/2, substitute/4, has_ref/2, all_variables/2, name/1]).
 
 
--export([new/1, smallest/3, normalize/6, transform/2, get_new_id/0]).
+-export([new/1, smallest/3, normalize_corec/6, transform/2, get_new_id/0]).
 
 -export_type([var/0]).
 
@@ -74,7 +74,7 @@ single(Pol, VPos, VNeg, Ty, VarToTy) ->
 
 
 % (NTLV rule)
-normalize(Ty, PVar, NVar, Fixed, VarToTy, Mx) ->
+normalize_corec(Ty, PVar, NVar, Fixed, VarToTy, Mx) ->
   SmallestVar = ty_variable:smallest(PVar, NVar, Fixed),
   case SmallestVar of
     {{pos, Var}, _Others} ->
@@ -85,7 +85,7 @@ normalize(Ty, PVar, NVar, Fixed, VarToTy, Mx) ->
       [[{Var, Singled, ty_rec:any()}]];
     {{{delta, _}, _}, _} ->
       % part 1 paper Lemma C.3 and C.11 all fixed variables can be eliminated
-      ty_rec:normalize(Ty, Fixed, Mx)
+      ty_rec:normalize_corec(Ty, Fixed, Mx)
   end.
 
 substitute(MkTy, Var, Map, _Memo) ->

--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -48,7 +48,8 @@ is_tlist({improper_list, _, _}) -> true;
 is_tlist({negation, {improper_list, _, _}}) -> true;
 is_tlist(_) -> false.
 
-tmu(_,_) -> throw(todo_mu).
+-spec tmu(ast:ty_var(), ast:ty()) -> ast:ty().
+tmu(Var,Ty) -> {mu, Var, Ty}.
 
 -spec tinter([ast:ty()]) -> ast:ty().
 tinter(Tys) -> {intersection, Tys}.


### PR DESCRIPTION
* Fixed soundness of memoization of subtyping. We are not allowed to use a global memoization set without also undoing some changes (how to use a global memo set, see CDuce)
* Memoization happens now at a single place for both emptiness checking and normalization and is tracked via an additional argument in co-recursive functions, as opposed to globally via side-effects; undoing changes happens automatically now
* Caching of subtyping and tallying is sound now: we only cache the result of the entry of `is_empty` and `normalize`. We are not allowed to cache the results in the intermediate state of a co-recursive call, without taking the memoization set into account.
* Memoization uses a map instead of a set (makes no difference in performance)
* The overall performance remains the same as before
* Co-recursive continuations now have by convention `_corec` in the method name, indicating that this is the right method to use inside a recursive call chain; it is not allowed to use `is_empty` in the same `is_empty` chain descending the co-inductive `ty_rec` construct, `is_empty_corec` should be used. The same applies for all other co-recursive functions.  

Prerequisite for recursive types and #84 to work.