### PR TITLE
Erlang ast() to internal representation parser

### DIFF
--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -2,7 +2,7 @@
 
 -export([
     reset/0, 
-    ast_to_erlang_ty/1, ast_to_erlang_ty/2, 
+    ast_to_erlang_ty/2, 
     erlang_ty_to_ast/1, erlang_ty_to_ast/2, 
     ast_to_erlang_ty_var/1, 
     mk_union/1, 
@@ -20,6 +20,7 @@
 
 reset() ->
     erlang:put(ty_ast_cache, #{}),
+    erlang:put(ast_ty_cache, #{}),
     ok.
 
 unfold_intersection([], All) -> All;
@@ -110,7 +111,6 @@ mk_union(Tys) ->
 mk_negation({predef, any}) -> {predef, none};
 mk_negation({predef, none}) -> {predef, any};
 mk_negation(T) -> {negation, T}.
-
 
 % if the name is the ID, transfer back the same way
 erlang_ty_var_to_var({var, name, Name}) -> {var, Name};
@@ -205,56 +205,64 @@ erlang_ty_to_ast(X, M) ->
         FinalTy
     end.
 
-ast_to_erlang_ty(Ty) ->
-    ast_to_erlang_ty(Ty, symtab:empty(), #{}).
+ast_to_erlang_ty(Ty, Symtab) ->
+  Cache = erlang:get(ast_ty_cache),
+  Cached = maps:get(Ty, Cache, undefined),
+  maybe_parse(Cached, Ty, Cache, Symtab).
 
-ast_to_erlang_ty(Ty, Sym) ->
-    ast_to_erlang_ty(Ty, Sym, #{}).
+maybe_parse(undefined, X, Cache, Symtab) ->
+    V = parse_ast_to_erlang_ty(X, Symtab),
+    CacheNew = maps:put(X, V, Cache),
+    put(ast_ty_cache, CacheNew),
+    V;
+maybe_parse(V, _, _, _) ->
+    V.
 
-ast_to_erlang_ty({singleton, Atom}, _Sym, _) when is_atom(Atom) ->
+
+parse_ast_to_erlang_ty({singleton, Atom}, _Sym) when is_atom(Atom) ->
     TyAtom = ty_atom:finite([Atom]),
     TAtom = dnf_var_ty_atom:ty_atom(TyAtom),
     ty_rec:atom(TAtom);
-ast_to_erlang_ty({singleton, IntOrChar}, _Sym, _) ->
+parse_ast_to_erlang_ty({singleton, IntOrChar}, _Sym) ->
     Int = dnf_var_ty_interval:int(dnf_ty_interval:interval(IntOrChar, IntOrChar)),
     ty_rec:interval(Int);
 % TODO
-ast_to_erlang_ty({binary, _, _}, _Sym, _) ->
+parse_ast_to_erlang_ty({binary, _, _}, _Sym) ->
     erlang:error("Bitstrings not implemented yet");
 
-ast_to_erlang_ty({tuple_any}, _Sym, _) ->
+parse_ast_to_erlang_ty({tuple_any}, _Sym) ->
     ty_rec:tuple();
-ast_to_erlang_ty({tuple, Comps}, Sym, M) when is_list(Comps)->
-    ETy = lists:map(fun(T) -> ast_to_erlang_ty(T, Sym, M) end, Comps),
+parse_ast_to_erlang_ty({tuple, Comps}, Sym) when is_list(Comps)->
+    ETy = lists:map(fun(T) -> parse_ast_to_erlang_ty(T, Sym) end, Comps),
 
     T = dnf_var_ty_tuple:tuple(dnf_ty_tuple:tuple(ty_tuple:tuple(ETy))),
     ty_rec:tuple(length(Comps), T);
 
 % funs
-ast_to_erlang_ty({fun_simple}, _Sym, _) ->
+parse_ast_to_erlang_ty({fun_simple}, _Sym) ->
     ty_rec:function();
-ast_to_erlang_ty({fun_full, Comps, Result}, Sym, M) ->
-    ETy = lists:map(fun(T) -> ast_to_erlang_ty(T, Sym, M) end, Comps),
-    TyB = ast_to_erlang_ty(Result, Sym, M),
+parse_ast_to_erlang_ty({fun_full, Comps, Result}, Sym) ->
+    ETy = lists:map(fun(T) -> parse_ast_to_erlang_ty(T, Sym) end, Comps),
+    TyB = parse_ast_to_erlang_ty(Result, Sym),
 
     T = dnf_var_ty_function:function(dnf_ty_function:function(ty_function:function(ETy, TyB))),
     ty_rec:function(length(Comps), T);
 
 % maps
-ast_to_erlang_ty({map_any}, _Sym, _M) ->
+parse_ast_to_erlang_ty({map_any}, _Sym) ->
     ty_rec:map();
-ast_to_erlang_ty({map, AssocList}, Sym, _M) ->
+parse_ast_to_erlang_ty({map, AssocList}, Sym) ->
     {_, TupPartTy, FunPartTy} = lists:foldl(
         fun({Association, Key, Val}, {PrecedenceDomain, Tuples, Functions}) ->
             case Association of
                 map_field_opt ->
                     % tuples only
-                    Tup = ast_to_erlang_ty({tuple, [mk_diff(Key, PrecedenceDomain), Val]}, Sym),
+                    Tup = parse_ast_to_erlang_ty({tuple, [mk_diff(Key, PrecedenceDomain), Val]}, Sym),
                     {mk_union(PrecedenceDomain, Key), ty_rec:union(Tuples, Tup), Functions};
                 map_field_req ->
                     % tuples & functions
-                    Tup = ast_to_erlang_ty({tuple, [mk_diff(Key, PrecedenceDomain), Val]}, Sym),
-                    Fun = ast_to_erlang_ty({fun_full, [mk_diff(Key, PrecedenceDomain)], Val}, Sym),
+                    Tup = parse_ast_to_erlang_ty({tuple, [mk_diff(Key, PrecedenceDomain), Val]}, Sym),
+                    Fun = parse_ast_to_erlang_ty({fun_full, [mk_diff(Key, PrecedenceDomain)], Val}, Sym),
                     {mk_union(PrecedenceDomain, Key), ty_rec:union(Tuples, Tup), ty_rec:intersect(Functions, Fun)}
             end
         end, {stdtypes:tnone(), ty_rec:empty(), ty_rec:function()}, AssocList),
@@ -266,95 +274,84 @@ ast_to_erlang_ty({map, AssocList}, Sym, _M) ->
 % TODO records
 
 % var
-ast_to_erlang_ty(V = {var, A}, _Sym, M) ->
-    % FIXME overloading of mu variables and normal variables
-    case M of
-        #{V := Ref} -> Ref;
-        _ -> 
-            % if this is a special $mu_integer()_name() variable, convert to that representation
-            case string:prefix(atom_to_list(A), "$mu_") of 
-                nomatch -> 
-                    ty_rec:variable(ty_variable:new_with_name(A));
-                IdName -> 
-                    % assumption: erlang types generates variables only in this pattern: $mu_integer()_name()
-                    [Id, Name] = string:split(IdName, "_"),
-                    ty_rec:variable(ty_variable:new_with_name_and_id(list_to_integer(Id), list_to_atom(Name)))
-            end
+parse_ast_to_erlang_ty(V = {var, A}, _Sym) ->
+    % if this is a special $mu_integer()_name() variable, convert to that representation
+    case string:prefix(atom_to_list(A), "$mu_") of 
+        nomatch -> 
+            ty_rec:variable(ty_variable:new_with_name(A));
+        IdName -> 
+            % assumption: erlang types generates variables only in this pattern: $mu_integer()_name()
+            [Id, Name] = string:split(IdName, "_"),
+            ty_rec:variable(ty_variable:new_with_name_and_id(list_to_integer(Id), list_to_atom(Name)))
     end;
 
 % ty_some_list
-ast_to_erlang_ty({list, Ty}, Sym, M) -> ty_rec:union( ast_to_erlang_ty({improper_list, Ty, {empty_list}}, Sym, M), ast_to_erlang_ty({empty_list}, Sym, M) );
-ast_to_erlang_ty({nonempty_list, Ty}, Sym, M) -> ast_to_erlang_ty({nonempty_improper_list, Ty, {empty_list}}, Sym, M);
-ast_to_erlang_ty({nonempty_improper_list, Ty, Term}, Sym, M) -> ty_rec:diff(ast_to_erlang_ty({list, Ty}, Sym, M), ast_to_erlang_ty(Term, Sym, M));
-ast_to_erlang_ty({improper_list, A, B}, Sym, M) ->
-    ty_rec:list(dnf_var_ty_list:list(dnf_ty_list:list(ty_list:list(ast_to_erlang_ty(A, Sym, M), ast_to_erlang_ty(B, Sym, M)))));
-ast_to_erlang_ty({empty_list}, _Sym, _) ->
+parse_ast_to_erlang_ty({list, Ty}, Sym) -> ty_rec:union( parse_ast_to_erlang_ty({improper_list, Ty, {empty_list}}, Sym), parse_ast_to_erlang_ty({empty_list}, Sym) );
+parse_ast_to_erlang_ty({nonempty_list, Ty}, Sym) -> parse_ast_to_erlang_ty({nonempty_improper_list, Ty, {empty_list}}, Sym);
+parse_ast_to_erlang_ty({nonempty_improper_list, Ty, Term}, Sym) -> ty_rec:diff(parse_ast_to_erlang_ty({list, Ty}, Sym), parse_ast_to_erlang_ty(Term, Sym));
+parse_ast_to_erlang_ty({improper_list, A, B}, Sym) ->
+    ty_rec:list(dnf_var_ty_list:list(dnf_ty_list:list(ty_list:list(parse_ast_to_erlang_ty(A, Sym), parse_ast_to_erlang_ty(B, Sym)))));
+parse_ast_to_erlang_ty({empty_list}, _Sym) ->
     ty_rec:predef(dnf_var_ty_predef:predef(dnf_ty_predef:predef('[]')));
-ast_to_erlang_ty({predef, T}, _Sym, _) when T == pid; T == port; T == reference; T == float ->
+parse_ast_to_erlang_ty({predef, T}, _Sym) when T == pid; T == port; T == reference; T == float ->
     ty_rec:predef(dnf_var_ty_predef:predef(dnf_ty_predef:predef(T)));
 
 % named
-ast_to_erlang_ty({named, Loc, Ref, Args}, Sym, M) ->
-    case M of
-        #{{Ref, Args} := NewRef} ->
-            NewRef;
-        _ ->
-            ({ty_scheme, Vars, Ty}) = symtab:lookup_ty(Ref, Loc, Sym),
-
-            % apply args to ty scheme
-            Map = subst:from_list(lists:zip([V || {V, _Bound} <- Vars], Args)),
-            NewTy = subst:apply(Map, Ty, no_clean),
-
-            NewRef = ty_ref:new_ty_ref(),
-            Res = ast_to_erlang_ty(NewTy, Sym, M#{{Ref, Args} => NewRef}),
-            NewRes = ty_ref:define_ty_ref(NewRef, ty_ref:load(Res)),
-
-            NewRes
-    end;
+parse_ast_to_erlang_ty(Ty = {named, Loc, Ref, Args}, Sym) ->
+    % todo check if really recursive 
+    ast_to_erlang_ty:ast_to_erlang_ty(Ty, Sym);
 
 % ty_predef_alias
-ast_to_erlang_ty({predef_alias, Alias}, Sym, M) ->
-    ast_to_erlang_ty(stdtypes:expand_predef_alias(Alias), Sym, M);
+parse_ast_to_erlang_ty({predef_alias, Alias}, Sym) ->
+    parse_ast_to_erlang_ty(stdtypes:expand_predef_alias(Alias), Sym);
 
 % ty_predef
-ast_to_erlang_ty({predef, atom}, _, _) ->
+parse_ast_to_erlang_ty({predef, atom}, _) ->
     Atom = dnf_var_ty_atom:any(),
     ty_rec:atom(Atom);
 
-ast_to_erlang_ty({predef, any}, _, _) -> ty_rec:any();
-ast_to_erlang_ty({predef, none}, _, _) -> ty_rec:empty();
-ast_to_erlang_ty({predef, integer}, _, _) ->
+parse_ast_to_erlang_ty({predef, any}, _) -> ty_rec:any();
+parse_ast_to_erlang_ty({predef, none}, _) -> ty_rec:empty();
+parse_ast_to_erlang_ty({predef, integer}, _) ->
     ty_rec:interval();
 
 % ints
-ast_to_erlang_ty({range, From, To}, _, _) ->
+parse_ast_to_erlang_ty({range, From, To}, _) ->
     Int = dnf_var_ty_interval:int(dnf_ty_interval:interval(From, To)),
     ty_rec:interval(Int);
 
-ast_to_erlang_ty({union, []}, _, _) -> ty_rec:empty();
-ast_to_erlang_ty({union, [A]}, Sym, M) -> ast_to_erlang_ty(A, Sym, M);
-ast_to_erlang_ty({union, [A|T]}, Sym, M) -> ty_rec:union(ast_to_erlang_ty(A, Sym, M), ast_to_erlang_ty({union, T}, Sym, M));
+parse_ast_to_erlang_ty({union, []}, _) -> ty_rec:empty();
+parse_ast_to_erlang_ty({union, [A]}, Sym) -> parse_ast_to_erlang_ty(A, Sym);
+parse_ast_to_erlang_ty({union, [A|T]}, Sym) -> ty_rec:union(parse_ast_to_erlang_ty(A, Sym), parse_ast_to_erlang_ty({union, T}, Sym));
 
-ast_to_erlang_ty({intersection, []}, _, _) -> ty_rec:any();
-ast_to_erlang_ty({intersection, [A]}, Sym, M) -> ast_to_erlang_ty(A, Sym, M);
-ast_to_erlang_ty({intersection, [A|T]}, Sym, M) -> ty_rec:intersect(ast_to_erlang_ty(A, Sym, M), ast_to_erlang_ty({intersection, T}, Sym, M));
+parse_ast_to_erlang_ty({intersection, []}, _) -> ty_rec:any();
+parse_ast_to_erlang_ty({intersection, [A]}, Sym) -> parse_ast_to_erlang_ty(A, Sym);
+parse_ast_to_erlang_ty({intersection, [A|T]}, Sym) -> ty_rec:intersect(parse_ast_to_erlang_ty(A, Sym), parse_ast_to_erlang_ty({intersection, T}, Sym));
 
-ast_to_erlang_ty({negation, Ty}, Sym, M) -> ty_rec:negate(ast_to_erlang_ty(Ty, Sym, M));
+parse_ast_to_erlang_ty({negation, Ty}, Sym) -> ty_rec:negate(parse_ast_to_erlang_ty(Ty, Sym));
 
-ast_to_erlang_ty({mu, RecVar, Ty}, Sym, M) ->
-    NewRef = ty_ref:new_ty_ref(),
-    Mp = M#{RecVar => NewRef},
-    InternalTy = ast_to_erlang_ty(Ty, Sym, Mp),
-    _NewRes = ty_ref:define_ty_ref(NewRef, ty_ref:load(InternalTy));
+parse_ast_to_erlang_ty(Ty = {mu, Var, InnerTy}, Sym) ->
+    % TODO test case if this is capture-avoiding
+    % what happens with mu X . mu X . X, 
+    % assumme type is well-formed and this case should not happen?
+    Vars = ast_utils:referenced_variables(InnerTy),
+    case lists:member(Var, Vars) of
+        true ->
+            % assumption: Var is inside InnerTy
+            ast_to_erlang_ty:ast_to_erlang_ty(Ty, Sym);
+        false ->
+            % TODO assume this is simplified before and well-formed ast includes mu -> recursive?
+            % otherwise: simplify, not a recursive type
+            parse_ast_to_erlang_ty(InnerTy, Sym)
+    end;
 
-ast_to_erlang_ty(T, _Sym, _M) ->
+parse_ast_to_erlang_ty(T, _Sym) ->
     erlang:error({"Norm not implemented or malformed type", T}).
 
+    
 -spec ast_to_erlang_ty_var(ast:ty_var()) -> ty_variable:var().
 ast_to_erlang_ty_var({var, Name}) when is_atom(Name) ->
     ty_variable:new_with_name(Name).
-
-
 
 % === useful for debugging
 raw_erlang_ty_to_ast(X) ->
@@ -415,7 +412,7 @@ raw_erlang_ty_to_ast(X, M) ->
 
         % SANITY CHECK
         % TODO is it always the case that once we are in the semantic world, when we go back we dont need the symtab?
-        Sanity = ast_lib:ast_to_erlang_ty(FinalTy, symtab:empty()),
+        Sanity = ast_lib:parse_ast_to_erlang_ty(FinalTy, symtab:empty()),
           % leave this sanity check for a while
           case ty_rec:is_equivalent(X, Sanity) of
             true -> ok;

--- a/src/erlang_types/ast_to_erlang_ty.erl
+++ b/src/erlang_types/ast_to_erlang_ty.erl
@@ -1,0 +1,235 @@
+-module(ast_to_erlang_ty).
+
+-ifdef(TEST).
+-import(stdtypes, [tyscm/2, tmu/2, tvar/1, ttuple_any/0, tnegate/1, tatom/0, tatom/1, tfun_full/2, trange/2, tint/1, tunion/1, tintersect/1, trange_any/0, tint/0, ttuple/1, tany/0, tnone/0, tmap/1, tmap_any/0, tmap_field_req/2, tmap_field_opt/2]).
+-import(test_utils, [extend_symtabs/2, extend_symtab/2, extend_symtab/3, is_subtype/2, is_equiv/2, named/1, named/2]).
+-endif.
+
+
+-type temporary_ref() :: 
+    {local_ref, integer()} % fresh type references created for the queue
+  | {mu_ref, atom()} 
+  | {named_ref, {Ref :: term(), Args :: term()}}.
+
+-spec new_local_ref() -> temporary_ref().
+new_local_ref() -> {local_ref, erlang:unique_integer()}.
+
+-spec var_ref(ast:ty_var()) -> temporary_ref().
+var_ref(Var) -> {mu_ref, Var}.
+
+-spec named_ref(ast:ty_ref(), [ast:ty()]) -> temporary_ref().
+named_ref(Def, Args) -> {named_ref, {Def, Args}}.
+
+-spec ast_to_erlang_ty(ast:ty(), symtab:t()) -> ty_rec:ty_ref().
+ast_to_erlang_ty(Ty, Sym) ->
+  % 1. Convert to temporary local representation
+  % Create a temporary type without internalizing the type refs
+  % Instead use local type references stored in a local map
+  LocalRef = new_local_ref(),
+  Result = convert(queue:from_list([{LocalRef, Ty, _Memoization = #{}}]), Sym, {#{}, #{}}),
+  io:format(user, "Result:~n~p~n", [{LocalRef, Result}]),
+
+  error(todo).
+
+
+-type queue() :: queue:queue({temporary_ref(), ast:ty(), memo()}).
+-type memo() :: #{}.
+-type ty_rec() :: ty_rec:ty_rec().
+% local database of type references; 
+% ty_recs can share multiple references, these will be unified
+-type result() :: {#{temporary_ref() => ty_rec()}, #{ty_rec() => [temporary_ref()]}}. 
+
+-spec group(#{A => list(X)}, A, X) -> #{A := list(X)}.
+group(M, Key, Value) ->
+  case M of
+    #{Key := Group} -> M#{Key => lists:usort(Group ++ [Value])};
+    _ -> M#{Key => [Value]}
+  end.
+
+-spec convert(queue(), symtab:t(), result()) -> result().
+convert(Queue, Sym, Res) ->
+  case queue:is_empty(Queue) of
+    true -> 
+      Res; 
+    _ -> % convert next layer
+      {{value, {LocalRef, Ty, Memo}}, Q} = queue:out(Queue),
+      {ErlangRecOrLocalRef, NewQ, {R1, R2}} = do_convert({Ty, Res}, Q, Sym, Memo),
+      convert(NewQ, Sym, {R1#{LocalRef => ErlangRecOrLocalRef}, group(R2, ErlangRecOrLocalRef, LocalRef)})
+  end.
+
+-spec do_convert({ast:ty(), result()}, queue(), symtab:t(), memo()) -> {ty_rec(), queue(), result()}.
+do_convert({{singleton, Atom}, R}, Q, _, _) when is_atom(Atom) ->
+  TyAtom = ty_atom:finite([Atom]),
+  TAtom = dnf_var_ty_atom:ty_atom(TyAtom),
+  {ty_rec:s_atom(TAtom), Q, R};
+do_convert({{singleton, IntOrChar}, R}, Q, _, _) ->
+  Int = dnf_var_ty_interval:int(dnf_ty_interval:interval(IntOrChar, IntOrChar)),
+  {ty_rec:s_interval(Int), Q, R};
+
+% TODO
+do_convert({{binary, _, _}, _}, _, _, _) ->
+    erlang:error("Bitstrings not implemented yet");
+
+do_convert({{tuple_any}, R}, Q, _, _) ->
+  {ty_rec:s_tuple(), Q, R};
+do_convert({{tuple, Comps}, R}, Q, Sym, M) when is_list(Comps)->
+  {ETy, Q0} = lists:foldl(
+    fun(Element, {Components, OldQ}) ->
+      % to be converted later, add to queue
+      Id = new_local_ref(),
+      {Components ++ [Id], queue:in({Id, Element, M}, OldQ)}
+    end, {[], Q}, Comps),
+    
+  T = dnf_var_ty_tuple:tuple(dnf_ty_tuple:tuple(ty_tuple:tuple(ETy))),
+  {ty_rec:s_tuple(length(Comps), T), Q0, R};
+
+% funs
+do_convert({{fun_simple}, R}, Q, _, _) ->
+    {ty_rec:s_function(), Q, R};
+do_convert({{fun_full, Comps, Result}, R}, Q, _Sym, M) ->
+    {ETy, Q0} = lists:foldl(
+        fun(Element, {Components, OldQ}) ->
+            % to be converted later, add to queue
+            Id = new_local_ref(),
+            {Components ++ [Id], queue:in({Id, Element, M}, OldQ)}
+        end, {[], Q}, Comps),
+
+    % add fun result to queue
+    Id = new_local_ref(),
+    Q1 = queue:in({Id, Result, M}, Q0),
+    
+    T = dnf_var_ty_function:function(dnf_ty_function:function(ty_function:function(ETy, Id))),
+    {ty_rec:s_function(length(Comps), T), Q1, R};
+ 
+% maps 
+do_convert({{map_any}, R}, Q, _Sym, _M) ->
+    {ty_rec:s_map(), Q, R};
+do_convert({{map, AssocList}, R}, Q, Sym, M) ->
+    {_, TupPart, FunPart} = lists:foldl(
+        fun({Association, Key, Val}, {PrecedenceDomain, Tuples, Functions}) ->
+            case Association of
+                map_field_opt ->
+                    % tuples only
+                    Tup = {tuple, [ast_lib:mk_diff(Key, PrecedenceDomain), Val]},
+                    {ast_lib:mk_union([PrecedenceDomain, Key]), ast_lib:mk_union([Tuples, Tup]), Functions};
+                map_field_req ->
+                    % tuples & functions
+                    Tup = {tuple, [ast_lib:mk_diff(Key, PrecedenceDomain), Val]},
+                    Fun = {fun_full, [ast_lib:mk_diff(Key, PrecedenceDomain)], Val},
+                    {ast_lib:mk_union([PrecedenceDomain, Key]), ast_lib:mk_union([Tuples, Tup]), ast_lib:mk_intersection([Functions, Fun])}
+            end
+        end, {stdtypes:tnone(), stdtypes:tnone(), stdtypes:tfun_any()}, AssocList),
+    MapTuple = stdtypes:ttuple([TupPart, FunPart]),
+    do_convert({MapTuple, R}, Q, Sym, M);
+
+% var
+do_convert({V = {var, A}, R = {IdTy, _}}, Q, _Sym, M) ->
+  % FIXME overloading of mu variables and normal variables
+  case M of
+    #{V := Ref} -> % mu variable
+      % io:format(user,"R: ~p~n", [{Ref, R}]),
+      #{Ref := Ty} = IdTy,
+      % We are allowed to load the memoized ref
+      % because the second occurrence of the mu variable
+      % is below a type constructor, 
+      % i.e. the memoized reference is fully (partially) defined
+      {Ty, Q, R};
+    _ -> 
+      % if this is a special $mu_integer()_name() variable, convert to that representation
+      case string:prefix(atom_to_list(A), "$mu_") of 
+        nomatch -> 
+          {ty_rec:s_variable(ty_variable:new_with_name(A)), Q, R};
+        IdName -> 
+          % assumption: erlang types generates variables only in this pattern: $mu_integer()_name()
+          [Id, Name] = string:split(IdName, "_"),
+          {ty_rec:s_variable(ty_variable:new_with_name_and_id(list_to_integer(Id), list_to_atom(Name))), Q, R}
+      end
+  end;
+
+do_convert({{list, Ty}, R}, Q, Sym, M) ->
+  do_convert({stdtypes:tunion([
+    {improper_list, Ty, {empty_list}}, 
+    {empty_list}
+  ]), R}, Q, Sym, M);
+do_convert({{nonempty_list, Ty}, R}, Q, Sym, M) ->
+  do_convert({{nonempty_improper_list, Ty, {empty_list}}, R}, Q, Sym, M);
+do_convert({{nonempty_improper_list, Ty, Term}, R}, Q, Sym, M) ->
+  do_convert({stdtypes:tintersect([{list, Ty}, stdtypes:tnegate(Term)]), R}, Q, Sym, M);
+do_convert({{improper_list, A, B}, R}, Q, _Sym, M) ->
+    T1 = new_local_ref(),
+    T2 = new_local_ref(),
+    Q0 = queue:in({T1, A, M}, Q),
+    Q1 = queue:in({T2, B, M}, Q0),
+    
+    {ty_rec:s_list(dnf_var_ty_list:list(dnf_ty_list:list(ty_list:list( T1, T2)))), Q1, R};
+do_convert({{empty_list}, R}, Q, _Sym, _) ->
+    {ty_rec:s_predef(dnf_var_ty_predef:predef(dnf_ty_predef:predef('[]'))), Q, R};
+do_convert({{predef, T}, R}, Q, _Sym, _M) when T == pid; T == port; T == reference; T == float ->
+    {ty_rec:s_predef(dnf_var_ty_predef:predef(dnf_ty_predef:predef(T))), Q, R};
+
+% named
+do_convert({{named, Loc, Ref, Args}, R = {IdTy, _}}, Q, Sym, M) ->
+  case M of
+    #{{Ref, Args} := NewRef} ->
+      #{NewRef := Ty} = IdTy,
+      {Ty, Q, R};
+    _ ->
+      ({ty_scheme, Vars, Ty}) = symtab:lookup_ty(Ref, Loc, Sym),
+
+      % apply args to ty scheme
+      Map = subst:from_list(lists:zip([V || {V, _Bound} <- Vars], Args)),
+      NewTy = subst:apply(Map, Ty, no_clean),
+      
+      % create a new reference (ref args pair) and memoize
+      NewRef = named_ref(Ref, Args),
+      Mp = M#{{Ref, Args} => NewRef},
+      {InternalTy, NewQ, {R0, R1}} = do_convert({NewTy, R}, Q, Sym, Mp),
+      
+      {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}}
+  end;
+
+% % ty_predef_alias
+do_convert({{predef_alias, Alias}, R}, Q, Sym, M) ->
+    do_convert({stdtypes:expand_predef_alias(Alias), R}, Q, Sym, M);
+
+% % ty_predef
+do_convert({{predef, atom}, R}, Q, _, _) ->
+    Atom = dnf_var_ty_atom:any(),
+    {ty_rec:s_atom(Atom), Q, R};
+
+do_convert({{predef, any}, R}, Q, _, _) -> {ty_rec:s_any(), Q, R};
+do_convert({{predef, none}, R}, Q, _, _) -> {ty_rec:s_empty(), Q, R};
+do_convert({{predef, integer}, R}, Q, _, _) -> {ty_rec:s_interval(), Q, R};
+ 
+% ints
+do_convert({{range, From, To}, R}, Q, _, _) ->
+    Int = dnf_var_ty_interval:int(dnf_ty_interval:interval(From, To)),
+    {ty_rec:s_interval(Int), Q, R};
+
+do_convert({{union, []}, R}, Q, _, _) -> {ty_rec:s_empty(), Q, R};
+do_convert({{union, [A]}, R}, Q, Sym, M) -> do_convert({A, R}, Q, Sym, M);
+do_convert({{union, [A|T]}, R}, Q, Sym, M) -> 
+  {R1, Q1, RR1} = do_convert({A, R}, Q, Sym, M),
+  {R2, Q2, RR2} = do_convert({{union, T}, RR1}, Q1, Sym, M),
+  {ty_rec:s_union(R1, R2), Q2, RR2};
+
+do_convert({{intersection, []}, R}, Q, _, _) -> {ty_rec:s_any(), Q, R};
+do_convert({{intersection, [A]}, R}, Q, Sym, M) -> do_convert({A, R}, Q, Sym, M);
+do_convert({{intersection, [A|T]}, R}, Q, Sym, M) -> 
+  {R1, Q1, RR0} = do_convert({A, R}, Q, Sym, M),
+  {R2, Q2, RR1} = do_convert({{intersection, T}, RR0}, Q1, Sym, M),
+  {ty_rec:s_intersect(R1, R2), Q2, RR1};
+
+do_convert({{negation, Ty}, R}, Q, Sym, M) -> 
+  {NewR, Q0, RR0} = do_convert({Ty, R}, Q, Sym, M),
+  {ty_rec:s_negate(NewR), Q0, RR0};
+
+do_convert({{mu, RecVar, Ty}, R}, Q, Sym, M) ->
+  NewRef = var_ref(RecVar),
+  Mp = M#{RecVar => NewRef},
+  {InternalTy, NewQ, {R0, R1}} = do_convert({Ty, R}, Q, Sym, Mp),
+  % return record
+  {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}};
+
+do_convert(T, _Q, _Sym, _M) ->
+  erlang:error({"Transformation from ast:ty() to ty_rec:ty() not implemented or malformed type", T}).

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -1,5 +1,7 @@
 -module(ty_rec).
 
+-export_type([ty_rec/0, ty_ref/0]).
+
 % co-recursive functions on types
 -export([is_empty/1, is_empty_start/1, normalize_start/2]).
 -export([is_empty_corec/2, normalize_corec/3]).
@@ -27,7 +29,6 @@
 
 -record(ty, {predef, atom, interval, list, tuple, function, map}).
 
--export_type([ty_rec/0, ty_ref/0]).
 
 -type ty_rec() :: #ty{}.
 -type ty_ref() :: {ty_ref, integer()}.

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -834,7 +834,7 @@ nonempty_function_test() ->
 % mu type is not enough, X is chosen fresh on second encounter
 sound_memoization_test() ->
   test_utils:reset_ets(),
-  EmptyList = ast_lib:ast_to_erlang_ty(stdtypes:tempty_list()),
+  EmptyList = ast_lib:ast_to_erlang_ty(stdtypes:tempty_list(), symtab:empty()),
 
   X = ty_ref:new_ty_ref(),
   BasicTuple = dnf_ty_tuple:tuple(ty_tuple:tuple([EmptyList, EmptyList])),
@@ -862,7 +862,7 @@ variable_translation_test() ->
   Tuple = ty_rec:tuple({default, []}, dnf_var_ty_tuple:any()),
   Var = ty_rec:variable(ty_variable:new(alpha)),
   Type = ty_rec:intersect(Tuple, Var),
-  EqType = ast_lib:ast_to_erlang_ty(ast_lib:erlang_ty_to_ast(Type)),
+  EqType = ast_lib:ast_to_erlang_ty(ast_lib:erlang_ty_to_ast(Type), symtab:empty()),
   true = ty_rec:is_equivalent(Type, EqType),
 
   ok.
@@ -876,7 +876,7 @@ tuple_transformation_default_test() ->
   Tuple01 = ty_rec:union(Tuple0, Tuple1),
   Tuple1Again = ty_rec:intersect(Tuple1, Tuple01),
 
-  EqType = ast_lib:ast_to_erlang_ty(ast_lib:erlang_ty_to_ast(Tuple1Again)),
+  EqType = ast_lib:ast_to_erlang_ty(ast_lib:erlang_ty_to_ast(Tuple1Again), symtab:empty()),
   true = ty_rec:is_equivalent(Tuple1Again, EqType),
 
   ok.

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -8,8 +8,10 @@
 -export([union/2, negate/1, intersect/2, diff/2, is_any/1]).
 -export([tuple_keys/1, function_keys/1]).
 
-% additional type constructors
+% additional type constructors (hash consed)
 -export([predef/0, predef/1, variable/1, atom/1, interval/1, tuple/2, map/1]).
+% additional type constructors (record only)
+-export([s_interval/0, s_intersect/2, s_union/2, s_negate/1, s_any/0, s_empty/0, s_map/0, s_predef/1, s_variable/1, s_atom/1, s_interval/1, s_function/2, s_tuple/2, s_map/1, s_list/1, s_tuple/0, s_function/0]).
 % type constructors with type refs
 -export([list/1, function/2]).
 % top type constructors
@@ -25,6 +27,9 @@
 
 -record(ty, {predef, atom, interval, list, tuple, function, map}).
 
+-export_type([ty_rec/0, ty_ref/0]).
+
+-type ty_rec() :: #ty{}.
 -type ty_ref() :: {ty_ref, integer()}.
 -type interval() :: term().
 %%-type ty_tuple() :: term().
@@ -316,6 +321,16 @@ maybe_remove_redundant_negative_variables(CurrentMap, T1, T, Pv, Nv, Pv1, Nv1) -
 % ======
 % Type constructors
 % ======
+s_empty() ->
+  #ty{
+    predef = dnf_var_ty_predef:empty(),
+    atom = dnf_var_ty_atom:empty(),
+    interval = dnf_var_ty_interval:empty(),
+    list = dnf_var_ty_list:empty(),
+    tuple = ty_tuples:empty(),
+    function = ty_functions:empty(),
+    map = dnf_var_ty_map:empty()
+  }.
 
 -spec empty() -> ty_ref().
 empty() ->
@@ -333,6 +348,19 @@ empty() ->
 any() ->
   ty_ref:any().
 
+s_any() ->
+  ty_ref:load(ty_ref:any()).
+
+s_variable(Var) ->
+  #ty{
+    predef = dnf_var_ty_predef:var(Var),
+    atom = dnf_var_ty_atom:var(Var),
+    interval = dnf_var_ty_interval:var(Var),
+    list = dnf_var_ty_list:var(Var),
+    tuple = ty_tuples:var(Var),
+    function = ty_functions:var(Var),
+    map = dnf_var_ty_map:var(Var)
+  }.
 -spec variable(ty_variable()) -> ty_ref().
 variable(Var) ->
   ty_ref:store(#ty{
@@ -345,10 +373,19 @@ variable(Var) ->
     map = dnf_var_ty_map:var(Var)
   }).
 
+s_list(List) ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ list = List }.
+
+
 list() -> list(dnf_var_ty_list:any()).
 list(List) ->
   Empty = ty_ref:load(empty()),
   ty_ref:store(Empty#ty{ list = List }).
+
+s_atom(Atom) ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ atom = Atom }.
 
 -spec atom(ty_atom()) -> ty_ref().
 atom(Atom) ->
@@ -358,6 +395,12 @@ atom(Atom) ->
 -spec atom() -> ty_ref().
 atom() -> atom(dnf_var_ty_atom:any()).
 
+s_interval(Interval) ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ interval = Interval }.
+
+s_interval() -> s_interval(dnf_var_ty_interval:any()).
+
 -spec interval(interval()) -> ty_ref().
 interval(Interval) ->
   Empty = ty_ref:load(empty()),
@@ -366,10 +409,21 @@ interval(Interval) ->
 -spec interval() -> ty_ref().
 interval() -> interval(dnf_var_ty_interval:any()).
 
+s_predef(Predef) ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ predef = Predef }.
 predef(Predef) ->
   Empty = ty_ref:load(empty()),
   ty_ref:store(Empty#ty{ predef = Predef }).
 predef() -> predef(dnf_var_ty_predef:any()).
+
+s_tuple({default, Sizes}, Tuple) ->
+  NotCaptured = maps:from_list(lists:map(fun(Size) -> {Size, dnf_var_ty_tuple:empty()} end, Sizes)),
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ tuple = {Tuple, NotCaptured}};
+s_tuple(ComponentSize, Tuple) ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ tuple = {dnf_var_ty_tuple:empty(), #{ComponentSize => Tuple}} }.
 
 tuple({default, Sizes}, Tuple) ->
   NotCaptured = maps:from_list(lists:map(fun(Size) -> {Size, dnf_var_ty_tuple:empty()} end, Sizes)),
@@ -379,10 +433,22 @@ tuple(ComponentSize, Tuple) ->
   Empty = ty_ref:load(empty()),
   ty_ref:store(Empty#ty{ tuple = {dnf_var_ty_tuple:empty(), #{ComponentSize => Tuple}} }).
 
+s_tuple() ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ tuple = ty_tuples:any() }.
+
 -spec tuple() -> ty_ref().
 tuple() ->
   Empty = ty_ref:load(empty()),
   ty_ref:store(Empty#ty{ tuple = ty_tuples:any() }).
+
+s_function({default, Sizes}, Function) ->
+  NotCaptured = maps:from_list(lists:map(fun(Size) -> {Size, dnf_var_ty_function:empty()} end, Sizes)),
+  Empty = ty_ref:load(empty()),
+  (Empty#ty{ function = {Function, NotCaptured}});
+s_function(ComponentSize, Fun) ->
+  Empty = ty_ref:load(empty()),
+  (Empty#ty{ function = {dnf_var_ty_function:empty(), #{ComponentSize => Fun} }}).
 
 function({default, Sizes}, Function) ->
   NotCaptured = maps:from_list(lists:map(fun(Size) -> {Size, dnf_var_ty_function:empty()} end, Sizes)),
@@ -392,14 +458,25 @@ function(ComponentSize, Fun) ->
   Empty = ty_ref:load(empty()),
   ty_ref:store(Empty#ty{ function = {dnf_var_ty_function:empty(), #{ComponentSize => Fun} }}).
 
+s_function() ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ function = ty_functions:any() }.
+
 -spec function() -> ty_ref().
 function() ->
   Empty = ty_ref:load(empty()),
   ty_ref:store(Empty#ty{ function = ty_functions:any() }).
 
+s_map(Map) ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ map = Map }.
 map(Map) ->
   Empty = ty_ref:load(empty()),
   ty_ref:store(Empty#ty{ map = Map }).
+
+s_map() ->
+  Empty = ty_ref:load(empty()),
+  Empty#ty{ map = dnf_var_ty_map:any() }.
 
 -spec map() -> ty_ref().
 map() ->
@@ -458,6 +535,33 @@ union(A, B) ->
     fun() ->
   negate(intersect(negate(A), negate(B)))
      end).
+
+s_union(A, B) ->
+  s_negate(s_intersect(s_negate(A), s_negate(B))).
+
+s_negate(#ty{predef = P1, atom = A1, interval = I1, list = L1, tuple = T, function = F, map = M1}) ->
+  #ty{
+    predef = dnf_var_ty_predef:negate(P1),
+    atom = dnf_var_ty_atom:negate(A1),
+    interval = dnf_var_ty_interval:negate(I1),
+    list = dnf_var_ty_list:negate(L1),
+    tuple = ty_tuples:negate(T),
+    function = ty_functions:negate(F),
+    map = dnf_var_ty_map:negate(M1)
+  }.
+
+s_intersect(TyRec1, TyRec2) ->
+  #ty{predef = P1, atom = A1, interval = I1, list = L1, tuple = T1, function = F1, map = M1} = TyRec1,
+  #ty{predef = P2, atom = A2, interval = I2, list = L2, tuple = T2, function = F2, map = M2} = TyRec2,
+  #ty{
+    predef = dnf_var_ty_predef:intersect(P1, P2),
+    atom = dnf_var_ty_atom:intersect(A1, A2),
+    interval = dnf_var_ty_interval:intersect(I1, I2),
+    list = dnf_var_ty_list:intersect(L1, L2),
+    tuple = ty_tuples:intersect(T1, T2),
+    function = ty_functions:intersect(F1, F2),
+    map = dnf_var_ty_map:intersect(M1, M2)
+  }.
 
 
 is_empty(TyRef) -> is_empty_start(TyRef).

--- a/src/erlang_types/ty_ref.erl
+++ b/src/erlang_types/ty_ref.erl
@@ -208,9 +208,9 @@ check_recursive_variable(Variable) ->
 -ifdef(TEST).
 
 % very unstable, should only be used to generate proper test cases while debugging
--type dump() :: {{ty_ref, integer()}, integer(), #{{ty_ref, integer()} => Ty :: term()}}.
+% -type dump() :: {{ty_ref, integer()}, integer(), #{{ty_ref, integer()} => Ty :: term()}}.
 % % dump a type and all its dependencies for creating a test case via importing the state
--spec write_dump_ty({ty_ref, integer()}) -> dump().
+% -spec write_dump_ty({ty_ref, integer()}) -> dump().
 write_dump_ty(Ty) ->
   State = lists:usort(write_dump_ty_h(Ty)),
 
@@ -231,11 +231,11 @@ write_dump_ty(Ty) ->
   VarIds = lists:usort(lists:flatten(utils:everything(
       fun F(InnerT) ->
           case InnerT of
-              (Ref = {ty_ref, Id}) -> 
+              (Ref = {ty_ref, _Id}) -> 
                 TyRec = load(Ref),
                 OtherIds = utils:everything(F, TyRec),
                 {ok, OtherIds};
-              ({var, Id, Name}) when is_integer(Id) -> 
+              ({var, Id, _Name}) when is_integer(Id) -> 
                 {ok, Id};
               _ -> 
                 error

--- a/src/erlang_types/ty_tuples.erl
+++ b/src/erlang_types/ty_tuples.erl
@@ -97,7 +97,10 @@ substitute({DefaultTuple, AllTuples}, SubstituteMap, Memo) ->
   AllVars = dnf_var_ty_tuple:all_variables(DefaultTuple),
   % note: OtherTupleKeys not be included in the AllTuples keys, they are known
   % TODO erlang 26 map comprehensions
-  Keys = maps:fold(fun(K,V,AccIn) -> case lists:member(K, AllVars) of true -> ty_rec:tuple_keys(V) -- maps:keys(AllTuples) ++ AccIn; _ -> AccIn end end, [], SubstituteMap),
+  Keys = maps:fold(fun(K,V,AccIn) -> 
+    case lists:member(K, AllVars) of true -> ty_rec:tuple_keys(V) -- maps:keys(AllTuples) ++ AccIn; _ -> AccIn 
+    end 
+  end, [], SubstituteMap),
   % Keys = [(tuple_keys(V) -- maps:keys(AllTuples)) || K := V <- SubstituteMap, lists:member(K, AllVars)],
   OtherTupleKeys = lists:usort(lists:flatten(Keys)),
   NewDefaultOtherTuples = maps:from_list([{Length, dnf_var_ty_tuple:substitute(DefaultTuple, SubstituteMap, Memo, fun(Ty) -> ty_rec:pi({tuple, Length}, Ty) end)} || Length <- OtherTupleKeys]),

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -197,7 +197,8 @@ extend_symtab_internal(Filename, Forms, RefType, Tab, OverlaySymtab) ->
                 end
         end,
     case IsNew of
-        false -> Tab;
+        false -> 
+            Tab;
         true ->
             NewTab =
                 lists:foldl(

--- a/src/test_utils.erl
+++ b/src/test_utils.erl
@@ -16,9 +16,11 @@
     reset_ets/0,
     ety_to_cduce_tally/2,
     format_tally_config/3,
+    named/1,
     named/2,
     extend_symtab/2, 
-    extend_symtab/3
+    extend_symtab/3,
+    extend_symtabs/2
 ]).
 
 -export_type([
@@ -156,6 +158,9 @@ to_var({var, Name}) ->
     "'" ++ string:replace(erlang:atom_to_list(Name), "$", "u").
 
 
+named(Ref) ->
+    named(Ref, []).
+
 named(Ref, Args) ->
   % Use the dummy '.' file as the module for testing purposes
   {named, ast:loc_auto(), {ty_ref, '.', Ref, length(Args)}, Args}.
@@ -167,6 +172,10 @@ extend_symtab(Def, Scheme, Symtab) ->
   TyDef = {Def, Scheme},
   Form = {attribute, ast:loc_auto(), type, transparent, TyDef},
   symtab:extend_symtab(".", [Form], Symtab, symtab:empty()).
+
+extend_symtabs(DefSchemes, Symtab) ->
+  Forms = [{attribute, ast:loc_auto(), type, transparent, TyDef} || TyDef <- DefSchemes],
+  symtab:extend_symtab(".", Forms, Symtab, symtab:empty()).
 
 
 -ifdef(TEST).

--- a/test/erlang_types/subtype/subtype_user_tests.erl
+++ b/test/erlang_types/subtype/subtype_user_tests.erl
@@ -17,19 +17,37 @@ simple_named_test() ->
   ok.
 
 % #182
-% mu_test() ->
-%   test_utils:reset_ets(),
-%   S = tmu(tvar(exp), ttuple([tunion([tatom(a), tvar(exp)])])),
-%   true = subty:is_subty(symtab:empty(), S, S),
-%   ok.
+mu_test() ->
+  test_utils:reset_ets(),
+  S = tmu(tvar(exp), ttuple([tunion([tatom(a), tvar(exp)])])),
+  true = subty:is_subty(symtab:empty(), S, S),
+  ok.
 
 % #182
-% exp_test() ->
-%   test_utils:reset_ets(),
-%   Sym = test_utils:extend_symtab(exp, tyscm([], ttuple([tunion([tatom(a), named(exp, [])])]))),
-%   S = named(exp, []),
-%   true = subty:is_subty(Sym, S, S),
-%   ok.
+exp_test() ->
+  test_utils:reset_ets(),
+  Sym = test_utils:extend_symtab(exp, tyscm([], ttuple([tunion([tatom(a), named(exp, [])])]))),
+  S = named(exp, []),
+  true = subty:is_subty(Sym, S, S),
+  ok.
+
+funs_test() ->
+  test_utils:reset_ets(),
+  Sym = test_utils:extend_symtab(exp, tyscm([], tfun_full([tunion([tatom(a), named(exp, [])])], tatom(b)))),
+  S = named(exp, []),
+  true = subty:is_subty(Sym, S, S),
+  ok.
+
+maps_test() ->
+  test_utils:reset_ets(),
+  Map = tmap([
+    tmap_field_req(tint(1), tatom(a)),
+    tmap_field_opt(tint(2), named(exp, []))
+  ]),
+  Sym = test_utils:extend_symtab(exp, tyscm([], ttuple([Map, named(exp, [])]))),
+  S = named(exp, []),
+  true = subty:is_subty(Sym, S, S),
+  ok.
 
 % TODO rewrite 
 %%simple_named2_test() ->

--- a/test/subst_tests.erl
+++ b/test/subst_tests.erl
@@ -4,12 +4,15 @@
 -import(stdtypes, [tvar/1, ttuple_any/0, tnegate/1, tatom/0, tatom/1, tfun_full/2, trange/2, tunion/1, tintersect/1, trange_any/0, ttuple/1, tany/0, tnone/0]).
 -import(test_utils, [is_subtype/2, is_equiv/2]).
 
+ast_to_erlang_ty(Ty) ->
+  ast_lib:ast_to_erlang_ty(Ty, symtab:empty()).
+
 test_subst(Name, Subst, Type, TypeExpected) ->
   {Name, fun() ->
     test_utils:reset_ets(),
-    SubstT = maps:from_list([{ast_lib:ast_to_erlang_ty_var(Var), ast_lib:ast_to_erlang_ty(Ty)} || {Var, Ty} <- maps:to_list(Subst)]),
-    TypeT = ast_lib:ast_to_erlang_ty(Type),
-    TypeExpectedT = ast_lib:ast_to_erlang_ty(TypeExpected),
+    SubstT = maps:from_list([{ast_lib:ast_to_erlang_ty_var(Var), ast_to_erlang_ty(Ty)} || {Var, Ty} <- maps:to_list(Subst)]),
+    TypeT = ast_to_erlang_ty(Type),
+    TypeExpectedT = ast_to_erlang_ty(TypeExpected),
     New = ty_rec:substitute(TypeT, SubstT),
     true = ty_rec:is_equivalent(New, TypeExpectedT)
                 end
@@ -23,14 +26,14 @@ eq_list(L1, L2) ->
 all_variables_fun_test() ->
   test_utils:reset_ets(),
   T = tfun_full([tvar('$0'), tvar('$1')], tvar('$2')),
-  Ty = ast_lib:ast_to_erlang_ty(T),
+  Ty = ast_to_erlang_ty(T),
   true = eq_list([ast_lib:ast_to_erlang_ty_var(tvar(V)) || V <- ['$0', '$1', '$2']], ty_rec:all_variables(Ty)),
   ok.
 
 all_variables_tuple_test() ->
   test_utils:reset_ets(),
   T = ttuple([tvar('$0'), tvar('$1'), tvar('$2')]),
-  Ty = ast_lib:ast_to_erlang_ty(T),
+  Ty = ast_to_erlang_ty(T),
   true = eq_list([ast_lib:ast_to_erlang_ty_var(tvar(V)) || V <- ['$0', '$1', '$2']], ty_rec:all_variables(Ty)),
   ok.
 
@@ -46,17 +49,17 @@ all_variables_test() ->
     tintersect([tvar('$8'), tfun_full([], tvar('$9'))]),
     tintersect([tvar('$10'), tfun_full([tvar('$11')], tvar('$12'))])
   ]),
-  Ty = ast_lib:ast_to_erlang_ty(T),
+  Ty = ast_to_erlang_ty(T),
   true = eq_list([ast_lib:ast_to_erlang_ty_var(tvar(V)) || V <- ['$1', '$2', '$3', '$4', '$5', '$6', '$7', '$8', '$9', '$10', '$11', '$12']], ty_rec:all_variables(Ty)),
   ok.
 
 simple_subst_test() ->
   test_utils:reset_ets(),
   All = [tatom(), trange_any(), stdtypes:tspecial_any(), stdtypes:tlist_any(), stdtypes:tfun_any(), stdtypes:ttuple_any()],
-  Ty = ast_lib:ast_to_erlang_ty(tvar('a')),
+  Ty = ast_to_erlang_ty(tvar('a')),
   [
     begin
-      TargetTy = ast_lib:ast_to_erlang_ty(Target),
+      TargetTy = ast_to_erlang_ty(Target),
       true = ty_rec:is_equivalent(TargetTy, ty_rec:substitute(Ty, #{ast_lib:ast_to_erlang_ty_var(tvar('a')) => TargetTy}))
     end
     || Target <- All],

--- a/test_files/tycheck_simple/user.erl
+++ b/test_files/tycheck_simple/user.erl
@@ -62,3 +62,8 @@ user_06(false) -> {foo, user_06(true)}.
 -spec user_07(user_t_07(foo)) -> integer().
 user_07(nil) -> 1;
 user_07({foo, X}) -> user_07(X).
+
+% #182
+-type user_t_08() :: {a | user_t_08()}.
+-spec user_08(user_t_08()) -> user_t_08().
+user_08(Forms) -> user_08(Forms).


### PR DESCRIPTION
A sound implementation of a parser from `ast.erl:ast()` to the internal `erlang_types` representation which supports mutual recursive types.

In contrast to the previous interpretation, which was only correct for non-recursive types, the algorithm has to additionally do the following:

* Parse the into a temporary `erlang_types` representation with temporary references in a breadth-first approach (corecursive)
* Unify the temporary references and minimize the type
* Transfer the new minimized type with temporary references into the internal representation

The old parser in `ast_lib.erl` is still used for types which are not `mu` or `named` types.

Fixes #182 #88.