### PR TITLE
Empty map values don't have an empty map type

### DIFF
--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -196,6 +196,8 @@ exp_constrs(Ctx, E, T) ->
             errors:unsupported(L, "list comprehension: ~200p", [E]);
         {mc, L, _E, _Qs} ->
             errors:unsupported(L, "map comprehension: ~200p", [E]);
+        {map_create, L, []} ->
+            utils:single({csubty, mk_locs("empty map", L), {map, []}, T});
         {map_create, L, Assocs} ->
             KeyAlpha = fresh_tyvar(Ctx),
             ValAlpha = fresh_tyvar(Ctx),

--- a/src/erlang_types/ty_map.erl
+++ b/src/erlang_types/ty_map.erl
@@ -28,7 +28,9 @@ unparse({ty_tuple, 2, [TupPart, FunPart]}, ST0) ->
   % the map representation depends on a synactical representation of tuples and functions
   % but unparsing returns a semantical unparsed representation with simplifications
   % manually unfold the type and hope for the best
-  {leaf, TyTupPart} = ty_node:load(TupPart),
+  {leaf, TyTupPart0} = ty_node:load(TupPart),
+  % remove the part that makes the tuple part always non-empty
+  TyTupPart = ty_rec:difference(TyTupPart0, ty_rec:atom(dnf_ty_atom:finite(['empty_map']))),
   {MandatoryAndOptional, ST1} = case TyTupPart of
     empty -> {{predef, none}, ST0};
     _ -> 

--- a/src/erlang_types/ty_parser.erl
+++ b/src/erlang_types/ty_parser.erl
@@ -564,7 +564,12 @@ do_convert({{map, AssocList}, R}, Q, Cache) ->
           Fun = {fun_full, [{intersection, [Key, {negation, PrecedenceDomain}]}], Val},
           {{union, [PrecedenceDomain, Key]}, {union, [Tuples, Tup]}, {intersection, [Functions, Fun]}}
       end
-    end, {{predef, none}, {predef, none}, {fun_simple}}, AssocList),
+    end, 
+    % a map type is never empty
+    % contrary to tuples, we can construct an empty map value: #{}
+    % since empty tuples are the empty type, we add an atom 'empty_map' to the tuple part
+    % so that the encoding is never empty
+    {{predef, none}, {singleton, empty_map}, {fun_simple}}, AssocList), 
   MapTuple = {tuple, [TupPart, FunPart]},
   {Recc, Q0, R0, C0} = do_convert({MapTuple, R}, Q, Cache),
   {?TY:tuple_to_map(Recc), Q0, R0, C0};

--- a/test/erlang_types/subtype/subtype_map_tests.erl
+++ b/test/erlang_types/subtype/subtype_map_tests.erl
@@ -8,6 +8,8 @@
 % =====
 
 maps_any_empty_test() ->
+  % none()
+  RealEmpty = tnone(),
   % #{}
   Empty = tmap([]),
   % map()
@@ -16,6 +18,7 @@ maps_any_empty_test() ->
   Any2 = tmap([tmap_field_opt(tany(), tany())]),
   Any3 = i([Any1, Any2]),
 
+  false = is_subtype(Empty, RealEmpty),
   true = is_subtype(Empty, Any1),
   true = is_equiv(Any1, Any2),
   true = is_equiv(Any2, Any3),

--- a/test/erlang_types/tally/tally_map_tests.erl
+++ b/test/erlang_types/tally/tally_map_tests.erl
@@ -226,7 +226,7 @@ maps_norm_req_2_test() ->
     tmap_field_req(tatom(a), tatom(b)),
     tmap_field_req(tint(20), tint(21))
   ]),
-  test_tally([{L, R}], solutions(10)).
+  test_tally([{L, R}], solutions(9)).
 
 
 maps_norm_req_3_test() ->

--- a/test/pretty_tests.erl
+++ b/test/pretty_tests.erl
@@ -220,3 +220,11 @@ recursive_2_test() ->
     ?assertEqual("mu $node_1.nil | {alpha, mu $node_1}", pretty:render_ty(B))
   end).
 
+empty_map_test() ->
+  global_state:with_new_state(fun() -> 
+    A = stdtypes:tmap([]),
+    B = id(A),
+    true = subty:is_equivalent(symtab:empty(), A, B),
+    ?assertEqual("#{}", pretty:render_ty(B))
+  end).
+

--- a/test_files/tycheck_simple/map.erl
+++ b/test_files/tycheck_simple/map.erl
@@ -21,6 +21,14 @@ const_map_00_fail() -> 1.
 -spec empty_map() -> #{}.
 empty_map() -> #{}.
 
+-type tlist(E) :: nil | {E, tlist(E)}.
+-spec foldl(fun((T, Acc) -> Acc), Acc, tlist(T)) -> Acc.
+foldl(_, _, _) -> error(err).
+-spec empty_map_is_not_empty() -> ok.
+empty_map_is_not_empty() ->
+  foldl(fun(_, _) -> error(todo) end, #{}, {foo, nil}),
+  ok.
+
 %% DISABLED because we only support maps as dictionaries
 %% -spec const_map_01() -> #{ a := 1, b := 2}.
 %% const_map_01() -> #{ a => 1, b => 2 }.


### PR DESCRIPTION
In contrast to tuples, we can create empty map values with `#{}`, thus map types are never empty. Fixed inside `erlang_types` and `constr_gen`.