### PR TITLE
Removed invalid dialyzer option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,6 @@
 %To check for deadcode, it is useful to add 'exports_not_used'
 
 {dialyzer, [
-  {src_dirs, ["src", "test"]},  % Include the test directory for checking
   {warnings, []},
   {plt_extra_apps, [eunit, syntax_tools, compiler]}
 ]}.


### PR DESCRIPTION
`src_dirs` is not part of the `dialyzer` configuration and has no effect. See [Dialyzer configuration](https://rebar3.org/docs/configuration/configuration/#dialyzer).