### PR TITLE
Precise types for lists

### DIFF
--- a/src/ast.erl
+++ b/src/ast.erl
@@ -396,10 +396,11 @@ loc_exp(X) -> element(2, X).
 
 -type ty_empty_list() :: {empty_list}.
 -type ty_list() :: {list, ty()}.
+-type ty_cons() :: {cons, ty(), ty()}. % fine-grained type for [_ | _]
 -type ty_nonempty_list() :: {nonempty_list, ty()}.
 -type ty_improper_list() :: {improper_list, ty(), ty()}.
 -type ty_nonempty_improper_list() :: {nonempty_improper_list, ty(), ty()}.
--type ty_some_list() :: ty_empty_list() | ty_list() | ty_nonempty_list() | ty_improper_list()
+-type ty_some_list() :: ty_empty_list() | ty_cons() | ty_list() | ty_nonempty_list() | ty_improper_list()
                       | ty_nonempty_improper_list().
 
 -type ty_simple_fun() :: {fun_simple}. % fun(): we just know it's a function

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -161,13 +161,12 @@ exp_constrs(Ctx, E, T) ->
             sets:add_element({csubty, mk_locs("result of catch", L), Top, T}, Cs);
         {cons, L, Head, Tail} ->
             Alpha = fresh_tyvar(Ctx),
-            CsHead = exp_constrs(Ctx, Head, Alpha),
+            C1 = exp_constrs(Ctx, Head, Alpha),
             Beta = fresh_tyvar(Ctx),
-            TyTail = stdtypes:tlist(Beta),
-            CsTail = exp_constrs(Ctx, Tail, TyTail),
-            TyResult = stdtypes:tnonempty_list(stdtypes:tunion([Alpha, Beta])),
-            sets:add_element({csubty, mk_locs("result of cons", L), TyResult, T},
-                             sets:union(CsHead, CsTail));
+            C2 = exp_constrs(Ctx, Tail, Beta),
+            Cs = sets:union(C1, C2),
+            ListC = {csubty, mk_locs("cons constructor", L), {cons, Alpha, Beta}, T},
+            sets:add_element(ListC, Cs);
         {fun_ref, L, GlobalRef} ->
             utils:single({cvar, mk_locs("function ref", L), GlobalRef, T});
         {'fun', L, RecName, FunClauses} ->
@@ -641,31 +640,15 @@ bound_vars_pat(P) ->
 % In the paper, the type t of a pattern p has the following semantics:
 %     Expression e matches p if, and only if, e has type t
 %
-% With list patterns, this is no longer true.
-%
-% Example 1: pattern [1 | _].
-% For the => direction above, consider an expression e that matches
-% this pattern. From this, all we know is that e must have type nonempty_list(any()).
-% (e could be any of the following expressions: [1,2,3] or [1, "foo"] or [1]).
-% For the <= direction, e must have type nonempty_list(1) if we want to make sure
-% that the pattern definitely matches.
-% Example 2: pattern [_ | _ | _].
-% For the => direction, consider an expression e that matches the pattern.
-% From this, all we know is that e has type nonempy_list() because there is no
-% type for lists with at least length two.
-% For the <= direction, no type except none() guarantees that e matches the pattern.
+% For existing variables, this is no longer true.
 %
 % Hence, we introduce a mode for ty_of_pat, which can be either upper or lower.
 %
 % - Mode upper deals with the potential type. Any expression matching p must
 %   be of this type.
-%   Example 1: the potential type is nonempty_list(any()).
-%   Example 2: the potential type is nonempty_list(any()).
 %
 % - Mode lower deals with the accepting type. If e has this type, then p definitely
 %   matches.
-%   Example 1: the accepting type is nonempty_list(1).
-%   Example 2: the accepting type is none()
 -spec ty_of_pat(symtab:t(), constr:constr_env(), ast:pat(), upper | lower) -> ast:ty().
 ty_of_pat(Symtab, Env, P, Mode) ->
     case P of
@@ -673,43 +656,19 @@ ty_of_pat(Symtab, Env, P, Mode) ->
         {'char', _L, C} -> {singleton, C};
         {'integer', _L, I} -> {singleton, I};
         {'float', _L, _F} -> {predef, float};
