### PR TITLE
Efficient Tuple Representation II

### DIFF
--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -148,7 +148,6 @@ erlang_ty_to_ast(X, M) ->
     % io:format(user,"Memoized ~p, replace with ~p~n", [X, Var]),
                 Var;
             _ ->
-    R = make_ref(),
         % Given a X = ... equation, create a new
         % TODO discuss how to ensure uniqueness
         RecVarID = erlang:unique_integer(),

--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -125,9 +125,9 @@ erlang_ty_to_ast(X) ->
     case ty_rec:is_equivalent(X, Sanity) of
     true -> ok;
     false ->
-        io:format(user, "--------~n", []),
-        io:format(user, "~p => ~p~n", [X, ty_ref:load(X)]),
-        io:format(user, "~p~n", [FinalTy]),
+        % io:format(user, "--------~n", []),
+        % io:format(user, "~p => ~p~n", [X, ty_ref:load(X)]),
+        % io:format(user, "~p~n", [FinalTy]),
         raw_erlang_ty_to_ast(X), % check if this is really a pretty printing bug or a transformation bug
         error(pretty_printing_bug)
     end,
@@ -420,7 +420,26 @@ ast_to_erlang_ty_var({var, Name}) when is_atom(Name) ->
 
 % === useful for debugging
 raw_erlang_ty_to_ast(X) ->
