### PR TITLE
Erlang comprehensions

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erlang: [ 27,28 ]
+        erlang: [ 28 ]
 
     container:
       image: erlang:${{ matrix.erlang }}
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erlang: [ 27,28 ]
+        erlang: [ 28 ]
 
     container:
       image: erlang:${{ matrix.erlang }}

--- a/src/ast.erl
+++ b/src/ast.erl
@@ -332,10 +332,13 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 -spec loc_exp(exp()) -> loc().
 loc_exp(X) -> element(2, X).
 
+-type qual_zip_gen() ::  {zip, loc(), [generators()]}. 
+-type qual_list_strict_gen() ::  {generate_strict, loc(), pat(), exp()}.
 -type qual_list_gen() ::  {generate, loc(), pat(), exp()}.
 -type qual_bitstring_gen() ::  {b_generate, loc(), pat(), exp()}.
 -type qual_map_gen() ::  {m_generate, loc(), KeyPat::pat(), ValPath::pat(), exp()}.
--type qualifier() :: exp() | qual_list_gen() | qual_bitstring_gen() | qual_map_gen().
+-type generators() :: qual_zip_gen() | qual_list_strict_gen() | qual_list_gen() | qual_bitstring_gen() | qual_map_gen().
+-type qualifier() :: exp() | generators().
 
 -type bitstring_tyspec() :: atom() | {atom(), Value::integer()}.
 -type bitstring_tyspec_list() :: [bitstring_tyspec()].

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -494,7 +494,7 @@ trans_exp(Ctx, Env, Exp) ->
             {NewQ, NewEnv} = trans_qualifiers(Ctx, Env, Qualifiers),
             % keep the old Env, comprehension opens a new scope
             {{bc, to_loc(Ctx, Anno), trans_exp_noenv(Ctx, NewEnv, E), NewQ}, Env};
-        {mc, Anno, {map_field_assoc, Anno, K, V}, Qualifiers} ->
+        {mc, Anno, {map_field_assoc, _Anno2, K, V}, Qualifiers} ->
             {NewQ, NewEnv} = trans_qualifiers(Ctx, Env, Qualifiers),
             % keep the old Env, map comprehension opens a new scope
             NewK = trans_exp_noenv(Ctx, NewEnv, K),
@@ -833,10 +833,13 @@ trans_qualifiers(Ctx, Env, Qs) ->
     -> {ast:qualifier(), varenv_local:t()}.
 trans_qualifier(Ctx, Env, Q) ->
     case Q of
-        {K, Anno, Pat, Exp} when (K == generate orelse K == b_generate) -> % generator "Pat <- Exp"
+        {K, Anno, Pat, Exp} when (K == generate_strict orelse K == generate orelse K == b_generate) -> % generator "Pat <- Exp"
             NewExp = trans_exp_noenv(Ctx, Env, Exp),
             {NewPat, NewEnv} = trans_pat(Ctx, Env, Pat, shadow),
             {{K, to_loc(Ctx, Anno), NewPat, NewExp}, NewEnv};
+        {zip, Anno, Qs} -> 
+            {NewQ, NewEnv} = trans_qualifiers(Ctx, Env, Qs),
+            {{zip, to_loc(Ctx, Anno), NewQ}, NewEnv};
         {m_generate, Anno, {map_field_exact, _Anno2, K, V}, Exp} ->
             NewExp = trans_exp_noenv(Ctx, Env, Exp),
             {NewK, NewEnv1} = trans_pat(Ctx, Env, K, shadow),

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -57,23 +57,36 @@
 -type set_of_constraint_sets() :: constraint_set:set_of_constraint_sets().
 -type monomorphic_variables() :: etally:monomorphic_variables().
 
+-spec reorder(X) -> X when X :: type().
 reorder(any) -> any;
 reorder(empty) -> empty;
 reorder(Ty) ->
   simpl_to_repr(map(fun(Module, Value) -> Module:reorder(Value) end, Ty)).
 