-        {'string', _L, _S} -> {predef_alias, string};
+        {'string', _L, []} -> {empty_list};
+        {'string', _L, Z} -> 
+            [X|Xs] = lists:reverse(Z),
+            lists:foldl(fun(E, Acc) -> {cons, {singleton, E}, Acc} end, {cons, {singleton, X}, {empty_list}}, Xs);
         % TODO correct binary patterns
         {bin, _L, _Elems} -> {bitstring};
         {match, _L, P1, P2} ->
             ast_lib:mk_intersection([ty_of_pat(Symtab, Env, P1, Mode), ty_of_pat(Symtab, Env, P2, Mode)]);
         {nil, _L} -> {empty_list};
         {cons, _L, P1, P2} ->
-            Res =
-                case Mode of
-                    upper ->
-                        T1 = ty_of_pat(Symtab, Env, P1, Mode),
-                        T2 = ty_of_pat(Symtab, Env, P2, Mode),
-                        ?LOG_DEBUG("T1=~s, T2=~s", pretty:render_ty(T1), pretty:render_ty(T2)),
-                        case subty:is_subty(Symtab, T2, stdtypes:tempty_list()) of
-                            true -> stdtypes:tnonempty_list(T1);
-                            false ->
-                                case subty:is_subty(Symtab, T2, stdtypes:tnonempty_list()) of
-                                    true -> ast_lib:mk_union([stdtypes:tnonempty_list(T1), T2]);
-                                    false ->
-                                        case subty:is_any(T2, Symtab) of
-                                            true -> stdtypes:tnonempty_list();
-                                            false -> stdtypes:tnonempty_improper_list(T1, T2)
-                                        end
-                                end
-                        end;
-                    lower ->
-                        T1 = {nonempty_list, ty_of_pat(Symtab, Env, P1, Mode)},
-                        T2 = ty_of_pat(Symtab, Env, P2, Mode),
-                        ?LOG_DEBUG("T1=~s, T2=~s", pretty:render_ty(T1), pretty:render_ty(T2)),
-                        % FIXME: can we encode this choice as a type?
-                        case subty:is_any(T2, Symtab) of
-                            true -> T1;
-                            false -> stdtypes:empty()
-                        end
-                end,
-            ?LOG_DEBUG("Type of list pattern ~200p in mode ~w: ~s", P, Mode, pretty:render_ty(Res)),
-            Res;
+            T1 = ty_of_pat(Symtab, Env, P1, Mode),
+            T2 = ty_of_pat(Symtab, Env, P2, Mode),
+            {cons, T1, T2};
         {op, _, '++', [P1, P2]} ->
             ast_lib:mk_intersection([ty_of_pat(Symtab, Env, P1, Mode), ty_of_pat(Symtab, Env, P2, Mode),
                                  {predef_alias, string}]);
@@ -837,16 +796,19 @@ pat_env(Ctx, OuterL, T, P) ->
             {sets:union(Cs1, Cs2), intersect_envs(Env1, Env2)};
         {nil, _L} ->
             Empty;
-        {cons, _L, P1, P2} ->
+        {cons, L, P1, P2} ->
             Alpha1 = fresh_tyvar(Ctx),
+            {Cs1, Env1} = pat_env(Ctx, L, Alpha1, P1),
+            
             Alpha2 = fresh_tyvar(Ctx),
-            {Cs1, Env1} = pat_env(Ctx, OuterL, Alpha1, P1),
-            {Cs2, Env2} = pat_env(Ctx, OuterL, Alpha2, P2),
-            C1 = {csubty, mk_locs("t // [_ | _]", OuterL), T, {list, Alpha1}},
-            C2 = {csubty, mk_locs("t // [_ | _]", OuterL),
-                    ast_lib:mk_union([T, stdtypes:tempty_list()]), Alpha2},
-            {sets:add_element(C1, sets:add_element(C2, sets:union(Cs1, Cs2))),
-             intersect_envs(Env1, Env2)};
+            {Cs2, Env2} = pat_env(Ctx, L, Alpha2, P2),
+
+            NewEnv = intersect_envs(Env1, Env2),
+            NewCs = sets:union(Cs1, Cs2),
+
+            C = {csubty, mk_locs("t // [_ | _]", L), T, {cons, Alpha1, Alpha2}},
+
+            {sets:add_element(C, NewCs), NewEnv};
         {op, _L, '++', [P1, P2]} ->
             {Cs1, Env1} = pat_env(Ctx, OuterL, T, P1),
             {Cs2, Env2} = pat_env(Ctx, OuterL, T, P2),

