### PR TITLE
Better error codes

### DIFF
--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -95,7 +95,7 @@ mk_union(Tys) ->
                     fun(T) ->
                         case T of
                             {predef, none} -> false;
-                            [] -> error(Tys);
+                            [] -> errors:bug(utils:sformat("~w", Tys));
                             _ -> true
                         end
                     end,
@@ -133,7 +133,7 @@ erlang_ty_to_ast(X) ->
         %   io:format(user, "~p => ~p~n", [X, ty_ref:load(X)]),
         %   io:format(user, "~p~n", [FinalTy]),
           raw_erlang_ty_to_ast(X), % check if this is really a pretty printing bug or a transformation bug
-          error(pretty_printing_bug)
+          errors:bug("Pretty printing bug")
       end,
 
     FinalTy.
@@ -357,7 +357,7 @@ parse_ast_to_erlang_ty(Ty = {mu, Var, InnerTy}, Sym) ->
     end;
 
 parse_ast_to_erlang_ty(T, _Sym) ->
-    erlang:error({"Norm not implemented or malformed type", T}).
+    errors:bug({"Norm not implemented or malformed type", T}).
 
 
 -spec ast_to_erlang_ty_var(ast:ty_var()) -> ty_variable:var().
@@ -380,7 +380,7 @@ raw_erlang_ty_to_ast(X) ->
             % io:format(user, "--------~n", []),
             % io:format(user, "~p => ~p~n", [X, ty_ref:load(X)]),
             % io:format(user, "~p~n", [FinalTy]),
-            error(raw_printing_bug)
+            errors:bug("Raw printing bug")
       end,
       
     FinalTy.

--- a/src/erlang_types/ast_to_erlang_ty.erl
+++ b/src/erlang_types/ast_to_erlang_ty.erl
@@ -286,7 +286,7 @@ do_convert({{mu, RecVar, Ty}, R}, Q, Sym, M) ->
   {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}};
 
 do_convert(T, _Q, _Sym, _M) ->