-    raw_erlang_ty_to_ast(X, #{}).
+    FinalTy = raw_erlang_ty_to_ast(X, #{}),
+
+    % SANITY CHECK
+    % TODO is it always the case that once we are in the semantic world, when we go back we dont need the symtab?
+    Sanity = ast_lib:ast_to_erlang_ty(FinalTy, symtab:empty()),
+      % leave this sanity check for a while
+      case ty_rec:is_equivalent(X, Sanity) of
+        true -> ok;
+        false ->
+            % Dump = ty_ref:write_dump_ty(X),
+            % io:format(user, "Dump~n~p~n", [Dump]),
+            % io:format(user, "--------~n", []),
+            % io:format(user, "~p => ~p~n", [X, ty_ref:load(X)]),
+            % io:format(user, "~p~n", [FinalTy]),
+            error(raw_printing_bug)
+      end,
+    
+    FinalTy.
+
+
 
 raw_erlang_ty_to_ast(X, M) ->
         case M of
@@ -474,20 +493,5 @@ raw_erlang_ty_to_ast(X, M) ->
             false ->
                 NewTy
         end,
-
-        % SANITY CHECK
-        % TODO is it always the case that once we are in the semantic world, when we go back we dont need the symtab?
-        Sanity = ast_lib:ast_to_erlang_ty(FinalTy, symtab:empty()),
-          % leave this sanity check for a while
-          case ty_rec:is_equivalent(X, Sanity) of
-            true -> ok;
-            false ->
-                % Dump = ty_ref:write_dump_ty(X),
-                % io:format(user, "Dump~n~p~n", [Dump]),
-                % io:format(user, "--------~n", []),
-                % io:format(user, "~p => ~p~n", [X, ty_ref:load(X)]),
-                % io:format(user, "~p~n", [FinalTy]),
-                error(raw_printing_bug)
-          end,
         FinalTy
     end.

--- a/src/erlang_types/bdd.hrl
+++ b/src/erlang_types/bdd.hrl
@@ -13,7 +13,7 @@
 % hide built-in Erlang node function
 -compile({no_auto_import, [node/1]}).
 
--export([raw_transform/2, all_variables/1, has_ref/2, get_dnf/1, any/0, empty/0, equal/2, node/1, terminal/1, compare/2, union/2, intersect/2, negate/1, diff/2]).
+-export([get_dnf_raw/1, dnf_raw/2, raw_transform/2, all_variables/1, has_ref/2, get_dnf/1, any/0, empty/0, equal/2, node/1, terminal/1, compare/2, union/2, intersect/2, negate/1, diff/2]).
 
 % these are defined here so the IDE does not complain
 -ifndef(ELEMENT).
@@ -143,7 +143,7 @@ is_empty_union(F1, F2) ->
   F1() andalso F2().
 
 get_dnf_raw(Bdd) ->
-  Raw = lists:filter(
+  lists:filter(
     fun({_,_,[]}) -> false; ({_, _, T}) ->
       case ?TERMINAL:empty() of
         T -> false;

--- a/src/erlang_types/dnf_ty_tuple.erl
+++ b/src/erlang_types/dnf_ty_tuple.erl
@@ -4,7 +4,7 @@
 -define(TERMINAL, bdd_bool).
 -define(F(Z), fun() -> Z end).
 
--export([is_empty_corec/2, normalize_corec/6, substitute/4, apply_to_node/3]).
+-export([simplify_dnf/1, is_empty_corec/2, normalize_corec/6, substitute/4, apply_to_node/3]).
 -export([tuple/1, all_variables/2, transform/2, to_singletons/1, phi_corec/3, phi_norm_corec/5]).
 
 -include("bdd_node.hrl").
@@ -128,6 +128,21 @@ phi_norm_corec(Size, BigS, [Ty | N], Fixed, M) ->
 
 apply_to_node(Node, Map, Memo) ->
   substitute(Node, Map, Memo, fun(N, S, M) -> ty_tuple:substitute(N, S, M) end).
+
+simplify_dnf(Dnf) ->
+
+  % step 1: intersect positive 
+  A = [{big_intersect(P), N, T} || {P, N, T} <- Dnf],
+
+  A.
+
+big_intersect([]) -> [];
+big_intersect([X]) -> [X];
+big_intersect(X) -> 
+  % io:format(user,"x",[]),
+  [ty_tuple:big_intersect(X)].
+
+
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/erlang_types/ty_tuple.erl
+++ b/src/erlang_types/ty_tuple.erl
@@ -24,7 +24,7 @@ raw_transform(T, Op) -> transform(T, Op).
 transform({ty_tuple, _, Refs}, #{to_tuple := ToTuple}) ->
     ToTuple(Refs).
 
-big_intersect([]) -> error(illegal_state);
+big_intersect([]) -> [];
 big_intersect([X]) -> X;
 big_intersect([X | Y]) ->
     lists:foldl(fun({ty_tuple, _, Refs}, {ty_tuple, Dim, Refs2}) ->

--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -19,6 +19,7 @@
     builtin_ops/0, builtin_funs/0,
     tatom/0, tatom/1,
     tintersect/1, tunion/1, tunion/2, tnegate/1,
+    tdiff/2,
     tinter/1, tinter/2,
     tyscm/2,
     any/0,
@@ -117,6 +118,9 @@ ttuple1(T) ->
 
 ttuple2(T, U) ->
     {tuple, [T, U]}.
+
+tdiff(T1, T2) ->
+    tintersect([T1, tnegate(T2)]).
 
 tintersect(Components) ->
     {intersection, Components}.

--- a/test.erl
+++ b/test.erl
@@ -1,0 +1,13 @@
+-module(test).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-type exp() :: integer() | {add, exp(), exp()}.
+
+-spec eval(exp()) -> integer().
+eval(E) ->
+    case E of
+        {add, E1, E2} -> eval(E1) + eval(E2);
+        _I -> 1
+    end.

--- a/test/pretty_tests.erl
+++ b/test/pretty_tests.erl
@@ -237,21 +237,10 @@ recursive_test() ->
   C = ty_rec:negate(B),
   BB = ty_rec:negate(C),
   true = ty_rec:is_equivalent(B, BB),
-  % io:format(user,"~p~n", [C]),
-  io:format(user,"B: ~s~n", [ty_rec:print(B)]),
-  io:format(user,"B: ~p~n", [ast_lib:erlang_ty_to_ast(B)]),
-  io:format(user,"!B: ~s~n", [ty_rec:print(C)]),
-  io:format(user,"!B: ~p~n", [ast_lib:erlang_ty_to_ast(C)]),
-  io:format(user,"!!B: ~s~n", [ty_rec:print(BB)]),
-  io:format(user,"!!B: ~p~n", [ast_lib:erlang_ty_to_ast(BB)]),
-  % Pretty = ast_lib:erlang_ty_to_ast(B),
-
-
-   
-   
+  Pretty = ast_lib:erlang_ty_to_ast(B),
   
   % % TODO how to test this with string output?
-  % {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
+  {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
   % %?assertEqual("mu X . nil | {alpha, mu X}", pretty:render_ty(Pretty)),
 
   ok.
@@ -269,9 +258,8 @@ recursive2_test() ->
   A = {mu, X, L},
 
   B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
-  io:format(user,"~p...~n", [B]),
   Pretty = ast_lib:erlang_ty_to_ast(B),
-  % true = subty:is_equivalent(none, A, Pretty),
+  true = subty:is_equivalent(none, A, Pretty),
   
   % % TODO how to test this with string output?
   % {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
@@ -416,17 +404,17 @@ tuple_wrapped_test() ->
   
 
 % TODO
-% tuple1_union_test() ->
-%   ecache:reset_all(),
-%   A = tunion([
-%     ttuple([tatom(a)]),
-%     ttuple([tatom(e)])
-%   ]),
-%   B = ast_lib:ast_to_erlang_ty(A),
-%   Pretty = ast_lib:erlang_ty_to_ast(B),
-%   true = subty:is_equivalent(none, A, Pretty),
-%   ?assertEqual("{a | e}", pretty:render_ty(Pretty)),
-%   ok.
+tuple1_union_test() ->
+  ecache:reset_all(),
+  A = tunion([
+    ttuple([tatom(a)]),
+    ttuple([tatom(e)])
+  ]),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("{a | e}", pretty:render_ty(Pretty)),
+  ok.
 
 % tuple2_union_test() ->
 %   ecache:reset_all(),

--- a/test/pretty_tests.erl
+++ b/test/pretty_tests.erl
@@ -1,7 +1,7 @@
 -module(pretty_tests).
 -include_lib("eunit/include/eunit.hrl").
 
--import(stdtypes, [tvar/1, ttuple_any/0, tnegate/1, tatom/0, tatom/1, tfun_full/2, trange/2, tunion/1, tintersect/1, trange_any/0, ttuple/1, tany/0, tnone/0]).
+-import(stdtypes, [tvar/1, ttuple_any/0, tnegate/1, tatom/0, tatom/1, tfun_full/2, trange/2, tdiff/2, tunion/1, tintersect/1, trange_any/0, ttuple/1, tany/0, tnone/0]).
 -import(test_utils, [is_subtype/2, is_equiv/2]).
 
 % TODO simplifications
@@ -129,7 +129,7 @@ ex1_test() ->
   B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
   Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
   true = subty:is_equivalent(none, A, Pretty),
-  ?assertEqual("$0 /\\ {b, tag} /\\ not({a, tag})", pretty:render_ty(Pretty)),
+  ?assertEqual("$0 /\\ {b, tag}", pretty:render_ty(Pretty)),
 
   ok.
 
@@ -228,18 +228,54 @@ recursive_test() ->
   ecache:reset_all(),
   X = tvar(x),
   L = tunion([
-    tatom(nil),
-    ttuple([tvar(alpha), X])
+    trange_any(),
+    ttuple([X])
   ]),
   A = {mu, X, L},
 
   B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
-  Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
-  true = subty:is_equivalent(none, A, Pretty),
+  C = ty_rec:negate(B),
+  BB = ty_rec:negate(C),
+  true = ty_rec:is_equivalent(B, BB),
+  % io:format(user,"~p~n", [C]),
+  io:format(user,"B: ~s~n", [ty_rec:print(B)]),
+  io:format(user,"B: ~p~n", [ast_lib:erlang_ty_to_ast(B)]),
+  io:format(user,"!B: ~s~n", [ty_rec:print(C)]),
+  io:format(user,"!B: ~p~n", [ast_lib:erlang_ty_to_ast(C)]),
+  io:format(user,"!!B: ~s~n", [ty_rec:print(BB)]),
+  io:format(user,"!!B: ~p~n", [ast_lib:erlang_ty_to_ast(BB)]),
+  % Pretty = ast_lib:erlang_ty_to_ast(B),
+
+
+   
+   
   
-  % TODO how to test this with string output?
-  {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
-  %?assertEqual("mu X . nil | {alpha, mu X}", pretty:render_ty(Pretty)),
+  % % TODO how to test this with string output?
+  % {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
+  % %?assertEqual("mu X . nil | {alpha, mu X}", pretty:render_ty(Pretty)),
+
+  ok.
+
+
+
+
+recursive2_test() ->
+  ecache:reset_all(),
+  X = tvar(x),
+  L = tunion([
+    trange_any(),
+    ttuple([trange_any(), X])
+  ]),
+  A = {mu, X, L},
+
+  B = ast_lib:ast_to_erlang_ty(A, symtab:empty()),
+  io:format(user,"~p...~n", [B]),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  % true = subty:is_equivalent(none, A, Pretty),
+  
+  % % TODO how to test this with string output?
+  % {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
+  % %?assertEqual("mu X . nil | {alpha, mu X}", pretty:render_ty(Pretty)),
 
   ok.
 
@@ -255,3 +291,216 @@ tuple2_intersect_test() ->
   ?assertEqual("{a, c}", pretty:render_ty(Pretty)),
 
   ok.
+
+tuple2_diff_test() ->
+  ecache:reset_all(),
+  A = tdiff(
+    ttuple([(tatom()), (tatom(c))]),
+    ttuple([(tatom(a)), tatom(c)])
+  ),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("{atom() /\\ not(a), c}", pretty:render_ty(Pretty)),
+
+  ok.
+
+tuple3_convert_test() ->
+  ecache:reset_all(),
+  A = ttuple([tatom(a), tatom(b), tatom(c)]),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("{a, b, c}", pretty:render_ty(Pretty)),
+  ok.
+
+tuple3_convert_neg_test() ->
+  ecache:reset_all(),
+  A = tnegate(ttuple([tatom(a), tatom(b), tatom(c)])),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("not({a, b, c})", pretty:render_ty(Pretty)),
+  ok.
+
+tuple3_diff_1_test() ->
+  ecache:reset_all(),
+  A = tdiff(ttuple([tatom(a), tatom(b), tatom(c)]), ttuple([tatom(), tatom(), tatom(c)])),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("none()", pretty:render_ty(Pretty)),
+  ok.
+
+tuple3_diff_2_test() ->
+  ecache:reset_all(),
+  A = tdiff(ttuple([tatom(), trange(20, 50), tatom()]), ttuple([tatom(a), trange(25, 50), tatom(c)])),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("none()", pretty:render_ty(Pretty)),
+  ok.
+
+tuple3_intersect_test() ->
+  ecache:reset_all(),
+  A = tintersect([
+    ttuple([tatom(a), tatom(c), tatom(d)]),
+    ttuple([tatom(), tatom(c), tatom()])
+  ]),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+
+  ?assertEqual("{a, c, d}", pretty:render_ty(Pretty)),
+
+  ok.
+
+tuple1_1_test() ->
+  ecache:reset_all(),
+  A = ttuple([tatom(a)]) ,
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("{a}", pretty:render_ty(Pretty)),
+
+  ok.
+
+tuple1_1_neg_test() ->
+  ecache:reset_all(),
+  A = tnegate(ttuple([tatom(a)])),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("not({a})", pretty:render_ty(Pretty)),
+
+  ok.
+
+tuple1_intersect_test() ->
+  ecache:reset_all(),
+  A = tintersect([
+    ttuple([tatom(a)]),
+    ttuple([tatom(e)])
+  ]),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("none()", pretty:render_ty(Pretty)),
+
+  ok.
+
+tuple1_intersect2_test() ->
+  ecache:reset_all(),
+  A = tintersect([
+    ttuple([tunion([tatom(a), tatom(b)])]),
+    ttuple([tatom(b)]),
+    ttuple([tany()]),
+    ttuple([tatom()])
+  ]),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("{b}", pretty:render_ty(Pretty)),
+
+  ok.
+
+tuple_wrapped_test() ->
+  ecache:reset_all(),
+
+  A = ttuple([ ttuple([tany(), tany()]) ]),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("{{any(), any()}}", pretty:render_ty(Pretty)),
+
+  ok.
+  
+
+% TODO
+% tuple1_union_test() ->
+%   ecache:reset_all(),
+%   A = tunion([
+%     ttuple([tatom(a)]),
+%     ttuple([tatom(e)])
+%   ]),
+%   B = ast_lib:ast_to_erlang_ty(A),
+%   Pretty = ast_lib:erlang_ty_to_ast(B),
+%   true = subty:is_equivalent(none, A, Pretty),
+%   ?assertEqual("{a | e}", pretty:render_ty(Pretty)),
+%   ok.
+
+% tuple2_union_test() ->
+%   ecache:reset_all(),
+%   A = tunion([
+%     ttuple([(tatom(a)), tatom(c)]),
+%     ttuple([(tatom()), (tatom(c))])
+%   ]),
+%   B = ast_lib:ast_to_erlang_ty(A),
+%   Pretty = ast_lib:erlang_ty_to_ast(B),
+%   true = subty:is_equivalent(none, A, Pretty),
+%   ?assertEqual("{atom(), c}", pretty:render_ty(Pretty)),
+%   ok.
+% 
+% tuple3_union_test() ->
+%   ecache:reset_all(),
+%   A = tunion([
+%     ttuple([tatom(a), tatom(c), tatom(d)]),
+%     ttuple([tatom(a), tatom(c), tatom(g)])
+%   ]),
+%   B = ast_lib:ast_to_erlang_ty(A),
+%   Pretty = ast_lib:erlang_ty_to_ast(B),
+%   true = subty:is_equivalent(none, A, Pretty),
+%   ?assertEqual("{a, c, d | g}", pretty:render_ty(Pretty)),
+%   ok.
+% tuple3_union2_test() ->
+%   ecache:reset_all(),
+%   A = tunion([
+%     ttuple([tatom(a), tatom(c), tatom(d)]),
+%     ttuple([tatom(a), tatom(g), tatom(d)])
+%   ]),
+%   B = ast_lib:ast_to_erlang_ty(A),
+%   Pretty = ast_lib:erlang_ty_to_ast(B),
+%   true = subty:is_equivalent(none, A, Pretty),
+%   ?assertEqual("{a, c | g, d}", pretty:render_ty(Pretty)),
+
+%   ok.
+
+% tuple3_union3_test() ->
+%   ecache:reset_all(),
+%   A = tunion([
+%     ttuple([tatom(a), tatom(c), tatom(d)]),
+%     ttuple([tatom(g), tatom(c), tatom(d)])
+%   ]),
+%   B = ast_lib:ast_to_erlang_ty(A),
+%   Pretty = ast_lib:erlang_ty_to_ast(B),
+%   true = subty:is_equivalent(none, A, Pretty),
+%   ?assertEqual("{a | g, c, d}", pretty:render_ty(Pretty)),
+
+%   ok.
+
+% tuple32_union_test() ->
+%   ecache:reset_all(),
+%   A = tunion([
+%     ttuple([(tatom(a)), tatom(c), tatom(d)]),
+%     ttuple([(tatom(e)), (tatom(f)), tatom(g)])
+%   ]),
+%   B = ast_lib:ast_to_erlang_ty(A),
+%   Pretty = ast_lib:erlang_ty_to_ast(B),
+%   true = subty:is_equivalent(none, A, Pretty),
+%   ?assertEqual("{a, c, d} | {e, f, g}", pretty:render_ty(Pretty)),
+
+%   ok.
+
+% tuple4_all_test() ->
+%   ecache:reset_all(),
+%   A = tintersect([tunion([
+%     ttuple([(tatom(a)), tatom(c), tatom(d), tatom()]),
+%     ttuple([(tatom(e)), (tatom(f)), tatom(g), tatom()])
+%   ]),
+%     ttuple([tany(), tatom(), tatom(), tatom(ra)])
+%   ]),
+%   B = ast_lib:ast_to_erlang_ty(A),
+%   Pretty = ast_lib:erlang_ty_to_ast(B),
+%   true = subty:is_equivalent(none, A, Pretty),
+%   ?assertEqual("{a, c, d, ra} | {e, f, g, ra}", pretty:render_ty(Pretty)),
+
+%   ok.

--- a/test/pretty_tests.erl
+++ b/test/pretty_tests.erl
@@ -206,7 +206,7 @@ other_test() ->
   Pretty = ast_lib:erlang_ty_to_ast(B, #{}),
 
   true = subty:is_equivalent(none, V0, Pretty),
-  ?assertEqual("{a5 /\\ b, int} | {a, int}", pretty:render_ty(Pretty)),
+  ?assertEqual("{a, int} | {a5 /\\ b, int}", pretty:render_ty(Pretty)),
 
   ok.
 
@@ -240,5 +240,18 @@ recursive_test() ->
   % TODO how to test this with string output?
   {mu, Mu, {union, [{singleton, nil}, {tuple, [{var, alpha}, Mu]}]}} = Pretty,
   %?assertEqual("mu X . nil | {alpha, mu X}", pretty:render_ty(Pretty)),
+
+  ok.
+
+tuple2_intersect_test() ->
+  ecache:reset_all(),
+  A = tintersect([
+    ttuple([(tatom(a)), tatom(c)]),
+    ttuple([(tatom()), (tatom(c))])
+  ]),
+  B = ast_lib:ast_to_erlang_ty(A),
+  Pretty = ast_lib:erlang_ty_to_ast(B),
+  true = subty:is_equivalent(none, A, Pretty),
+  ?assertEqual("{a, c}", pretty:render_ty(Pretty)),
 
   ok.

--- a/test/pretty_tests.erl
+++ b/test/pretty_tests.erl
@@ -334,11 +334,11 @@ tuple3_diff_1_test() ->
 
 tuple3_diff_2_test() ->
   ecache:reset_all(),
-  A = tdiff(ttuple([tatom(), trange(20, 50), tatom()]), ttuple([tatom(a), trange(25, 50), tatom(c)])),
+  A = tdiff(ttuple([tatom(), trange(20, 50), tatom()]), ttuple([tatom(a), trange(25, 50), tatom()])),
   B = ast_lib:ast_to_erlang_ty(A),
   Pretty = ast_lib:erlang_ty_to_ast(B),
   true = subty:is_equivalent(none, A, Pretty),
-  ?assertEqual("none()", pretty:render_ty(Pretty)),
+  ?assertEqual("{atom() /\\ not(a), 20..50, atom()} | {atom(), 20..24, atom()}", pretty:render_ty(Pretty)),
   ok.
 
 tuple3_intersect_test() ->

--- a/test/subty_tests.erl
+++ b/test/subty_tests.erl
@@ -719,8 +719,6 @@ simplification_tuple_test() ->
     Sis = Si(Size),
     Tis = Ti(Size),
 
-    All = lists:zip3(lists:seq(1, length(Sis)), Sis, Tis),
-
     TuplesLeftSide = tdiff(
       ttuple(Sis), 
       ttuple(Tis) 
@@ -731,7 +729,7 @@ simplification_tuple_test() ->
           I -> tdiff(lists:nth(Index, Sis), lists:nth(Index, Tis)); 
           _ -> lists:nth(Index, Sis) 
         end || Index <- lists:seq(1, Size)])
-      || {I, Si, Ti} <- All]),
+      || I <- lists:seq(1, length(Sis))]),
 
     true = is_equiv(TuplesLeftSide, TuplesRightSide)
 

--- a/test/tally_tests.erl
+++ b/test/tally_tests.erl
@@ -458,7 +458,12 @@ sol_number_test() ->
 
   % variable order determines if a variable is used as a lower or upper bound for another variable
   test_tally( [ C2 ], solutions(1)),
-  test_tally( [ C1 ], solutions(2)).
+  % Before tuple simplification, tally(C1) would produce 2 solutions
+  % since ('a2, 42) \ ('a1, 42) == (`a2 \ `a1, 42)
+  % we get only one solution, same as
+  % since ('a1, 42) \ ('a2, 42) == (`a1 \ `a2, 42)
+  test_tally( [ C1 ], solutions(1)).
+
 
 pretty_printing_bug_test() ->
   V0 = tvar(v1),
@@ -667,7 +672,7 @@ maps_norm_opt_13_test() ->
     ])
   ),
 
-  test_tally([{L, R}], solutions(16)).
+  test_tally([{L, R}], solutions(8)).
 
 maps_norm_opt_14_test() ->
   % #{β_0 => β_1} ≤ {a => b}, a ≤ β_0, b ≤ β_1
@@ -692,7 +697,10 @@ maps_norm_opt_15_test() ->
     tmap_field_opt(tatom(a), tatom(b)),
     tmap_field_opt(tint(20), tint(21))
   ]),
-  test_tally([{L, R}], [ {#{beta_1 => tnone(), beta_3 => tnone()}, #{beta_1 => tatom(b), beta_3 => tint(21)}} ]).
+  test_tally([{L, R}], 
+    solutions(2) % TODO tuple simplification produces more solutions
+    %[ {#{beta_1 => tnone(), beta_3 => tnone()}, #{beta_1 => tatom(b), beta_3 => tint(21)}} ]
+  ).
 
 maps_norm_req_1_test() ->
   % #{β_0 := β_1} ≤ {atom() => int()}


### PR DESCRIPTION
Supersedes #84 by fixing all left-over issues.

* Instead of encoding all n-tuples into products (2-tuples), we keep tuples as is
* Tuples are not stored in normal form, we keep the BDD structure
* Instead, simplification happens every time the DNF is requested
  * There is the problem of doing the simplification of a DNF of recursive type; there, we need to check emptiness and request a DNF again, leading to a loop
  * Instead of providing a single DNF form, the API provides a "raw" emptiness check and a "optimized" emptiness check. 
    *  [ ] Think about a better nomenclature for this  
  * The raw emptiness check needs to be used during the simplification part to avoid looping
  * Therefore, recursive types pose no problem
    * There could be a possible small optimization where we could use the optimized emptiness check everywhere for non-recursive types

Notes:

* Some test could fail because the expected output changes
  *  Some tally tests have less solutions
    * [ ] document these and compare against CDuce
  * Recursive types behave a bit different with these simplifications, as we currently do not share same recursive types
    * [ ] document those cases, will be fixed in a different PR
* Measuring performance impact should be done on test cases which don't employ recursive types and a lot of tuples


## Simplifications on tuples

### 1) Intersect positive tuples

Tuples are co-variant in their element types.

![image](https://github.com/user-attachments/assets/5315c64d-7911-4f52-90fd-05802be82ee4)

### 2) Move negations inwards

For a difference of two n-tuples, this creates at most n unions of n-tuples.

* [ ] Check if the partitioning produces the same result as the partitioning formula in #84 
  * `(t,s) - ((t1,s1) | (t2,s2) | ... | (tn,sn)) = (t & t1, s - s1) | ... | (t & tn, s - sn) | (t - (t1|...|tn), s)` 

![image](https://github.com/user-attachments/assets/aa2f6871-14bc-4038-8689-752a295d3fc6)

### 3) Merge common components of positive tuples

* [ ] TODO: generalize for n-tuples

![image](https://github.com/user-attachments/assets/a065c7a0-aff5-4f84-bcb0-20b1bf3d33b7)

### 4) Normal form for n-tuples

CDuce does one extra step and defines a normal form for products. The normal form transforms products to be disjoint on the first component of all unions of the product.

* [ ] TODO: implement this for tuples (i.e. disjoint on the n-th component) and measure performance impact
  * Idea: implement a function which returns a normal form which is disjoint on the n-th component of the tuples and apply a heuristic which component index to pick, maybe even apply multiple rounds depending on heuristic
* [ ] TODO: is there any generalized normal form which makes sense for n-tuples?
  * In CDuce, multi-arity products are equivalent to/parsed as products with the appropriate associativity (e.g. `(A,B,C) = (A, (B, C))`

## Performance Impact

* [ ] TODO: Measure impact on issues mentioned #84.