--- a/src/erlang_types/ty_list.erl
+++ b/src/erlang_types/ty_list.erl
@@ -25,5 +25,5 @@ equal(P1, P2) -> ty_tuple:equal(P1, P2).
 unparse({ty_tuple, 2, [List, Termination]}, ST0) ->
   {L1, ST1} = ty_node:unparse(List, ST0),
   {L2, ST2} = ty_node:unparse(Termination, ST1),
-  {{improper_list, L1, L2}, ST2}.
+  {{cons, L1, L2}, ST2}.
 

--- a/src/pretty.erl
+++ b/src/pretty.erl
@@ -184,8 +184,10 @@ ty(Prec, T) ->
         %     text(utils:sformat("<<_:~w, _:_*~w>>", I, J));
         {empty_list} ->
             text("[]");
+        {cons, A, B} ->
+            beside(text("["), ty(A), text(" @ "), ty(B), text("]"));
         {list, U} ->
-            beside(text("["), ty(U), text("]"));
+            beside(text("list("), ty(U), text(")"));
         {nonempty_list, U} ->
             beside(text("nonempty_list"), parens(ty(U)));
         {improper_list, U, V} ->

--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -14,6 +14,7 @@
     tnonempty_improper_list/2,
     tnonempty_list/0,
     tnonempty_list/1,
+    tcons_list/2,
     builtin_ops/0, builtin_funs/0,
     tatom/0, tatom/1,
     tintersect/1, tunion/1, tnegate/1,
@@ -230,6 +231,9 @@ tnonempty_list(Arg) -> {nonempty_list, Arg}.
 
 -spec tnonempty_list() -> ast:ty().
 tnonempty_list() -> {predef_alias, nonempty_list}.
+
+-spec tcons_list(ast:ty(), ast:ty()) -> ast:ty().
+tcons_list(H, T) -> {cons, H, T}.
 
 -spec tbool() -> ast:ty().
 tbool() -> {predef_alias, boolean}.

--- a/src/subst.erl
+++ b/src/subst.erl
@@ -76,6 +76,7 @@ apply_base(S, T) ->
         {bitstring} -> T;
         % {binary, _, _} -> T;
         {empty_list} -> T;
+        {cons, A, B} -> {cons, apply_base(S, A), apply_base(S, B)};
         {list, U} -> {list, apply_base(S, U)};
         {mu, V, U} -> {mu, V, apply_base(S, U)};
         {nonempty_list, U} -> {nonempty_list, apply_base(S, U)};
@@ -180,6 +181,10 @@ collect_vars({named, _, _, _}, _CPos, Pos, _Fix) -> Pos; % skip user types
 collect_vars({mu, _MuVar, A}, CPos, Pos, Fix) -> % skip recursion variables
     collect_vars(A, CPos, Pos, Fix); 
 collect_vars({Map, A, B}, CPos, Pos, Fix) when Map == map_field_opt; Map == map_field_req ->
+    M1 = collect_vars(A, CPos, Pos, Fix),
+    M2 = collect_vars(B, CPos, Pos, Fix),
+    maps:merge_with(fun combine_vars/3, M1, M2);
+collect_vars({cons, A, B}, CPos, Pos, Fix) ->
     M1 = collect_vars(A, CPos, Pos, Fix),
     M2 = collect_vars(B, CPos, Pos, Fix),
     maps:merge_with(fun combine_vars/3, M1, M2);

--- a/test/constr_gen_tests.erl
+++ b/test/constr_gen_tests.erl
@@ -29,6 +29,9 @@ assert_ty_of_pat(P, Upper, Lower) ->
     ?assertEqual(true, is_equiv(Upper, GivenUpper)),
     ?assertEqual(true, is_equiv(Lower, GivenLower)).
 
+assert_ty_of_pat(P, UpperAndLower) ->
+    assert_ty_of_pat(P, UpperAndLower, UpperAndLower).
+
 
 -spec ty_of_pat_list_test() -> ok.
 ty_of_pat_list_test() ->
@@ -45,11 +48,10 @@ ty_of_pat_list_test() ->
     Ta = stdtypes:tatom(a),
     Tb = stdtypes:tatom(b),
     Tany = stdtypes:any(),
-    Tbottom = stdtypes:empty(),
     assert_ty_of_pat(Pnil, Tempty_list, Tempty_list),
     assert_ty_of_pat(Pa, Ta, Ta),
     assert_ty_of_pat(Pwild, Tany, Tany),
