### PR TITLE
Exhaustiveness checking feature flag

### DIFF
--- a/example_project/check.sh
+++ b/example_project/check.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 cd ety_example && rebar3 compile && cd ..
-../ety --build --report-timeout 2000 --report-mode report -f -P ety_example -S ety_example/src
-
-
+../ety --build --exhaustiveness-mode disabled --report-timeout 2000 --report-mode report -f -P ety_example -S ety_example/src
+../ety --build --exhaustiveness-mode enabled --report-timeout 2000 --report-mode report -f -P ety_example -S ety_example/src
 

--- a/example_project/ety_example/src/ety_example.erl
+++ b/example_project/ety_example/src/ety_example.erl
@@ -2,6 +2,10 @@
 
 -compile([export_all, nowarn_export_all]).
 
+% exhaustiveness type error
+-spec exhaustive(pos_integer()) -> ok.
+exhaustive(N) when N > 0 -> ok.
+
 -spec fun0() -> integer().
 fun0() -> 2.
 

--- a/src/cm_check.erl
+++ b/src/cm_check.erl
@@ -95,7 +95,8 @@ traverse_and_check([CurrentFile | RemainingFiles], Symtab, OverlaySymtab, Search
     Sanity = perform_sanity_check(CurrentFile, Forms, Opts#opts.sanity),
     ReportMode = Opts#opts.report_mode,
     ReportTimeout = Opts#opts.report_timeout,
-    Ctx = typing:new_ctx(ExpandedSymtab, OverlaySymtab, Sanity, ReportMode, ReportTimeout),
+    ExhaustivenessMode = Opts#opts.exhaustiveness_mode,
+    Ctx = typing:new_ctx(ExpandedSymtab, OverlaySymtab, Sanity, ReportMode, ReportTimeout, ExhaustivenessMode),
     case Opts#opts.no_type_checking of
         true ->
             ?LOG_INFO("Not type checking ~p as requested", CurrentFile);

--- a/src/erlang_types/feature_flags.erl
+++ b/src/erlang_types/feature_flags.erl
@@ -1,5 +1,6 @@
 -module(feature_flags).
 
--export_type([report_mode/0]).
+-export_type([report_mode/0, exhaustiveness_mode/0]).
 
 -type report_mode() :: early_exit | report.
+-type exhaustiveness_mode() :: enabled | disabled.

--- a/src/etylizer_main.erl
+++ b/src/etylizer_main.erl
@@ -68,6 +68,10 @@ parse_args(Args) ->
          {report_timeout, undefined, "report-timeout", string,
             "Define a timeout in milliseconds for type checking a function in report_mode 'report'." ++
             "Default timeout is 5000 milliseconds."},
+         {exhaustiveness_mode, undefined, "exhaustiveness-mode", string,
+            "Change the mode of how to check for exhaustiveness. Currently, " ++
+            "the checker can either globally enable or disable exhaustiveness." ++
+            "Default: enabled (enabled, disabled)."},
          {only, $o, "only", string,
             "Only type check these functions (given as module:name/arity or name/arity or just the name)"},
          {ignore, $i, "ignore", string,
@@ -115,6 +119,9 @@ parse_args(Args) ->
                         {report_mode, "report"} -> Opts#opts{ report_mode = report };
                         {report_mode, M} -> utils:quit(2, "Invalid report mode: " ++ M ++ "~n");
                         {report_timeout, T} -> Parsed = list_to_integer(T), true = Parsed > 0, Opts#opts{ report_timeout = Parsed };
+                        {exhaustiveness_mode, "enabled"} -> Opts#opts{ exhaustiveness_mode = enabled };
+                        {exhaustiveness_mode, "disabled"} -> Opts#opts{ exhaustiveness_mode = disabled };
+                        {exhaustiveness_mode, M} -> utils:quit(2, "Invalid exhaustiveness mode: " ++ M ++ "~n");
                         no_deps -> Opts#opts{ no_deps = true };
                         {type_overlay, S} -> Opts#opts{ type_overlay = S };
                         help -> Opts#opts{ help = true }

--- a/src/etylizer_main.hrl
+++ b/src/etylizer_main.hrl
@@ -9,6 +9,7 @@
                no_type_checking = false :: boolean(),
                report_mode = early_exit :: feature_flags:report_mode(),
                report_timeout = 5000 :: pos_integer(),
+               exhaustiveness_mode = enabled :: feature_flags:exhaustiveness_mode(),
                no_deps = false :: boolean(),
                type_check_only = [] :: [string()],
                type_check_ignore = [] :: [string()],

--- a/src/typing.erl
+++ b/src/typing.erl
@@ -3,7 +3,7 @@
 -export([
     check_forms/5,
     new_ctx/3,
-    new_ctx/5
+    new_ctx/6
 ]).
 
 -include("log.hrl").
@@ -11,11 +11,11 @@
 
 -spec new_ctx(symtab:t(), symtab:t(), t:opt(ast_check:ty_map())) -> ctx().
 new_ctx(Tab, Overlay, Sanity) ->
-    new_ctx(Tab, Overlay, Sanity, early_exit, 5000).
+    new_ctx(Tab, Overlay, Sanity, early_exit, 5000, enabled).
 
--spec new_ctx(symtab:t(), symtab:t(), t:opt(ast_check:ty_map()), feature_flags:report_mode(), pos_integer()) -> ctx().
-new_ctx(Tab, Overlay, Sanity, ReportMode, ReportTimeout) ->
-    Ctx = #ctx{ symtab = Tab, overlay_symtab = Overlay, sanity = Sanity, report_mode = ReportMode, report_timeout = ReportTimeout },
+-spec new_ctx(symtab:t(), symtab:t(), t:opt(ast_check:ty_map()), feature_flags:report_mode(), pos_integer(), feature_flags:exhaustiveness_mode()) -> ctx().
+new_ctx(Tab, Overlay, Sanity, ReportMode, ReportTimeout, ExhaustivenessMode) ->
+    Ctx = #ctx{ symtab = Tab, overlay_symtab = Overlay, sanity = Sanity, report_mode = ReportMode, report_timeout = ReportTimeout, exhaustiveness_mode = ExhaustivenessMode },
     Ctx.
 
 % Checks all forms of a module

--- a/src/typing.hrl
+++ b/src/typing.hrl
@@ -3,7 +3,8 @@
           overlay_symtab :: symtab:t(),
           sanity :: t:opt(ast_check:ty_map()),
           report_mode :: feature_flags:report_mode(),
-          report_timeout :: pos_integer()
+          report_timeout :: pos_integer(),
+          exhaustiveness_mode :: feature_flags:exhaustiveness_mode()
         }).
 
 -type ctx() :: #ctx{}.

--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -183,7 +183,7 @@ check_alt(Ctx, Decl = {function, Loc, Name, Arity, _}, FunTy, BranchMode, Fixed)
     FunStr = utils:sformat("~w/~w at ~s", Name, Arity, ast:format_loc(Loc)),
     ?LOG_INFO("Checking function ~s against type ~s",
                FunStr, pretty:render_ty(FunTy)),
-    Cs = constr_gen:gen_constrs_annotated_fun(Ctx#ctx.symtab, FunTy, Decl),
+    Cs = constr_gen:gen_constrs_annotated_fun(Ctx#ctx.exhaustiveness_mode ,Ctx#ctx.symtab, FunTy, Decl),
     case Ctx#ctx.sanity of
         {ok, TyMap} -> constr_gen:sanity_check(Cs, TyMap);
         error -> ok

--- a/src/typing_infer.erl
+++ b/src/typing_infer.erl
@@ -40,7 +40,7 @@ infer(Ctx, Decls) ->
         case Decls of
             [{function, L, _, _, _} | _] -> L
         end,
-    {Cs, Env} = constr_gen:gen_constrs_fun_group(Ctx#ctx.symtab, Decls),
+    {Cs, Env} = constr_gen:gen_constrs_fun_group(Ctx#ctx.exhaustiveness_mode, Ctx#ctx.symtab, Decls),
     case Ctx#ctx.sanity of
         {ok, TyMap} -> constr_gen:sanity_check(Cs, TyMap);
         error -> ok


### PR DESCRIPTION
* Added a flag to disable exhaustiveness globally. Exhaustiveness checks are enabled by default.
* Depends on #266, rebase after its merged