### PR TITLE
Case study finish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test: build testtest
 	@echo "Checking syntax transformation for source code of type checker ..."
 	./_build/default/bin/ety --sanity --no-type-checking -I ./src ./src/*.erl
 	@echo "Running case study ..."
+	ETY_CASE_STUDY_LOGLEVEL=warn test_files/etylizer-mini/check-std.sh
 	ETY_CASE_STUDY_LOGLEVEL=warn test_files/etylizer-mini/check.sh
 
 testtest:

--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -293,6 +293,7 @@ tyscm(Vars, Ty) -> {ty_scheme, lists:map(fun(Alpha) -> {Alpha, {predef, any}} en
 -spec builtin_ops() -> [{atom(), arity(), ast:ty_scheme()}].
 builtin_ops() ->
     NumOpTy = tyscm(tinter([
+        tfun([{predef_alias, non_neg_integer}, {predef_alias, non_neg_integer}], {predef_alias, non_neg_integer}),
         tfun([tint(), tint()], tint()),
         tfun([tint(), tfloat()], tfloat()),
         tfun([tfloat(), tint()], tfloat()),
@@ -305,8 +306,8 @@ builtin_ops() ->
     IntOpTy = tyscm(tfun([tint(), tint()], tint())),
     BoolOpTy = tyscm(tfun([tbool(), tbool()], tbool())),
     AndShortcutOpTy = tyscm(tinter([tfun([tatom(false), tany()], tatom(false)), tfun([tatom(true), tvar(a)], tvar(a))])),
-    OrShortcutOpTy = tyscm(tinter([tfun([tatom(true), tany()], tatom(true)), tfun([tatom(false), tvar(a)], tvar(a))])),
-    PolyOpTy = tyscm(tfun([tvar(a), tvar(a)], tbool())),
+    OrShortcutOpTy = tyscm(tinter([tfun([tatom(true), tany()], tatom(true)), tfun([tatom(false), tvar(b)], tvar(b))])),
+    PolyOpTy = tyscm(tfun([tvar(aa), tvar(aa)], tbool())),
     [
         {'+', 2, NumOpTy},
         {'-', 2, NumOpTy},

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -28,12 +28,12 @@
 
 % quit exits the erlang program with the given exit code. No stack trace is produced,
 % so don't use this function for aborting because of a bug.
--spec quit(non_neg_integer(), string(), [_]) -> ok.
+-spec quit(non_neg_integer(), string(), [_]) -> _.
 quit(Code, Msg, L) ->
     io:format(Msg, L),
     halt(Code).
 
--spec quit(integer(), string()) -> ok.
+-spec quit(non_neg_integer(), string()) -> _.
 quit(Code, Msg) ->
     io:format(Msg),
     halt(Code).

--- a/test_files/etylizer-mini/changelog.txt
+++ b/test_files/etylizer-mini/changelog.txt
@@ -3,12 +3,10 @@ Document all changes necessary to get the source code working
 
 - explicitly specify record arguments that have default values (we do not have support for
   default values) #200
-- add some type annotations to stdtypes, otherwise definitions cannot be used from other modules
 - fix map_opt/3, it's type was not correct.
-- overlays for several functions using binary
+- overlays for imprecise list functions
 - overlay for erlang:element/2
-- spec for utils:mingle/5 and utils:is_same_file (we have to ignore these functions because
-  of missing support for binary)
-- Logging: two parameters instead of all in one list. See commit
-  ff9c856c8db724682237c4f99265d3f21f7eee37
+- spec for utils:mingle/5 and utils:is_same_file 
+- Logging: two parameters instead of all in one list. See commit ff9c856c8db724682237c4f99265d3f21f7eee37
 - Replace list comprehension with lists:map
+- removed reference for self module 

--- a/test_files/etylizer-mini/check-std.sh
+++ b/test_files/etylizer-mini/check-std.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+../../ety --build --no-deps -f -l debug stdlib/ordsets2.erl -i intersection/1
+
+# drop_r drop out out_r memory exhaustive
+# delete_with/2 split/2 delete/2 timeout
+# delete_front unknown type error
+# f2r/1 r2f/1 get/2 get_r/1 peek/1 peek_r/1 type error, imprecise
+# split_f1_to_r2 split_r1_to_f2 exhaustiveness fail
+# filter_f filtermap_r needs function optimizations
+../../ety --build --no-deps -f -l debug stdlib/queue2.erl \
+  -i out \
+  -i out_r \
+  -i get/2 \
+  -i get_r \
+  -i peek \
+  -i peek_r \
+  -i drop \
+  -i drop_r \
+  -i split \
+  -i split_f1_to_r2 \
+  -i split_r1_to_f2 \
+  -i delete \
+  -i delete_front \
+  -i delete_with \
+  -i r2f -i f2r \
+  -i filter_f \
+  -i filtermap_r
+

--- a/test_files/etylizer-mini/check.sh
+++ b/test_files/etylizer-mini/check.sh
@@ -12,120 +12,36 @@ function run_ety() {
     ../../ety --build --type-overlay $OVERLAY --force --level $LOGLEVEL -P . -I src --no-deps "$@" || exit 1
 }
 
-# 6/6
-run_ety src/varenv.erl
-
-# 6/6
-run_ety src/varenv_local.erl
-
-# 36/49
-# unconsult/2, mkdirs/1: #12
-# hash_file/1: Name error: hash_sha1/1 undefined
-# diff_terms/3: Name error: sformat/3 undefined
-# fails type check:
-#  is_same_file/2
-#  mingle/5
-#  sformat_raw/2
-#  quit/2
-# try support:
-#  timeout/2 file_get_lines/1 sformat/2
-# hard:
-#  everywhere/2 
-#  everything/2
+# 9/10
+# type error: 1
+#   to_loc/2 (#238)
 run_ety \
-    --ignore is_same_file/2 --ignore quit/2 --ignore sformat_raw/2 --ignore sformat/2 \
-    --ignore everything/2 --ignore everywhere/2 --ignore diff_terms/3 --ignore file_get_lines/1 \
-    --ignore mkdirs/1 --ignore hash_file/1 \
-    --ignore timeout/2 --ignore mingle/5 --ignore unconsult/2 \
-    src/utils.erl
+    --ignore to_loc/2 \
+    src/ast.erl
 
-# 3/5
-# with_tmp_file/4 and with_tmp_dir/4 because they use try
-run_ety \
-    --ignore with_tmp_file/4 --ignore with_tmp_dir/4 \
-    src/tmp.erl
+# 2/2
+run_ety src/ast_erl.erl
 
-# 0/0
-run_ety src/t.erl
-
-# 17/17
-run_ety src/errors.erl
-
-# 29/55
-# type error: builtin_funs/0
-# type error: mk_builtin_funs/1
-# others: too slow
-run_ety src/stdtypes.erl \
-  --ignore extra_funs/0 \
-  --ignore tmu/2 \
-  --ignore tinter/1 \
-  --ignore tinter/2 \
-  --ignore tfun/2 \
-  --ignore tfun1/2 \
-  --ignore tfun2/3 \
-  --ignore tatom/0 \
-  --ignore tmap/1 \
-  --ignore tmap/2 \
-  --ignore tmap_req/2 \
-  --ignore tmap_field_opt/2 \
-  --ignore tmap_field_req/2 \
-  --ignore tfun_full/2 \
-  --ignore ttuple/1 \
-  --ignore ttuple1/1 \
-  --ignore ttuple2/2 \
-  --ignore tintersect/1 \
-  --ignore tunion/1 \
-  --ignore tunion/2 \
-  --ignore tspecial_any/0 \
-  --ignore expand_predef_alias/1 \
-  --ignore tyscm/1 \
-  --ignore tyscm/2 \
-  --ignore builtin_ops/0 \
-  --ignore builtin_funs/0 \
-  --ignore mk_builtin_funs/1
+# 1/8
+# false positive: 2
+#   unfold_intersection/2 unfold_union/2 (#241)
+# timeout: 5
+run_ety src/ast_lib.erl \
+  -i unfold_intersection -i unfold_union \
+  -i mk_intersection/2 -i mk_intersection/1 -i mk_diff \
+  -i mk_union/1 -i mk_union/2
 
 # 6/43
-# trans_tys/3 timeout
-# trans_ty_map_assoc/3 timeout
-# shallow_remove_match/1 timeout
-# trans/4 timeout
-# trans_form/3 timeout
-# trans_guards/3 timeout
-# trans_exp/3 timeout
-# trans_case_clause/3 timeout
-# trans_case_clauses/3 timeout
-# trans_catch_clause/3 timeout
-# trans_catch_clauses/3 timeout
-# trans_fun_clause/3 timeout
-# trans_fun_clauses/3 timeout
-# trans_if_clause/3 timeout
-# trans_if_clauses/3 timeout
-# trans_qualifier/3 timeout
-# trans_qualifiers/3 timeout
-# trans_pat/4 timeout
-# trans_pats/4 timeout
-# trans_pat_bin_elem/4 timeout
-# trans_exps/3 timeout
-# trans_exp_bin_elem/3 timeout
-# trans_exp_noenv/3 timeout
-# trans_exp_seq_noenv/3 timeout
-# trans_exp_seq/3 timeout
-# trans_map_assoc/3 timeout
-# trans_map_assocs/3 timeout
-# trans_record_field/3 timeout
-# trans_record_fields/3 timeout
-# trans_tydef/2 timeout
-# trans_constraint/3 timeout
-# resolve_ety_ty/3 timeout
-# eval_const_ty/2 try support
-# Slow:
-#  thread_through_env/3
-# Type error: 
-#  trans_ty/3
-#  build_funenv/2
-#  trans_tydef/2
-#  trans_spec_ty/3
-#  make_tyenv/3
+# timeout: 32
+# try support: 1
+#   eval_const_ty/2
+# type error: 4
+#  make_tyenv/3 (type error, empty var env is not compatible with tyenv()!)
+#  trans_ty/3 (error log format!) 
+#  build_funenv/2 (???)
+#  trans_tydef/2 (???)
+# false positive: 1
+#  trans_spec_ty/3 (utils:everything)
 run_ety src/ast_transform.erl \
     --ignore thread_through_env/3 \
     --ignore eval_const_ty/2 \
@@ -166,20 +82,44 @@ run_ety src/ast_transform.erl \
     --ignore trans_spec_ty/3 \
     --ignore build_funenv/2
 
-# 9/10
-# to_loc/2 : type error
+# 2/4
+# false positives: 2
+#   referenced_modules/1 referenced_variables/1 (utils:everything)
 run_ety \
-    --ignore to_loc/2 \
-    src/ast.erl
+    --ignore referenced_modules/1 \
+    --ignore referenced_variables/1 \
+    src/ast_utils.erl
 
-# 2/2
-run_ety src/ast_erl.erl
+# 17/17
+run_ety src/errors.erl
+
+# 5/12
+# false positive: 2
+#   macro_log/5 (#230)
+#   parse_level/1 (#239)
+# type error: 1
+#   allow/1 (#12)
+# receive and try supp: 5
+#   get_logger_pid shutdown file_logger log_to_file
+run_ety -o get_logl_level/1 \
+    --ignore allow/1 \
+    --ignore macro_log/5 \
+    --ignore parse_level/1 \
+    --ignore get_logger_pid --ignore shutdown --ignore file_logger --ignore log_to_file \
+    src/log.erl
+
+# 2/5
+# timeout: 2
+# try support: 1
+#   parse_transform/2
+run_ety \
+    --ignore parse_file/2 \
+    --ignore parse_file_or_die/2 \
+    --ignore parse_transform/2 \
+    src/parse.erl
 
 # 1/5
-# record_ty_from_decl/2: timeout
-# lookup_field_ty/3: timeout
-# lookup_field_index/3: timeout
-# encode_record_ty/2: timeout
+# timeout: 4
 run_ety \
     --ignore record_ty_from_decl/2 \
     --ignore encode_record_ty/2 \
@@ -187,37 +127,74 @@ run_ety \
     --ignore lookup_field_index/3 \
     src/records.erl
 
-# 1/5
-# timeout: parse_file/2 parse_file_or_die/2
-# type error: parse_file_or_die/1
-# try: parse_transform/2
-run_ety \
-    --ignore parse_file/2 \
-    --ignore parse_file_or_die/2 \
-    --ignore parse_file_or_die/1 \
-    --ignore parse_transform/2 \
-    src/parse.erl
+# 29/55 in 67s
+# false positive: 1
+#   mk_builtin_funs/1 (#240)
+# type error: 1
+#   builtin_funs/0 (#12)
+# timeout: 24
+run_ety src/stdtypes.erl \
+  --ignore extra_funs/0 \
+  --ignore tmu/2 \
+  --ignore tinter/1 \
+  --ignore tinter/2 \
+  --ignore tfun/2 \
+  --ignore tfun1/2 \
+  --ignore tfun2/3 \
+  --ignore tatom/0 \
+  --ignore tmap/1 \
+  --ignore tmap/2 \
+  --ignore tmap_req/2 \
+  --ignore tmap_field_opt/2 \
+  --ignore tmap_field_req/2 \
+  --ignore tfun_full/2 \
+  --ignore ttuple/1 \
+  --ignore ttuple1/1 \
+  --ignore ttuple2/2 \
+  --ignore tintersect/1 \
+  --ignore tunion/1 \
+  --ignore tunion/2 \
+  --ignore tspecial_any/0 \
+  --ignore expand_predef_alias/1 \
+  --ignore tyscm/1 \
+  --ignore tyscm/2 \
+  --ignore builtin_ops/0 \
+  --ignore mk_builtin_funs/1 \
+  --ignore builtin_funs/0
 
-# 5/12
-# BUG: macro_log/5
-# type error: allow/1 (#12)
-# type error: parse_level/1
-# get_logger_pid shutdown file_logger log_to_file: receive & try
+# 3/5
+# try support: 2
+#   with_tmp_file with_tmp_dir
 run_ety \
-    --ignore allow/1 \
-    --ignore macro_log/5 \
-    --ignore parse_level/1 \
-    --ignore get_logger_pid --ignore shutdown --ignore file_logger --ignore log_to_file \
-    src/log.erl
+    --ignore with_tmp_file/4 --ignore with_tmp_dir/4 \
+    src/tmp.erl
 
-# 1/4
-# type error: modname_from_path/1 referenced_modules/1 referenced_variables/1
-# slow: remove_locs/1
-run_ety \
-    --ignore modname_from_path/1 \
-    --ignore referenced_modules/1 \
-    --ignore referenced_variables/1 \
-    src/ast_utils.erl
+# 39/49
+# type error: 5
+#  diff_terms/3 io:format not compatible
+#  unconsult/2, mkdirs/1: #12
+#  quit/2 quit/3: spec wrong
+# try support: 3
+#  timeout/2 file_get_lines/1 sformat/2
+# false positives: 2
+#  everywhere/2 
+#  everything/2
+# type overlay: fl/1
+run_ety --ignore fl/1 \
+    --ignore sformat/2 \
+    --ignore everything/2 -i everywhere/2 -i diff_terms/3 --ignore file_get_lines/1 \
+    --ignore mkdirs/1 \
+    --ignore timeout/2 --ignore unconsult/2 -i quit/2 -i quit/3\
+    src/utils.erl
 
-# 2/2
+# 6/6
+run_ety src/varenv.erl
+
+# 6/6
+run_ety src/varenv_local.erl
+
+# # 2/2
 run_ety src/ast_erl.erl
+
+# 0/0
+run_ety src/t.erl

--- a/test_files/etylizer-mini/overlay.erl
+++ b/test_files/etylizer-mini/overlay.erl
@@ -17,6 +17,9 @@
 -spec 'filename:join'(string(), string()) -> string().
 'filename:join'(_, _) -> error(overlay).
 
+-spec 'filename:basename'(string(), string()) -> string().
+'filename:basename'(_, _) -> error(overlay).
+
 -spec 'lists:map'(fun((A) -> B), [A]) -> [B].
 'lists:map'(_, _) -> error(overlay).
 
@@ -25,6 +28,13 @@
 
 -spec 'lists:keyfind'(Key :: term(), N :: pos_integer(), [Tuple]) -> Tuple | false.
 'lists:keyfind'(_, _, _) -> error(overlay).
+
+-spec 'maps:from_list'([{Key, Value}]) -> #{Key => Value}.
+'maps:from_list'(_) -> error(overlay).
+
+% -type deepList(A) :: [A | deepList(A)].
+% -spec 'lists:flatten'(deepList(A)) -> [A].
+% 'lists:flatten'(_) -> error(overlay).
 
 -spec 'erlang:element'
     (2, {_A, B}) -> B;
@@ -41,6 +51,3 @@
 'erlang:element'(_, {_A, B, _C, _D, _E, _F}) -> B;
 'erlang:element'(_, {_A, B, _C, _D, _E, _F, _G}) -> B;
 'erlang:element'(_, {_A, B, _C, _D, _E, _F, _G, _H}) -> B.
-
--spec 'maps:find'(Key, #{Key => Value}) -> {ok, Value} | error.
-'maps:find'(_, _) -> error(eqwalizer_specs).

--- a/test_files/etylizer-mini/src/ast_lib.erl
+++ b/test_files/etylizer-mini/src/ast_lib.erl
@@ -9,12 +9,14 @@
     mk_diff/2
 ]).
 
+-spec unfold_intersection([ast:ty()], [ast:ty()]) -> [ast:ty()].
 unfold_intersection([], All) -> All;
 unfold_intersection([{intersection, Components} | Rest], All) ->
     unfold_intersection(Components ++ Rest, All);
 unfold_intersection([X | Rest], All) ->
     unfold_intersection(Rest, All ++ [X]) .
 
+-spec unfold_union([ast:ty()], [ast:ty()]) -> [ast:ty()].
 unfold_union([], All) -> All;
 unfold_union([{union, Components} | Rest], All) ->
     unfold_union(Components ++ Rest, All);
@@ -58,6 +60,7 @@ mk_intersection(Tys) ->
             end
     end.
 
+-spec mk_diff(ast:ty(), ast:ty()) -> ast:ty().
 mk_diff(T1, T2) ->
    mk_intersection([T1, mk_negation(T2)]).
 

--- a/test_files/etylizer-mini/src/parse.erl
+++ b/test_files/etylizer-mini/src/parse.erl
@@ -64,7 +64,7 @@ parse_file(Path, Opts) ->
     end.
 
 -spec parse_file_or_die(string()) -> [ast_erl:form()].
-parse_file_or_die(Path) -> parse_file_or_die(Path, #parse_opts{}).
+parse_file_or_die(Path) -> parse_file_or_die(Path, #parse_opts{includes = [], defines = [], verbose = true}).
 
 -spec parse_file_or_die(string(), parse_opts()) -> [ast_erl:form()].
 parse_file_or_die(Path, Opts) ->

--- a/test_files/etylizer-mini/src/utils.erl
+++ b/test_files/etylizer-mini/src/utils.erl
@@ -43,10 +43,14 @@ map_opt(F, L) ->
 % quit exits the erlang program with the given exit code. No stack trace is produced,
 % so don't use this function for aborting because of a bug.
 -spec quit(non_neg_integer(), string(), [_]) -> ok.
+% this is the correct spec
+% -spec quit(non_neg_integer(), string(), [_]) -> _.
 quit(Code, Msg, L) ->
     io:format(Msg, L),
     halt(Code).
 
+% thats the correct spec
+% -spec quit(non_neg_integer(), string()) -> no_return().
 -spec quit(integer(), string()) -> ok.
 quit(Code, Msg) ->
     io:format(Msg),
@@ -55,9 +59,14 @@ quit(Code, Msg) ->
 -spec undefined() -> none().
 undefined() -> erlang:error("undefined").
 
+% hack for type overlay + type spec
+-type deepList(A) :: [A | deepList(A)].
+-spec fl(deepList(A)) -> [A].
+fl(L) -> lists:flatten(L).
+
 -spec sformat_raw(string(), list()) -> string().
 sformat_raw(Msg, L) ->
-    lists:flatten(io_lib:format(Msg, L)).
+    fl(io_lib:format(Msg, L)).
 
 % Does some magic to distinguish whether term() is a list of arguments or a single argument
 -spec sformat(string(), term()) -> string().
@@ -254,7 +263,7 @@ hash_sha1(Data) ->
 -spec hash_file(file:filename()) -> string() | {error, any()}.
 hash_file(Path) ->
     case file:read_file(Path) of
-        {ok, FileContent} -> utils:hash_sha1(FileContent);
+        {ok, FileContent} -> hash_sha1(FileContent);
         X -> X
     end.
 

--- a/test_files/etylizer-mini/stdlib/ordsets2.erl
+++ b/test_files/etylizer-mini/stdlib/ordsets2.erl
@@ -1,0 +1,267 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1996-2020. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+
+-module(ordsets2).
+
+-export([new/0,is_set/1,size/1,is_empty/1,to_list/1,from_list/1]).
+-export([is_element/2,add_element/2,del_element/2]).
+-export([union/2,union/1,intersection/2,intersection/1]).
+-export([is_disjoint/2]).
+-export([subtract/2,is_subset/2]).
+-export([fold/3,filter/2]).
+
+-export_type([ordset/1]).
+
+-type ordset(T) :: [T].
+
+%% new() -> Set.
+%%  Return a new empty ordered set.
+
+-spec new() -> [].
+
+new() -> [].
+
+%% is_set(Term) -> boolean().
+%%  Return 'true' if Set is an ordered set of elements, else 'false'.
+
+-spec is_set(Ordset) -> boolean() when
+      Ordset :: term().
+
+is_set([E|Es]) -> is_set(Es, E);
+is_set([]) -> true;
+is_set(_) -> false.
+
+-spec is_set(list(term()), term()) -> boolean().
+is_set([E2|Es], E1) when E1 < E2 ->
+    is_set(Es, E2);
+is_set([_|_], _) -> false;
+is_set([], _) -> true.
+
+%% size(OrdSet) -> int().
+%%  Return the number of elements in OrdSet.
+
+-spec size(Ordset) -> non_neg_integer() when
+      Ordset :: ordset(_).
+
+size(S) -> length(S).
+
+%% is_empty(OrdSet) -> boolean().
+%%  Return 'true' if OrdSet is an empty set, otherwise 'false'.
+-spec is_empty(Ordset) -> boolean() when
+      Ordset :: ordset(_).
+
+is_empty(S) -> S=:=[].
+
+%% to_list(OrdSet) -> [Elem].
+%%  Return the elements in OrdSet as a list.
+
+-spec to_list(Ordset) -> List when
+      Ordset :: ordset(T),
+      List :: [T].
+
+to_list(S) -> S.
+
+%% from_list([Elem]) -> Set.
+%%  Build an ordered set from the elements in List.
+
+-spec from_list(List) -> Ordset when
+      List :: [T],
+      Ordset :: ordset(T).
+
+from_list(L) ->
+    lists:usort(L).
+
+%% is_element(Element, OrdSet) -> boolean().
+%%  Return 'true' if Element is an element of OrdSet, else 'false'.
+
+-spec is_element(Element, Ordset) -> boolean() when
+      Element :: term(),
+      Ordset :: ordset(_).
+
+is_element(E, [H|Es]) when E > H -> is_element(E, Es);
+is_element(E, [H|_]) when E < H -> false;
+is_element(_E, [_H|_]) -> true;			%E == H
+is_element(_, []) -> false.
+
+%% add_element(Element, OrdSet) -> OrdSet.
+%%  Return OrdSet with Element inserted in it.
+
+-spec add_element(Element, Ordset1) -> Ordset2 when
+      Element :: E,
+      Ordset1 :: ordset(T),
+      Ordset2 :: ordset(T | E).
+
+%-spec add_element(E, ordset(T)) -> [T | E,...].
+
+add_element(E, [H|Es]) when E > H -> [H|add_element(E, Es)];
+add_element(E, [H|_]=Set) when E < H -> [E|Set];
+add_element(_E, [_H|_]=Set) -> Set;		%E == H
+add_element(E, []) -> [E].
+
+%% del_element(Element, OrdSet) -> OrdSet.
+%%  Return OrdSet but with Element removed.
+
+-spec del_element(Element, Ordset1) -> Ordset2 when
+      Element :: term(),
+      Ordset1 :: ordset(T),
+      Ordset2 :: ordset(T).
+
+del_element(E, [H|Es]) when E > H -> [H|del_element(E, Es)];
+del_element(E, [H|_]=Set) when E < H -> Set;
+del_element(_E, [_H|Es]) -> Es;			%E == H
+del_element(_, []) -> [].
+
+%% union(OrdSet1, OrdSet2) -> OrdSet
+%%  Return the union of OrdSet1 and OrdSet2.
+
+-spec union(Ordset1, Ordset2) -> Ordset3 when
+      Ordset1 :: ordset(T1),
+      Ordset2 :: ordset(T2),
+      Ordset3 :: ordset(T1 | T2).
+
+union([E1|Es1], [E2|_]=Set2) when E1 < E2 ->
+    [E1|union(Es1, Set2)];
+union([E1|_]=Set1, [E2|Es2]) when E1 > E2 ->
+    [E2|union(Es2, Set1)];			% switch arguments!
+union([E1|Es1], [_E2|Es2]) ->			%E1 == E2
+    [E1|union(Es1, Es2)];
+union([], Es2) -> Es2;
+union(Es1, []) -> Es1.
+
+%% union([OrdSet]) -> OrdSet
+%%  Return the union of the list of ordered sets.
+
+-spec union(OrdsetList) -> Ordset when
+      OrdsetList :: [ordset(T)],
+      Ordset :: ordset(T).
+
+union(OrdsetList) ->
+    lists:umerge(OrdsetList).
+
+%% intersection(OrdSet1, OrdSet2) -> OrdSet.
+%%  Return the intersection of OrdSet1 and OrdSet2.
+
+-spec intersection(Ordset1, Ordset2) -> Ordset3 when
+      Ordset1 :: ordset(_),
+      Ordset2 :: ordset(_),
+      Ordset3 :: ordset(_).
+
+intersection([E1|Es1], [E2|_]=Set2) when E1 < E2 ->
+    intersection(Es1, Set2);
+intersection([E1|_]=Set1, [E2|Es2]) when E1 > E2 ->
+    intersection(Es2, Set1);			% switch arguments!
+intersection([E1|Es1], [_E2|Es2]) ->		%E1 == E2
+    [E1|intersection(Es1, Es2)];
+intersection([], _) ->
+    [];
+intersection(_, []) ->
+    [].
+
+%% intersection([OrdSet]) -> OrdSet.
+%%  Return the intersection of the list of ordered sets.
+
+-spec intersection(OrdsetList) -> Ordset when
+      OrdsetList :: [ordset(_),...],
+      Ordset :: ordset(_).
+
+intersection([S1,S2|Ss]) ->
+    intersection1(intersection(S1, S2), Ss);
+intersection([S]) -> S.
+% intersection(_) -> error(bad_state). % list redundancy check not enough
+
+-spec intersection1(ordset(_), [ordset(_)]) -> ordset(_).
+intersection1(S1, [S2|Ss]) ->
+    intersection1(intersection(S1, S2), Ss);
+intersection1(S1, []) -> S1.
+
+%% is_disjoint(OrdSet1, OrdSet2) -> boolean().
+%%  Check whether OrdSet1 and OrdSet2 are disjoint.
+
+-spec is_disjoint(Ordset1, Ordset2) -> boolean() when
+      Ordset1 :: ordset(_),
+      Ordset2 :: ordset(_).
+
+is_disjoint([E1|Es1], [E2|_]=Set2) when E1 < E2 ->
+    is_disjoint(Es1, Set2);
+is_disjoint([E1|_]=Set1, [E2|Es2]) when E1 > E2 ->
+    is_disjoint(Es2, Set1);			% switch arguments!
+is_disjoint([_E1|_Es1], [_E2|_Es2]) ->		%E1 == E2
+    false;
+is_disjoint([], _) ->
+    true;
+is_disjoint(_, []) ->
+    true.
+
+%% subtract(OrdSet1, OrdSet2) -> OrdSet.
+%%  Return all and only the elements of OrdSet1 which are not also in
+%%  OrdSet2.
+
+-spec subtract(Ordset1, Ordset2) -> Ordset3 when
+      Ordset1 :: ordset(_),
+      Ordset2 :: ordset(_),
+      Ordset3 :: ordset(_).
+
+subtract([E1|Es1], [E2|_]=Set2) when E1 < E2 ->
+    [E1|subtract(Es1, Set2)];
+subtract([E1|_]=Set1, [E2|Es2]) when E1 > E2 ->
+    subtract(Set1, Es2);
+subtract([_E1|Es1], [_E2|Es2]) ->		%E1 == E2
+    subtract(Es1, Es2);
+subtract([], _) -> [];
+subtract(Es1, []) -> Es1.
+
+%% is_subset(OrdSet1, OrdSet2) -> boolean().
+%%  Return 'true' when every element of OrdSet1 is also a member of
+%%  OrdSet2, else 'false'.
+
+-spec is_subset(Ordset1, Ordset2) -> boolean() when
+      Ordset1 :: ordset(_),
+      Ordset2 :: ordset(_).
+
+is_subset([E1|_], [E2|_]) when E1 < E2 ->	%E1 not in Set2
+    false;
+is_subset([E1|_]=Set1, [E2|Es2]) when E1 > E2 ->
+    is_subset(Set1, Es2);
+is_subset([_E1|Es1], [_E2|Es2]) ->		%E1 == E2
+    is_subset(Es1, Es2);
+is_subset([], _) -> true;
+is_subset(_, []) -> false.
+
+%% fold(Fun, Accumulator, OrdSet) -> Accumulator.
+%%  Fold function Fun over all elements in OrdSet and return Accumulator.
+
+-spec fold(Function, Acc0, Ordset) -> Acc1 when
+      Function :: fun((Element :: T, AccIn :: term()) -> AccOut :: term()),
+      Ordset :: ordset(T),
+      Acc0 :: term(),
+      Acc1 :: term().
+
+fold(F, Acc, Set) ->
+    lists:foldl(F, Acc, Set).
+
+%% filter(Fun, OrdSet) -> OrdSet.
+%%  Filter OrdSet with Fun.
+
+-spec filter(Pred, Ordset1) -> Ordset2 when
+      Pred :: fun((Element :: T) -> boolean()),
+      Ordset1 :: ordset(T),
+      Ordset2 :: ordset(T).
+
+filter(F, Set) ->
+    lists:filter(F, Set).

--- a/test_files/etylizer-mini/stdlib/queue2.erl
+++ b/test_files/etylizer-mini/stdlib/queue2.erl
@@ -1,0 +1,746 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1996-2016. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+-module(queue2).
+
+%% Creation, inspection and conversion
+-export([new/0,is_queue/1,is_empty/1,len/1,to_list/1,from_list/1,member/2]).
+%% Original style API
+-export([in/2,in_r/2,out/1,out_r/1]).
+%% Less garbage style API
+-export([get/1,get_r/1,peek/1,peek_r/1,drop/1,drop_r/1]).
+
+%% Higher level API
+-export([reverse/1,join/2,split/2,filter/2,filtermap/2,fold/3,any/2,all/2,
+	 delete/2,delete_r/2,delete_with/2,delete_with_r/2]).
+
+%% Okasaki API from klacke
+-export([cons/2,head/1,tail/1,
+	 snoc/2,last/1,daeh/1,init/1,liat/1]).
+
+-export_type([queue/0, queue/1]).
+
+%% Mis-spelled, deprecated.
+-export([lait/1]).
+-deprecated([{lait,1,"use queue:liat/1 instead"}]).
+
+%%--------------------------------------------------------------------------
+%% Efficient implementation of double ended fifo queues
+%%
+%% Queue representation
+%%
+%% {RearList,FrontList}
+%%
+%% The first element in the queue is at the head of the FrontList
+%% The last element in the queue is at the head of the RearList,
+%% that is; the RearList is reversed.
+%%
+
+-opaque queue(Item) :: {list(Item), list(Item)}.
+
+-type queue() :: queue(_).
+
+%% Creation, inspection and conversion
+
+%% O(1)
+-spec new() -> queue().
+new() -> {[],[]}. %{RearList,FrontList}
+
+%% O(1)
+-spec is_queue(Term :: term()) -> boolean().
+is_queue({R,F}) when is_list(R), is_list(F) ->
+    true;
+is_queue(_) ->
+    false.
+
+%% O(1)
+-spec is_empty(Q :: queue()) -> boolean().
+is_empty({[],[]}) ->
+    true;
+is_empty({In,Out}) when is_list(In), is_list(Out) ->
+    false. 
+% is_empty(Q) ->
+%     erlang:error(badarg, [Q]).
+
+%% O(len(Q))
+-spec len(Q :: queue()) -> non_neg_integer().
+len({R,F}) when is_list(R), is_list(F) ->
+    length(R)+length(F).
+% len(Q) ->
+%     erlang:error(badarg, [Q]).
+
+%% O(len(Q))
+-spec to_list(Q :: queue(Item)) -> list(Item).
+to_list({In,Out}) when is_list(In), is_list(Out) ->
+    Out++lists:reverse(In, []).
+% to_list(Q) ->
+%     erlang:error(badarg, [Q]).
+
+%% Create queue from list
+%%
+%% O(length(L))
+-spec from_list(L :: list(Item)) -> queue(Item).
+from_list(L) when is_list(L) ->
+    f2r(L). %DIFF
+% from_list(L) ->
+%     erlang:error(badarg, [L]).
+
+%% Return true or false depending on if element is in queue
+%% 
+%% O(length(Q)) worst case
+-spec member(Item, Q :: queue(Item)) -> boolean().
+member(X, {R,F}) when is_list(R), is_list(F) ->
+    lists:member(X, R) orelse lists:member(X, F).
+% member(X, Q) ->
+%     erlang:error(badarg, [X,Q]).
+
+%%--------------------------------------------------------------------------
+%% Original style API
+
+%% Append to tail/rear
+%% Put at least one element in each list, if it is cheap
+%%
+%% O(1)
+-spec in(Item, Q1 :: queue(Item)) -> Q2 :: queue(Item).
+in(X, {[_]=In,[]}) ->
+    {[X], In};
+in(X, {In,Out}) when is_list(In), is_list(Out) ->
+    {[X|In],Out}.
+% in(X, Q) ->
+%     erlang:error(badarg, [X,Q]).
+
+%% Prepend to head/front
+%% Put at least one element in each list, if it is cheap
+%%
+%% O(1)
+-spec in_r(Item, Q1 :: queue(Item)) -> Q2 :: queue(Item).
+in_r(X, {[],[_]=F}) ->
+    {F,[X]};
+in_r(X, {R,F}) when is_list(R), is_list(F) ->
+    {R,[X|F]}.
+% in_r(X, Q) ->
+%     erlang:error(badarg, [X,Q]).
+
+%% Take from head/front
+%%
+%% O(1) amortized, O(len(Q)) worst case
+-spec out(Q1 :: queue(Item)) ->
+                 {{value, Item}, Q2 :: queue(Item)} |
+                 {empty, Q1 :: queue(Item)}.
+out({[],[]}=Q) ->
+    {empty,Q};
+out({[V],[]}) ->
+    {{value,V},{[],[]}};
+out({[Y|In],[]}) ->
+    [V|Out] = lists:reverse(In, []),
+    {{value,V},{[Y],Out}};
+out({In,[V]}) when is_list(In) ->
+    {{value,V},r2f(In)};
+out({In,[V|Out]}) when is_list(In) ->
+    {{value,V},{In,Out}};
+out(Q) ->
+    erlang:error(badarg, [Q]).
+
+%% Take from tail/rear
+%%
+%% O(1) amortized, O(len(Q)) worst case
+-spec out_r(Q1 :: queue(Item)) ->
+                 {{value, Item}, Q2 :: queue(Item)} |
+                 {empty, Q1 :: queue(Item)}.
+out_r({[],[]}=Q) ->
+    {empty,Q};
+out_r({[],[V]}) ->
+    {{value,V},{[],[]}};
+out_r({[],[Y|Out]}) ->
+    [V|In] = lists:reverse(Out, []),
+    {{value,V},{In,[Y]}};
+out_r({[V],Out}) when is_list(Out) ->
+    {{value,V},f2r(Out)};
+out_r({[V|In],Out}) when is_list(Out) ->
+    {{value,V},{In,Out}};
+out_r(Q) ->
+    erlang:error(badarg, [Q]).
+
+%%--------------------------------------------------------------------------
+%% Less garbage style API.
+
+%% Return the first element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec get(Q :: queue(Item)) -> Item.
+get({[],[]}=Q) ->
+    erlang:error(empty, [Q]);
+get({R,F}) when is_list(R), is_list(F) ->
+    get(R, F).
+% get(Q) ->
+%     erlang:error(badarg, [Q]).
+
+% -spec get(list(), list()) -> term().
+-spec get(list(Item), list(Item)) -> Item.
+get([_ | R], _) -> lists:last(R);
+get(_, _) -> error(todo).
+
+%% Return the last element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec get_r(Q :: queue(Item)) -> Item.
+get_r({[],[]}=Q) ->
+    erlang:error(empty, [Q]);
+get_r({[H|_],F}) when is_list(F) ->
+    H;
+get_r({[],[H]}) ->
+    H;
+get_r({[],[_|F]}) -> % malformed queue -> O(len(Q))
+    lists:last(F);
+get_r(Q) ->
+    erlang:error(badarg, [Q]).
+
+%% Return the first element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec peek(Q :: queue(Item)) -> empty | {value, Item}.
+peek({[],[]}) ->
+    empty;
+peek({R,[H|_]}) when is_list(R) ->
+    {value,H};
+peek({[H],[]}) ->
+    {value,H};
+peek({[_|R],[]}) -> % malformed queue -> O(len(Q))
+    {value,lists:last(R)};
+peek(Q) ->
+    erlang:error(badarg, [Q]).
+
+%% Return the last element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec peek_r(Q :: queue(Item)) -> empty | {value, Item}.
+peek_r({[],[]}) ->
+    empty;
+peek_r({[H|_],F}) when is_list(F) ->
+    {value,H};
+peek_r({[],[H]}) ->
+    {value,H};
+peek_r({[],[_|R]}) -> % malformed queue -> O(len(Q))
+    {value,lists:last(R)};
+peek_r(Q) ->
+    erlang:error(badarg, [Q]).
+
+%% Remove the first element and return resulting queue
+%%
+%% O(1) amortized
+-spec drop(Q1 :: queue(Item)) -> Q2 :: queue(Item).
+drop({[],[]}=Q) ->
+    erlang:error(empty, [Q]);
+drop({[_],[]}) ->
+    {[],[]};
+drop({[Y|R],[]}) ->
+    [_|F] = lists:reverse(R, []),
+    {[Y],F};
+drop({R, [_]}) when is_list(R) ->
+    r2f(R);
+drop({R, [_|F]}) when is_list(R) ->
+    {R,F};
+drop(Q) ->
+    erlang:error(badarg, [Q]).
+
+%% Remove the last element and return resulting queue
+%%
+%% O(1) amortized
+-spec drop_r(Q1 :: queue(Item)) -> Q2 :: queue(Item).
+drop_r({[],[]}=Q) ->
+    erlang:error(empty, [Q]);
+drop_r({[],[_]}) ->
+    {[],[]};
+drop_r({[],[Y|F]}) ->
+    [_|R] = lists:reverse(F, []),
+    {R,[Y]};
+drop_r({[_], F}) when is_list(F) ->
+    f2r(F);
+drop_r({[_|R], F}) when is_list(F) ->
+    {R,F};
+drop_r(Q) ->
+    erlang:error(badarg, [Q]).
+
+%%--------------------------------------------------------------------------
+%% Higher level API
+
+%% Return reversed queue
+%%
+%% O(1)
+-spec reverse(Q1 :: queue(Item)) -> Q2 :: queue(Item).
+reverse({R,F}) when is_list(R), is_list(F) ->
+    {F,R}.
+% reverse(Q) ->
+%     erlang:error(badarg, [Q]).
+
+%% Join two queues
+%%
+%% Q2 empty: O(1)
+%% else:     O(len(Q1))
+-spec join(Q1 :: queue(Item), Q2 :: queue(Item)) -> Q3 :: queue(Item).
+join({R,F}=Q, {[],[]}) when is_list(R), is_list(F) ->
+    Q;
+join({[],[]}, {R,F}=Q) when is_list(R), is_list(F) ->
+    Q;
+join({R1,F1}, {R2,F2}) when is_list(R1), is_list(F1), is_list(R2), is_list(F2) ->
+    {R2,F1++lists:reverse(R1,F2)}.
+% join(Q1, Q2) ->
+%     erlang:error(badarg, [Q1,Q2]).
+
+%% Split a queue in two
+%%
+%% N = 0..len(Q)
+%% O(max(N, len(Q)))
+-spec split(N :: non_neg_integer(), Q1 :: queue(Item)) ->
+                   {Q2 :: queue(Item),Q3 :: queue(Item)}.
+split(0, {R,F}=Q) when is_list(R), is_list(F) ->
+    {{[],[]},Q};
+split(N, {R,F}=Q) when is_integer(N), N >= 1, is_list(R), is_list(F) ->
+    Lf = erlang:length(F),
+    if  N < Lf -> % Lf >= 2
+	    [X|F1] = F,
+	    split_f1_to_r2(N-1, R, F1, [], [X]);
+        N > Lf ->
+	    Lr = length(R),
+	    M = Lr - (N-Lf),
+	    if  M < 0 ->
+		    erlang:error(badarg, [N,Q]);
+		M > 0 ->
+		    [X|R1] = R,
+		    split_r1_to_f2(M-1, R1, F, [X], []);
+		true -> % M == 0
+		    {Q,{[],[]}}
+	    end;
+	true -> % N == Lf
+	    {f2r(F),r2f(R)}
+    end;
+split(N, Q) ->
+    erlang:error(badarg, [N,Q]).
+
+-spec split_f1_to_r2(integer(), [Item], [Item], [Item], [Item]) -> {queue(Item), queue(Item)}.
+%% Move N elements from F1 to R2
+split_f1_to_r2(0, R1, F1, R2, F2) ->
+    {{R2,F2},{R1,F1}};
+split_f1_to_r2(N, R1, [X|F1], R2, F2) ->
+    split_f1_to_r2(N-1, R1, F1, [X|R2], F2).
+
+-spec split_r1_to_f2(integer(), [Item], [Item], [Item],[Item]) -> {queue(Item), queue(Item)}.
+%% Move N elements from R1 to F2
+split_r1_to_f2(0, R1, F1, R2, F2) ->
+    {{R1,F1},{R2,F2}};
+split_r1_to_f2(N, [X|R1], F1, R2, F2) ->
+    split_r1_to_f2(N-1, R1, F1, R2, [X|F2]).
+
+%% filter, or rather filtermap with insert, traverses in queue order
+%% 
+%% Fun(_) -> List: O(length(List) * len(Q))
+%% else:           O(len(Q)
+-spec filter(Fun, Q1 :: queue(Item)) -> Q2 :: queue(Item) when
+      Fun :: fun((Item) -> boolean() | list(Item)).
+filter(Fun, {R0,F0}) when is_function(Fun, 1), is_list(R0), is_list(F0) ->
+    F = filter_f(Fun, F0),
+    R = filter_r(Fun, R0),
+    if R =:= [] ->
+	    f2r(F);
+       F =:= [] ->
+	    r2f(R);
+       true ->
+	    {R,F}
+    end;
+filter(Fun, Q) ->
+    erlang:error(badarg, [Fun,Q]).
+
+-spec filter_f(Fun, Q1 :: list(Item)) -> Q2 :: list(Item) when
+      Fun :: fun((Item) -> boolean() | list(Item)).
+%% Call Fun in head to tail order
+filter_f(_, []) ->
+    [];
+filter_f(Fun, [X|F]) ->
+    case Fun(X) of
+	true ->
+	    [X|filter_f(Fun, F)];
+	[Y] ->
+	    [Y|filter_f(Fun, F)];
+	false ->
+	    filter_f(Fun, F);
+	[] ->
+	    filter_f(Fun, F);
+	L when is_list(L) ->
+	    L++filter_f(Fun, F)
+    end.
+
+-spec filter_r(Fun, Q1 :: list(Item)) -> Q2 :: list(Item) when
+      Fun :: fun((Item) -> boolean() | list(Item)).
+%% Call Fun in reverse order, i.e tail to head
+%% and reverse list result from fun to match queue order
+filter_r(_, []) ->
+    [];
+filter_r(Fun, [X|R0]) ->
+    R = filter_r(Fun, R0),
+    case Fun(X) of
+	true ->
+	    [X|R];
+	[Y] ->
+	    [Y|R];
+	false ->
+	    R;
+	[] ->
+	    R;
+	L when is_list(L) ->
+	    lists:reverse(L, R)
+    end.
+
+%% Filter and map a queue, traverses in queue order.
+%%
+%% O(len(Q1))
+-spec filtermap(Fun, Q1) -> Q2 when
+      Fun :: fun((Item) -> boolean() | {'true', Value}),
+      Q1 :: queue(Item),
+      Q2 :: queue(Item | Value),
+      Item :: term(),
+      Value :: term().
+filtermap(Fun, {R0, F0}) when is_function(Fun, 1), is_list(R0), is_list(F0) ->
+    F = lists:filtermap(Fun, F0),
+    R = filtermap_r(Fun, R0),
+    if R =:= [] ->
+	    f2r(F);
+       F =:= [] ->
+	    r2f(R);
+       true ->
+	    {R,F}
+    end;
+filtermap(Fun, Q) ->
+    erlang:error(badarg, [Fun,Q]).
+
+-spec filtermap_r(Fun, Q1) -> Q2 when
+      Fun :: fun((Item) -> boolean() | {'true', Value}),
+      Q1 :: list(Item),
+      Q2 :: list(Item | Value),
+      Item :: term(),
+      Value :: term().
+%% Call Fun in reverse order, i.e tail to head
+filtermap_r(_, []) ->
+    [];
+filtermap_r(Fun, [X|R0]) ->
+    R = filtermap_r(Fun, R0),
+    case Fun(X) of
+	true ->
+	    [X|R];
+	{true, Y} ->
+	    [Y|R];
+	false ->
+	    R
+    end.
+
+%% Fold a function over a queue, in queue order.
+%%
+%% O(len(Q))
+-spec fold(Fun, Acc0, Q :: queue(Item)) -> Acc1 when
+      Fun :: fun((Item, AccIn) -> AccOut),
+      Acc0 :: term(),
+      Acc1 :: term(),
+      AccIn :: term(),
+      AccOut :: term().
+fold(Fun, Acc0, {R, F}) when is_function(Fun, 2), is_list(R), is_list(F) ->
+    Acc1 = lists:foldl(Fun, Acc0, F),
+    lists:foldr(Fun, Acc1, R);
+fold(Fun, Acc0, Q) ->
+    erlang:error(badarg, [Fun, Acc0, Q]).
+
+%% Check if any item satisfies the predicate, traverse in queue order.
+%%
+%% O(len(Q)) worst case
+-spec any(Pred, Q :: queue(Item)) -> boolean() when
+      Pred :: fun((Item) -> boolean()).
+any(Pred, {R, F}) when is_function(Pred, 1), is_list(R), is_list(F) ->
+    lists:any(Pred, F) orelse
+    lists:any(Pred, R);
+any(Pred, Q) ->
+    erlang:error(badarg, [Pred, Q]).
+
+%% Check if all items satisfy the predicate, traverse in queue order.
+%%
+%% O(len(Q)) worst case
+-spec all(Pred, Q :: queue(Item)) -> boolean() when
+      Pred :: fun((Item) -> boolean()).
+all(Pred, {R, F}) when is_function(Pred, 1), is_list(R), is_list(F) ->
+    lists:all(Pred, F) andalso
+    lists:all(Pred, R);
+all(Pred, Q) ->
+    erlang:error(badarg, [Pred, Q]).
+
+%% Delete the first occurence of an item in the queue,
+%% according to queue order.
+%%
+%% O(len(Q1)) worst case
+-spec delete(Item, Q1) -> Q2 when
+      Item :: T,
+      Q1 :: queue(T),
+      Q2 :: queue(T),
+      T :: term().
+delete(Item, {R0, F0} = Q) when is_list(R0), is_list(F0) ->
+    case delete_front(Item, F0) of
+        false ->
+            case delete_rear(Item, R0) of
+                false ->
+                    Q;
+                [] ->
+                    f2r(F0);
+                R1 ->
+                    {R1, F0}
+            end;
+        [] ->
+            r2f(R0);
+        F1 ->
+            {R0, F1}
+    end;
+delete(Item, Q) ->
+    erlang:error(badarg, [Item, Q]).
+
+%% Delete the last occurence of an item in the queue,
+%% according to queue order.
+%%
+%% O(len(Q1)) worst case
+-spec delete_r(Item, Q1) -> Q2 when
+      Item :: T,
+      Q1 :: queue(T),
+      Q2 :: queue(T),
+      T :: term().
+delete_r(Item, {R0, F0}) when is_list(R0), is_list(F0) ->
+    {F1, R1}=delete(Item, {F0, R0}),
+    {R1, F1}.
+% delete_r(Item, Q) ->
+%     erlang:error(badarg, [Item, Q]).
+
+-spec delete_front(Item, [Item]) -> false | [Item].
+delete_front(Item, [Item|Rest]) ->
+    Rest;
+delete_front(Item, [X|Rest]) ->
+    case delete_front(Item, Rest) of
+        false -> false;
+        F -> [X|F]
+    end;
+delete_front(_, []) ->
+    false.
+
+
+-spec delete_rear(Item, [Item]) -> false | [Item].
+delete_rear(Item, [X|Rest]) ->
+    case delete_rear(Item, Rest) of
+        false when X=:=Item ->
+            Rest;
+        false ->
+            false;
+        R ->
+            [X|R]
+    end;
+delete_rear(_, []) ->
+    false.
+
+%% Delete the first occurence of an item in the queue
+%% matching a predicate, according to queue order.
+%%
+%% O(len(Q1)) worst case
+-spec delete_with(Pred, Q1) -> Q2 when
+      Pred :: fun((Item) -> boolean()),
+      Q1 :: queue(Item),
+      Q2 :: queue(Item),
+      Item :: term().
+delete_with(Pred, {R0, F0} = Q) when is_function(Pred, 1), is_list(R0), is_list(F0) ->
+    case delete_with_front(Pred, F0) of
+	false ->
+	    case delete_with_rear(Pred, R0) of
+		false ->
+		    Q;
+		[] ->
+		    f2r(F0);
+		R1 ->
+		    {R1, F0}
+	    end;
+	[] ->
+	    r2f(R0);
+	F1 ->
+	    {R0, F1}
+    end.
+% delete_with(Pred, Q) ->
+%     erlang:error(badarg, [Pred, Q]).
+
+%% Delete the last occurence of an item in the queue
+%% matching a predicate, according to queue order.
+%%
+%% O(len(Q1)) worst case
+-spec delete_with_r(Pred, Q1) -> Q2 when
+      Pred :: fun((Item) -> boolean()),
+      Q1 :: queue(Item),
+      Q2 :: queue(Item),
+      Item :: term().
+delete_with_r(Pred, {R0, F0}) when is_function(Pred, 1), is_list(R0), is_list(F0) ->
+    {F1, R1} = delete_with(Pred, {F0, R0}),
+    {R1, F1};
+delete_with_r(Pred, Q) ->
+    erlang:error(badarg, [Pred, Q]).
+
+-spec delete_with_front(Pred, Q1) -> false | Q2 when
+      Pred :: fun((Item) -> boolean()),
+      Q1 :: [Item],
+      Q2 :: [Item],
+      Item :: term().
+delete_with_front(Pred, [X|Rest]) ->
+    case Pred(X) of
+	true ->
+	    Rest;
+	false ->
+	    case delete_with_front(Pred, Rest) of
+		false ->
+		    false;
+		F ->
+		    [X|F]
+	    end
+    end;
+delete_with_front(_, []) ->
+    false.
+
+-spec delete_with_rear(Pred, R1) -> false | R2 when
+      Pred :: fun((Item) -> boolean()),
+      R1 :: [Item],
+      R2 :: [Item],
+      Item :: term().
+delete_with_rear(Pred, [X|Rest]) ->
+    case delete_with_rear(Pred, Rest) of
+	false ->
+	    case Pred(X) of
+		true ->
+		    Rest;
+		false ->
+		    false
+	    end;
+	R ->
+	    [X|R]
+    end;
+delete_with_rear(_, []) ->
+    false.
+
+%%--------------------------------------------------------------------------
+%% Okasaki API inspired by an Erlang user contribution "deque.erl" 
+%% by Claes Wikstrom <klacke@kaja.klacke.net> 1999.
+%%
+%% This implementation does not use the internal data format from Klacke's
+%% doubly ended queues that was "shamelessly stolen" from 
+%% "Purely Functional Data structures" by Chris Okasaki, since the data
+%% format of this module must remain the same in case some application
+%% has saved a queue in external format or sends it to an old node.
+%%
+%% This implementation tries to do the best of the situation and should 
+%% be almost as efficient as Okasaki's queues, except for len/1 that
+%% is O(n) in this implementation instead of O(1).
+%%
+%% The new representation in this module again adds length field and
+%% fixes this, but it is not yet default.
+%%
+%% The implementation keeps at least one element in both the forward
+%% and the reversed lists to ensure that i.e head/1 or last/1 will
+%% not have to reverse a list to find the element.
+%%
+%% To be compatible with the old version of this module, as much data as 
+%% possible is moved to the receiving side using lists:reverse/2 when data
+%% is needed, except for two elements (when possible). These two elements
+%% are kept to prevent alternating tail/1 and init/1 operations from 
+%% moving data back and forth between the sides.
+%%
+%% An alternative would be to balance for equal list length when one side
+%% is exhausted. Although this could be better for a general double
+%% ended queue, it would more han double the amortized cost for 
+%% the normal case (one way queue).
+
+%% Cons to head
+%%
+-spec cons(Item, Q1 :: queue(Item)) -> Q2 :: queue(Item).
+cons(X, Q) ->
+    in_r(X, Q).
+
+%% Return head element
+%%
+%% Return the first element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec head(Q :: queue(Item)) -> Item.
+head({[],[]}=Q) ->
+    erlang:error(empty, [Q]);
+head({R,F}) when is_list(R), is_list(F) ->
+    get(R, F).
+% head(Q) ->
+%     erlang:error(badarg, [Q]).
+
+%% Remove head element and return resulting queue
+%%
+-spec tail(Q1 :: queue(Item)) -> Q2 :: queue(Item).
+tail(Q) ->
+    drop(Q).
+
+%% Functions operating on the other end of the queue
+
+%% Cons to tail
+%%
+-spec snoc(Q1 :: queue(Item), Item) -> Q2 :: queue(Item).
+snoc(Q, X) ->
+    in(X, Q).
+
+%% Return last element
+-spec daeh(Q :: queue(Item)) -> Item.
+daeh(Q) -> get_r(Q).
+-spec last(Q :: queue(Item)) -> Item.
+last(Q) -> get_r(Q).
+
+%% Remove last element and return resulting queue
+-spec liat(Q1 :: queue(Item)) -> Q2 :: queue(Item).
+liat(Q) -> drop_r(Q).
+-spec lait(Q1 :: queue(Item)) -> Q2 :: queue(Item).
+lait(Q) -> drop_r(Q). %% Oops, mis-spelled 'tail' reversed. Forget this one.
+-spec init(Q1 :: queue(Item)) -> Q2 :: queue(Item).
+init(Q) -> drop_r(Q).
+
+%%--------------------------------------------------------------------------
+%% Internal workers
+
+-compile({inline, [{r2f,1},{f2r,1}]}).
+
+-spec r2f([Item]) -> queue(Item).
+%% Move half of elements from R to F, if there are at least three
+r2f([]) ->
+  erlang:'div'(1,2),
+    {[],[]};
+r2f([_]=R) ->
+    {[],R};
+r2f([X,Y]) ->
+    {[X],[Y]};
+r2f(List) ->
+    {FF,RR} = lists:split(length(List) div 2 + 1, List),
+    {FF,lists:reverse(RR, [])}.
+
+%% Move half of elements from F to R, if there are enough
+-spec f2r([Item]) -> queue(Item).
+f2r([]) ->
+    {[],[]};
+f2r([_]=F) ->
+    {F,[]};
+f2r([X,Y]) ->
+    {[Y],[X]};
+f2r(List) ->
+    {FF,RR} = lists:split(length(List) div 2 + 1, List),
+    {lists:reverse(RR, []),FF}.


### PR DESCRIPTION
Follow up to #232 

* Added `queue.erl` and `ordsets.erl` from stdlib to case study
* Refined `NumOpTy` type operator definition in `stdtypes.erl`, with a quick fix for #235 
* Fixed type specs of `quit/2` and `quit/3` found by case study
* Added missing `ast_lib.erl` to case study
* Reordered `check.sh`
* Added some type to the case study overlay
* Default record values for one more function
* Quick fix for #237 for case study