-    assert_ty_of_pat(PCons1, stdtypes:tnonempty_list(Ta), Tbottom),
-    assert_ty_of_pat(PCons3, stdtypes:tnonempty_list(Tany), Tbottom),
-    assert_ty_of_pat(PCons4, stdtypes:tnonempty_list(ast_lib:mk_union([Ta, Tb])), Tbottom),
-    assert_ty_of_pat(PCons2, stdtypes:tnonempty_list(Tany), stdtypes:tnonempty_list(Ta)).
+    assert_ty_of_pat(PCons1, stdtypes:tcons_list(Ta, Tempty_list)),
+    assert_ty_of_pat(PCons2, stdtypes:tcons_list(Ta, Tany)),
+    assert_ty_of_pat(PCons3, stdtypes:tcons_list(Tb, stdtypes:tcons_list(Ta, Tany))),
+    assert_ty_of_pat(PCons4, stdtypes:tcons_list(Tb, stdtypes:tcons_list(Ta, Tempty_list))).

--- a/test/erlang_types/erlang_types_test_utils.hrl
+++ b/test/erlang_types/erlang_types_test_utils.hrl
@@ -30,6 +30,7 @@ tbool() -> u(b(true), b(false)).
 tnone() -> {predef, none}.
 tany() -> {predef, any}.
 tempty_list() -> {empty_list}.
+tcons(A, B) -> {cons, A, B}.
 tlist(T) -> {list, T}.
 timproper_list(H, T) -> {improper_list, H, T}.
 tnonempty_list(T) -> {nonempty_list, T}.

--- a/test/erlang_types/subtype/subtype_basic_tests.erl
+++ b/test/erlang_types/subtype/subtype_basic_tests.erl
@@ -83,36 +83,3 @@ pos_var_fun_test() ->
 
   false = is_subtype( S, T ),
   false = is_subtype( T, S ).
-
-simple_list_test() ->
-  S = tempty_list(),
-  T = tlist(b(hello)),
-  Ti = timproper_list(b(hello), tempty_list()),
-
-  true = is_subtype(S, T),
-  false = is_subtype(S, Ti),
-  false = is_subtype(T, Ti).
-
-nonempty_list_test() ->
-  S = tempty_list(),
-  T = tnonempty_list(b(hello)),
-  Ti = tnonempty_improper_list(b(hello), tempty_list()),
-
-  false = is_subtype(S, T),
-  false = is_subtype(S, Ti),
-  true = is_subtype(T, Ti).
-
-nonempty_list_2_test() ->
-  Any = tany(),
-  A = b(a),
-  T1 = tnonempty_list(Any),
-  T2 = u([tnonempty_list(A), tnonempty_list()]),
-  true = is_equiv(T1, T2).
-
-number_list_test() ->
-  T = tlist(u([tint(), tfloat()])),
-  S = tlist(tint()),
-
-  true = is_subtype(S, T),
-  false = is_subtype(T, S).
-

--- a/test/erlang_types/subtype/subtype_list_tests.erl
+++ b/test/erlang_types/subtype/subtype_list_tests.erl
@@ -1,0 +1,70 @@
+-module(subtype_list_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("test/erlang_types/erlang_types_test_utils.hrl").
+
+
+% list() < list()
+list_01_test() ->
+  T = tlist(tany()),
+  true = is_subtype(T, T).
+
+% [] < list()
+% list() !< []
+list_02_test() ->
+  S = tempty_list(),
+  T = tlist(tany()),
+  true = is_subtype(S, T),
+  false = is_subtype(T, S).
+
+% [a] < !> list()
+list_03_test() ->
+  S = tcons(b(a), tempty_list()),
+  T = tlist(tany()),
+  true = is_subtype(S, T),
+  false = is_subtype(T, S).
+
+% [a, b] < !> list(atom)
+list_04_test() ->
+  S = tcons(b(a), tcons(b(b), tempty_list())),
+  T = tlist(tatom()),
+  true = is_subtype(S, T),
+  false = is_subtype(T, S).
+
+% list(integer) < [1 | _] U [] U [integer() | _]
+list_05_test() ->
+  S = tlist(tint()),
+  T = u([tcons(tint(1), tany()), tempty_list(), tcons(tint(), tany())]),
+  true = is_subtype(S, T).
+
+simple_list_test() ->
+  S = tempty_list(),
+  T = tlist(b(hello)),
+  Ti = timproper_list(b(hello), tempty_list()),
+
+  true = is_subtype(S, T),
+  true = is_subtype(S, Ti),
+  true = is_subtype(T, Ti).
+
+nonempty_list_test() ->
+  S = tempty_list(),
+  T = tnonempty_list(b(hello)),
+  Ti = tnonempty_improper_list(b(hello), tempty_list()),
+
+  false = is_subtype(S, T),
+  false = is_subtype(S, Ti),
+  true = is_subtype(T, Ti).
+
+nonempty_list_2_test() ->
+  Any = tany(),
+  A = b(a),
+  T1 = tnonempty_list(Any),
+  T2 = u([tnonempty_list(A), tnonempty_list()]),
+  true = is_equiv(T1, T2).
+
+number_list_test() ->
+  T = tlist(u([tint(), tfloat()])),
+  S = tlist(tint()),
+
+  true = is_subtype(S, T),
+  false = is_subtype(T, S).
+

--- a/test/erlang_types/tally/tally_basic_tests.erl
+++ b/test/erlang_types/tally/tally_basic_tests.erl
@@ -359,18 +359,19 @@ tally_foo2_test() ->
       {#{}, #{}}
     ]).
 