-% TODO
+-spec assert_valid(type()) -> _.
 assert_valid(any) -> ok;
 assert_valid(empty) -> ok;
 assert_valid(#ty{ty_tuples = T}) ->
   ty_tuples:assert_valid(T),
   ok.
 
+-spec find_atom_index(atom(), list()) -> pos_integer() | not_found.
 find_atom_index(Atom, List) ->
     case lists:keyfind(Atom, 1, lists:zip(List, lists:seq(1, length(List)))) of
         {Atom, Index} -> Index;
         false -> not_found
     end.
+
+% -spec pi(type(), type_module()) -> type_module:type(). 
+-spec pi
+  (type(), dnf_ty_predefined) -> dnf_ty_predefined:type();
+  (type(), dnf_ty_atom) -> dnf_ty_atom:type();
+  (type(), dnf_ty_interval) -> dnf_ty_interval:type();
+  (type(), dnf_ty_list) -> dnf_ty_list:type();
+  (type(), dnf_ty_bitstring) -> dnf_ty_bitstring:type();
+  (type(), ty_tuples) -> ty_tuples:type();
+  (type(), ty_functions) -> ty_functions:type();
+  (type(), dnf_ty_map) -> dnf_ty_map:type().
 pi(Ty, Mod) ->
   Fields = record_info(fields, ty),
   Ind = find_atom_index(Mod, Fields),
@@ -234,6 +247,7 @@ normalize(TyRec, Fixed, ST) ->
 % Unparse
 % ===
 
+-spec unparse(type(), ST) -> {ast_ty(), ST}.
 unparse(T, ST) ->
   {Positive, ST0_A} = unparse_h(T, ST),
   {Negative, ST0_B} = unparse_h(negate(T), ST),

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -154,7 +154,12 @@ simple_test_() ->
   % The following functions are currently excluded from being tested.
   WhatNot = [
     % TODO binary pattern element size verification
-    "b4_fail"
+    "b4_fail",
+    % TODO refinement for list comprehensions doesn't work (#279)
+    "lc_13",
+    % TODO unbound cariable in constraint simplification (#278)
+    "lc_11",
+    "lc_12_fail"
   ],
 
   NoInfer = [
@@ -169,7 +174,10 @@ simple_test_() ->
     "list_pattern_07",
     "inter_04_ok",
     "foo",
-    "op_08"
+    "op_08",
+    % TODO inferred type is less general than spec?
+    "lc_10",
+    "zip_01"
   ],
 
   %What = ["atom_03_fail"],

--- a/test_files/tycheck_simple/comprehension.erl
+++ b/test_files/tycheck_simple/comprehension.erl
@@ -7,7 +7,78 @@
 % against its spec, inference is also tested.
 % If the name ends with _fail, the test must fail.
 
-% Test for a scoping bug
-% Currently deactivated because we have no support for list comprehension #151
-% -spec foo(list(T)) -> list({T, T}).
-% foo(Alts) -> [{S, A} || A <- Alts, S=A].
+% strict and non-strict versions;
+% strict only behaves differently when the pattern match fails
+%   i.e. the pattern match should be the same as the element type of the input list
+
+-spec lc_01() -> [integer()].
+lc_01() -> [I || I <- [1,2]].
+
+-spec lc_01s() -> [integer()].
+lc_01s() -> [I || I <:- [1,2]].
+
+-spec lc_02_fail() -> [integer()].
+lc_02_fail() -> [I || I <- [1,foo]]. % fails because pattern I does not filter foo
+
+-spec lc_02s_fail() -> [integer()].
+lc_02s_fail() -> [I || I <:- [1,foo]]. 
+
+-spec lc_03([integer()]) -> [integer()].
+lc_03(L) -> [I || I <- L].
+
+-spec lc_03s([integer()]) -> [integer()].
+lc_03s(L) -> [I || I <:- L].
+
+-spec lc_04([integer()]) -> [integer()].
+lc_04(L) -> [I + J || I <- L, J <- L].
+
+-spec lc_05_fail([integer()], [string()]) -> [integer()].
+lc_05_fail(L, Z) -> [I + J || I <- L, J <- Z].
+
+% we can't statically verify that the result is just []
+-spec lc_06() -> [ok].
+lc_06() -> [ok || _ <- []].
+
+-spec lc_07_fail() -> [].
+lc_07_fail() -> [ok || _ <- []].
+
+-spec lc_08() -> [integer()].
+lc_08() -> [I || I <- [1], true].
+
+-spec lc_09() -> [integer()].
+lc_09() -> 
+  [1 || X <- [42], X > 3].
+
+% cartesian product example from Erlang documentation
+-spec lc_10() -> [{integer(), atom()}].
+lc_10() -> 
+  [{X, Y} || X <- [1,2,3], Y <- [a,b]].
+
+% test for a scoping bug
+-spec lc_11(list(boolean())) -> list({boolean(), boolean()}).
+lc_11(Alts) -> [{S, A} || A <- Alts, S=A].
+
+% filter expression result (S=A) must be boolean
+-spec lc_12_fail(list(T)) -> list({T, T}).
+lc_12_fail(Alts) -> [{S, A} || A <- Alts, S=A].
+
+-spec lc_13() -> [integer()].
+lc_13() -> 
+  [X || X <- [1,a,2,b,3], X > 3].
+
+-spec mc_01() -> #{atom() => integer()}.
+mc_01() -> 
+  #{K => V || {K, V} <- [{hello, 42}]}.
+
+-spec mc_02_fail() -> #{atom() => integer()}.
+mc_02_fail() -> 
+  #{K => V || {K, V} <- [{hello, ok}]}.
+
+-spec zip_01() -> [{integer(), atom(), integer()}].
+zip_01() ->
+  [{X, Y, Z} || X <- [1,2,3] && Y <- [a,b,c], Z <- [1,2,3]].
+
+-spec zip_02_fail() -> [{integer(), atom()}].
+zip_02_fail() ->
+  [{X, Y} || X <- [1] && Y <- [4]].
+


### PR DESCRIPTION
Implemented Erlang comprehensions. Currently has the same semantics for strict and non-strict list comprehensions.

This PR limits support to Erlang 28 and higher.