-  erlang:error({"Transformation from ast:ty() to ty_rec:ty() not implemented or malformed type", T}).
+  errors:bug({"Transformation from ast:ty() to ty_rec:ty() not implemented or malformed type", T}).
 
 
 -spec unify(temporary_ref(), result()) -> {temporary_ref(), #{temporary_ref() => ty_rec()}}.

--- a/src/erlang_types/dnf_ty_interval.erl
+++ b/src/erlang_types/dnf_ty_interval.erl
@@ -8,7 +8,7 @@
 
 -export([empty/0, any/0]).
 -export([union/2, intersect/2, diff/2, negate/1, is_any/1]).
--export([is_empty/1, eval/1, normalize_corec/5, substitute/4, all_variables/2, to_singletons/1]).
+-export([is_empty/1, normalize_corec/5, substitute/4, all_variables/2, to_singletons/1]).
 
 
 -export([interval/2, cointerval/2]).
@@ -46,9 +46,6 @@ to_singletons(_) ->
 %% representation
 %% left? range* right?
 
-
-% TODO witness
-eval(_) -> erlang:error("TODO").
 
 empty() -> [].
 any() -> [any_int].

--- a/src/erlang_types/dnf_ty_predef.erl
+++ b/src/erlang_types/dnf_ty_predef.erl
@@ -6,7 +6,7 @@
 
 -export([empty/0, any/0]).
 -export([union/2, intersect/2, diff/2, negate/1, is_any/1]).
--export([is_empty/1, eval/1, normalize_corec/5, substitute/4]).
+-export([is_empty/1, normalize_corec/5, substitute/4]).
 
 -export([has_ref/2, predef/1, raw_transform/2, transform/2, all_variables/2]).
 
@@ -32,8 +32,6 @@ transform(All = [Predef | Others], Ops = #{union := U, any := A}) ->
 transform_single(Predef, #{to_predef := P}) ->
     P(Predef).
 
-% TODO witness
-eval(_) -> erlang:error("TODO").
 
 empty() -> [].
 any() -> [ '[]', float, pid, port, reference ].

--- a/src/erlang_types/ty_map.erl
+++ b/src/erlang_types/ty_map.erl
@@ -37,7 +37,7 @@ split_into_associations({fun_simple}, OnlyOptional) ->
             [{map_field_opt, X, Y} || {tuple, [X, Y]} <- Tuples];
         Got -> 
             io:format(user,"Got:~p~n", [Got]),
-            error(sanity_not_implemented)
+            errors:bug("Internal map representation error")
     end;
 split_into_associations({intersection, Funs}, {union, Tups}) ->
     RawFun = [{A, B} || {fun_full, [A], B} <- Funs],
@@ -51,7 +51,7 @@ split_into_associations(F = {fun_full, [_], _}, T = {tuple, [_, _]}) ->
 split_into_associations(Mandatory, MandatoryAndOptional) ->
     io:format(user,"Mandatory: ~p~n", [Mandatory]),
     io:format(user,"Mandatory and opt: ~p~n", [MandatoryAndOptional]),
-    error(illegal_internal_map_representation).
+    errors:bug("Illegal internal map representation").
 
 substitute({ty_tuple, Dim, Refs}, Map, Memo) ->
     {ty_tuple, Dim, [ ty_rec:substitute(B, Map, Memo) || B <- Refs ] }.

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -7,7 +7,7 @@
 -export([is_empty_corec/2, normalize_corec/3]).
 
 -export([empty/0, any/0]).
--export([union/2, negate/1, intersect/2, diff/2, is_any/1]).
+-export([union/2, negate/1, intersect/2, diff/2]).
 -export([tuple_keys/1, function_keys/1]).
 
 % additional type constructors (hash consed)
@@ -624,9 +624,6 @@ is_empty_corec(TyRef, M) ->
         andalso ty_functions:is_empty_corec(Ty#ty.function, MNew)
         andalso dnf_var_ty_map:is_empty_corec(Ty#ty.map, MNew)
   end.
-
-is_any(_Arg0) ->
-  erlang:error(any_not_implemented). % TODO needed?
 
 normalize_start(TyRef, Fixed) ->
   % first try op-cache

--- a/src/etylizer_main.erl
+++ b/src/etylizer_main.erl
@@ -189,6 +189,13 @@ main(Args) ->
                     ?LOG_ERROR("~s", Raw),
                     io:format("~s~n", [Msg])
             end,
-            erlang:halt(1)
+            case K of
+              ty_error -> erlang:halt(1);
+              name_error -> erlang:halt(1);
+              parse_error -> erlang:halt(1);
+              unsupported -> erlang:halt(5);
+              not_implemented -> erlang:halt(5);
+              _ -> erlang:halt(2)
+            end
     end,
     ok.

--- a/src/subst.erl
+++ b/src/subst.erl
@@ -194,4 +194,4 @@ collect_vars({var, Name}, CPos, Pos, Fix) ->
     end;
 collect_vars(Ty, _, _, _) ->
     logger:error("Unhandled collect vars branch: ~p", [Ty]),
-    throw({todo_collect_vars, Ty}).
+    errors:bug("Unhandled collect vars branch").

--- a/src/test_utils.erl
+++ b/src/test_utils.erl
@@ -156,8 +156,8 @@ to_cduce({union, X}) -> "(" ++ lists:join(" | ", [to_cduce(Z) || Z <- X]) ++ ")"
 to_cduce({var, Name}) -> to_var({var, Name});
 to_cduce({named, _, _, _}) -> "NAMED";
 to_cduce({fun_full, [S], T}) -> io_lib:format("(~s -> ~s)", [to_cduce(S), to_cduce(T)]);
-to_cduce(Ast) ->
-    error({construct_not_supported, Ast}).
+to_cduce(_Ast) ->
+    errors:not_implemented("Cduce construct not supported").
 
 % we use $ in the variable name which is not a valid character in OCaml
 % replace this with some other character


### PR DESCRIPTION
Exit codes now depend on the error kind.

* 1: type error
* 2: unknown, bug
* 5: not implemented features

`erlang_types` sub-library now depends on the `errors` module.