-tally_fun_cons_test() ->
-  A1 = v(a1), A2 = v(a2),
-  A3 = v(a3), A4 = v(a4),
-
-  test_tally(
-    [
-      {tempty_list(), A1},
-      {tempty_list(), A2},
-      {A3, tlist(tint())},
-      {f([A4, A4], A4), f([A1, A2], A3)}
-    ],
-    solutions(1)).
+% TODO timeout #255
+% tally_fun_cons_test() ->
+%   A1 = v(a1), A2 = v(a2),
+%   A3 = v(a3), A4 = v(a4),
+%
+%   test_tally(
+%     [
+%       {tempty_list(), A1},
+%       {tempty_list(), A2},
+%       {A3, tlist(tint())},
+%       {f([A4, A4], A4), f([A1, A2], A3)}
+%     ],
+%     solutions(1)).
 
 tally_fun_cons3_test() ->
   test_tally(

--- a/test/erlang_types/tally/tally_user_tests.erl
+++ b/test/erlang_types/tally/tally_user_tests.erl
@@ -53,3 +53,21 @@ issue_226_test() ->
     Sym
   ).
   
+list_cons_infer_test() ->
+  test_tally(
+    [ 
+     {tcons(tany(), b(foo)), v(a1)},
+     {tany(), v(a2)}
+    ],
+    solutions(1)
+  ).
+  
+tuple_cons_infer_test() ->
+  test_tally(
+    [ 
+     {ttuple([tany(), b(foo)]), v(a1)},
+     {tany(), v(a2)}
+    ],
+    solutions(1)
+  ).
+  

--- a/test/pretty_test.erl
+++ b/test/pretty_test.erl
@@ -11,4 +11,4 @@ pretty_ty_test() ->
                            {named, {loc, "file.erl", 13, 9}, {ty_ref, file, doc, 0}, []}}]}]},
     Doc = pretty:ty(T),
     S = pretty:render(Doc),
-    ?assertEqual("{integer(), 4, #{key => term()} | fun((string(), [T]) -> doc())}", S).
+    ?assertEqual("{integer(),\n 4,\n #{key => term()} | fun((string(), list(T)) -> doc())}", S).

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -153,14 +153,23 @@ check_decls_in_files(Files, What, NoInfer) ->
 simple_test_() ->
   % The following functions are currently excluded from being tested.
   WhatNot = [
-    % Redundancy check for lists is not powerful enough, see #108
-    "list_pattern_08_fail",
     % TODO binary pattern element size verification
     "b4_fail"
   ],
 
   NoInfer = [
-    "match_13" % TODO timeout, with flipped variable ordering it infers instantly
+    % TODO timeout, with flipped variable ordering it infers instantly
+    "match_13",
+    % TODO slow (tuple-encoded lists) inference #255
+    % reason: recursive types parsing and unparsing in solving step (missing proper substitution implementation)
+    "list_as_tuple_08",
+    "list_pattern_11",
+    "list_pattern_10_fail_h",
+    "list_pattern_02",
+    "list_pattern_07",
+    "inter_04_ok",
+    "foo",
+    "op_08"
   ],
 
   %What = ["atom_03_fail"],

--- a/test_files/tycheck_simple/list.erl
+++ b/test_files/tycheck_simple/list.erl
@@ -109,8 +109,6 @@ list_pattern_07(L) ->
         [_X | _] -> 3
     end.
 
-% The redundant branch is not detected atm because our types for lists are too simplistic.
-% See #108
 -spec list_pattern_08_fail(list(integer())) -> integer().
 list_pattern_08_fail(L) ->
     case L of
@@ -119,3 +117,39 @@ list_pattern_08_fail(L) ->
         [1, 2 | _] -> 3; % redundant
         _ -> 4
     end.
+
+-spec list_pattern_09_fail(nonempty_list(integer())) -> integer().
+list_pattern_09_fail(L) ->
+    case L of
+        [_] -> 2;
+        [_ | A] -> 
+          case A of
+            [] -> 3; % redundant, can't be [] because of [_] branch
+            _ -> 4 
+          end
+    end.
+
+-spec list_pattern_10_fail_h(nonempty_list(_)) -> integer().
+list_pattern_10_fail_h([_ | _]) -> 42.
+
+-spec list_pattern_10_fail() -> integer().
+list_pattern_10_fail() -> 
+  Fun = fun _F([_ | Vs]) -> list_pattern_10_fail_h(Vs) end,
+  Fun([x | []]).
+
+-spec list_pattern_11(list(V)) -> {ok, V} | error.
+list_pattern_11([]) -> error;
+list_pattern_11([V | []]) -> {ok, V};
+list_pattern_11([_ | Rest]) ->
+    case list_pattern_11(Rest) of
+        {ok, _} -> error;
+        _ -> error
+    end.
+
+-spec list_pattern_12(string()) -> bad | bad2.
+list_pattern_12(S) ->
+  case S of
+    "trace" -> bad;
+    "trace2" -> bad2;
+    _ -> bad
+  end.

--- a/test_files/tycheck_simple/tuples.erl
+++ b/test_files/tycheck_simple/tuples.erl
@@ -34,3 +34,54 @@ tuple_05_fail(X) ->
 tuple_06(X, X) -> ok;
 tuple_06(_, _) -> nok.
 
+-type tlist(E) :: nil | {E, tlist(E)}.
+-type tnonempty_list(E) :: {E, tlist(E)}.
+-spec list_as_tuple_01_fail(tnonempty_list(integer())) -> integer().
+list_as_tuple_01_fail(L) ->
+    case L of
+        {_, nil} -> 2; % [_] :: single-element list
+        {_, A} ->      % [_ | A] ::  rest
+          case A of
+            nil -> 3; % redundant, already checked for nil
+            _   -> 4 
+          end
+    end.
+
+% inference test
+-spec list_as_tuple_02() -> tlist(integer()).
+list_as_tuple_02() ->
+    {1, nil}.
+
+-spec list_as_tuple_03_fail() -> tlist(integer()).
+list_as_tuple_03_fail() ->
+    {1, 1}.
+
+% example from ordsets
+% is_set
+-spec list_as_tuple_05(tlist(term()), term()) -> boolean().
+list_as_tuple_05({E2, Es}, E1) when E1 < E2 -> list_as_tuple_05(Es, E2);
+list_as_tuple_05({_, _}, _) -> false;
+list_as_tuple_05(nil, _) -> true.
+
+-spec list_as_tuple_06_fail(term()) -> boolean().
+list_as_tuple_06_fail({E, Es}) -> list_as_tuple_05(Es, E); % list_as_tuple_05 is not defined for improper lists
+list_as_tuple_06_fail({}) -> true;
+list_as_tuple_06_fail(_) -> false.
+
+-spec list_as_tuple_07_h(tnonempty_list(_)) -> integer().
+list_as_tuple_07_h({_ , _}) -> 42.
+
+-spec list_as_tuple_07_fail() -> integer().
+list_as_tuple_07_fail() -> 
+  Fun = fun _F({_, Vs}) -> list_as_tuple_07_h(Vs) end,
+  Fun({x, nil}).
+
+-spec list_as_tuple_08(tlist(V)) -> {ok, V} | error | error2.
+list_as_tuple_08(nil) -> error;
+list_as_tuple_08({V, nil}) -> {ok, V};
+list_as_tuple_08({_ , Rest}) ->
+    case list_as_tuple_08(Rest) of
+        {ok, _} -> error2;
+        _ -> error
+    end.
+


### PR DESCRIPTION
Fixes #108 and fixes many false positives when using lists.

* Added a new `cons` type that captures the type of a `[_ | _]` cons cell.
* List types are now recursive: `list(T) :: [] | {T, list(T)}_List` where `{_}_List` behave the same as tuples but get their own type space in the `erlang_types` library
* Inference for lists got slower because of more recursive types now: #255  
* Simplifies types of patterns for the list case in `constr_gen.erl` by a lot
* Fixes #239 by giving string values a precise list type