### PR TITLE
Tally Satisfiability Optimization

### DIFF
--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -481,7 +481,7 @@ var_funcall_constrs(Ctx, L, Var, Args, T) ->
 
 -spec funcall_constrs_with_tyscm(ctx(), ast:loc(), ast:exp_var(), ast:ty_scheme(), [ast:exp()], ast:ty()) -> constr:constrs().
 funcall_constrs_with_tyscm(Ctx, L, Var, TyScm, Args, T) ->
-    {Mono, _, _} = typing_common:mono_ty(L, TyScm, none, fun(_, none) -> {fresh_ty_varname(Ctx), none} end),
+    {Mono, _, _} = typing_common:mono_ty(L, TyScm, none, fun(_, none) -> {fresh_ty_varname(Ctx), none} end, Ctx#ctx.symtab),
     case Mono of
         {fun_full, ArgTys, ResTy} when length(Args) =:= length(ArgTys) ->
             FunName = pretty:render_var(Var),

--- a/src/constr_simp.erl
+++ b/src/constr_simp.erl
@@ -129,7 +129,7 @@ fresh_ty_scheme(Ctx, {ty_scheme, Tyvars, T}) ->
           Tyvars
          ),
     Subst = subst:from_list(L),
-    subst:apply(Subst, T).
+    subst:apply(Subst, T, {clean, Ctx#ctx.symtab}).
 
 -spec loc(constr:locs() | sets:set(ast:loc()) | constr:constrs()) -> ast:loc().
 loc(Locs) ->

--- a/src/erlang_types/etally.erl
+++ b/src/erlang_types/etally.erl
@@ -105,7 +105,7 @@ is_satisfiable_v3(Constraints, MonomorphicVariables) ->
                 _ ->
                   % io:format("Got ~p complex~n", [length(All2)]),
                   % io:format("~n~p~n", [All2]),
-                  {T2, ComplexSat} = 
+                  {_T2, ComplexSat} = 
                   timer:tc(fun() -> lists:foldl(fun(E, E2) -> 
                                                     % io:format(user,".~p", [length(E2)]), 
                                                     tally_saturate(constraint_set:meet(E, E2, MonomorphicVariables), MonomorphicVariables) end, SimpleSat, All2) end),

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -29,6 +29,12 @@
     get_types/1
 ]).
 
+-ifdef(TEST). % for tally tests
+-export([
+    from_types/1
+]).
+-endif.
+
 -type fun_env() :: #{ ast:global_ref() => ast:ty_scheme() }.
 -type ty_key() :: {ty_key, Module::atom(), Name::atom(), Arity::arity()}.
 -type ty_env() :: #{ ty_key() => ast:ty_scheme() }.
@@ -279,3 +285,10 @@ retrieve_forms_for_source({Kind, Src, Includes}) ->
         local -> parse_cache:parse(intern, Src);
         _ -> parse_cache:parse({extern, Includes}, Src)
     end.
+
+-ifdef(TEST).
+-spec from_types(any()) -> t().
+from_types(Types) when is_list(Types) -> (empty())#tab{types = maps:from_list(Types)};
+from_types(Types) when is_map(Types) -> (empty())#tab{types = Types}.
+-endif.
+

--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -57,7 +57,7 @@ check_report(Ctx, Decl = {function, Loc, Name, Arity, _}, PolyTy) ->
         Timeout,
         fun () -> 
             FunStr = utils:sformat("~w/~w", Name, Arity),
-            {MonoTy, Fixed, _} = typing_common:mono_ty(Loc, PolyTy),
+            {MonoTy, Fixed, _} = typing_common:mono_ty(Loc, PolyTy, Ctx#ctx.symtab),
             ensure_type_supported(Loc, MonoTy),
             AltTys = case MonoTy of {intersection, L} -> L; _ -> [MonoTy] end,
             BranchMode =
@@ -134,7 +134,7 @@ check(Ctx, Decl = {function, Loc, Name, Arity, _}, PolyTy) ->
     ?LOG_INFO("Type checking ~w/~w at ~s against type ~s",
               Name, Arity, ast:format_loc(Loc), pretty:render_tyscheme(PolyTy)),
     FunStr = utils:sformat("~w/~w", Name, Arity),
-    {MonoTy, Fixed, _} = typing_common:mono_ty(Loc, PolyTy),
+    {MonoTy, Fixed, _} = typing_common:mono_ty(Loc, PolyTy, Ctx#ctx.symtab),
     ensure_type_supported(Loc, MonoTy),
     AltTys =
         case MonoTy of

--- a/src/typing_infer.erl
+++ b/src/typing_infer.erl
@@ -81,7 +81,7 @@ infer(Ctx, Decls) ->
                                                 errors:bug("Function ~w/~w not found in env",
                                                             [Name, Arity]);
                                             {ok, T} ->
-                                                {Ref, generalize(subst:apply(Subst, T))}
+                                                {Ref, generalize(subst:apply(Subst, T, {clean, Ctx#ctx.symtab}))}
                                         end
                                 end)),
                             ?LOG_DEBUG("Environment:~n~s", [pretty:render_fun_env(ResultEnv)]),
@@ -106,9 +106,9 @@ more_general(Loc, Ts1, Ts2, Tab) ->
     % Ts1 is more general than Ts2 iff for every instantiation Mono2 of Ts2, there
     % exists an instantition Mono1 of Ts1 such that Mono1 <= Mono2.
     % A flexible instantiation of Ts1 with type variables that can be further instantiated by tally
-    {Mono1, _, Next} = typing_common:mono_ty(Loc, Ts1, 0),
+    {Mono1, _, Next} = typing_common:mono_ty(Loc, Ts1, 0, Tab),
     % Arbitrary instantiation of Ts2, the type variables A2 are fix
-    {Mono2, A2, _} = typing_common:mono_ty(Loc, Ts2, Next),
+    {Mono2, A2, _} = typing_common:mono_ty(Loc, Ts2, Next, Tab),
     C = {scsubty, sets:new([{version, 2}]), Mono1, Mono2},
     {SatisfyRes, Delta} = utils:timing(fun() -> tally:is_satisfiable(Tab, sets:from_list([C], [{version, 2}]), A2) end),
     ?LOG_DEBUG("Tally time: ~pms", Delta),

--- a/test/erlang_types/erlang_types_test_utils.erl
+++ b/test/erlang_types/erlang_types_test_utils.erl
@@ -23,7 +23,7 @@ test_tally(ConstrList, ExpectedSubst) ->
 
 % -spec test_tally(list({ast:ty(), ast:ty()}), list(expected_subst()), [ast:ty_varname()]) -> _.
 test_tally(ConstrList, ExpectedSubst, FixedVars) ->
-  test_tally(ConstrList, ExpectedSubst, FixedVars, symtab:empty()).
+  test_tally(ConstrList, ExpectedSubst, FixedVars, #{}).
 
 test_tally(ConstrList, ExpectedSubst, FixedVars, Symtab) ->
   % io:format(user,"Fixed variables: ~p~n", [FixedVars]),
@@ -58,7 +58,7 @@ test_tally(ConstrList, ExpectedSubst, FixedVars, Symtab) ->
   end, Symtab).
 
 test_tally_satisfiable(Satisfiable, ConstrList) ->
-  test_tally_satisfiable(Satisfiable, ConstrList, [], symtab:empty()).
+  test_tally_satisfiable(Satisfiable, ConstrList, [], #{}).
 
 % -spec test_tally_satisfiable(boolean(), list({ast:ty(), ast:ty()}), [ast:ty_varname()], symtab:t()) -> ok.
 test_tally_satisfiable(Satisfiable, ConstrList, FixedVars, Symtab) ->
@@ -71,7 +71,7 @@ test_tally_satisfiable(Satisfiable, ConstrList, FixedVars, Symtab) ->
       )),
 
     % test satisfiable mode of tally, symtab parsed before tally
-    {Satisfiable, _} = tally:is_satisfiable(symtab:empty(), Constrs, sets:from_list(FixedVars)),
+    {Satisfiable, _} = tally:is_satisfiable(symtab:from_types(Symtab), Constrs, sets:from_list(FixedVars)),
     ok
               end,
     Symtab).

--- a/test/erlang_types/erlang_types_test_utils.hrl
+++ b/test/erlang_types/erlang_types_test_utils.hrl
@@ -45,7 +45,7 @@ ttuple_any() -> {tuple_any}.
 ttuple(Types) -> {tuple, Types}.
 ttuple1(Type) -> {tuple, [Type]}.
 test_key(Key) -> test_key(Key, 0).
-test_key(Key, LenArgs) -> {test_key, '.', Key, LenArgs}.
+test_key(Key, LenArgs) -> {ty_key, '.', Key, LenArgs}.
 tnamed_ns(Ns, Ref, Args) -> 
   {named, {loc, "AUTO", -1, -1}, {ty_ref, Ns, Ref, length(Args)}, Args}.
 tnamed(Ref) -> tnamed(Ref, []).

--- a/test/erlang_types/tally/tally_config_tests.erl
+++ b/test/erlang_types/tally/tally_config_tests.erl
@@ -49,7 +49,7 @@ mk_negation_cache_bug_test() ->
 
 
   with_symtab(fun() ->
-    Constrs1 = 
+    _Constrs1 = 
       sets:from_list(
         lists:map( 
           fun ({T, U}) -> {scsubty, sets:from_list([loc_auto()]), T, U} end,
@@ -62,8 +62,8 @@ mk_negation_cache_bug_test() ->
           Cons2
       )),
 
-    % {true, _} = tally:is_satisfiable(symtab:empty(), Constrs1, sets:from_list([])),
-    {false, _} = tally:is_satisfiable(symtab:empty(), Constrs2, sets:from_list([])),
+    % {true, _} = tally:is_satisfiable(symtab:from_types(Symtab), Constrs1, sets:from_list([])),
+    {false, _} = tally:is_satisfiable(symtab:from_types(Symtab), Constrs2, sets:from_list([])),
     ok
               end,
     Symtab).

--- a/test/erlang_types/tally/tally_user_tests.erl
+++ b/test/erlang_types/tally/tally_user_tests.erl
@@ -41,10 +41,10 @@ issue_226_test() ->
   GuardTest = tnamed(gen_tuple, [tnamed(guard_test, [])]),
   GenTuple = ttuple([tlist(v('T'))]),
 
-  Sym = [
-    {test_key(guard_test), tyscm([], GuardTest)},
-    {test_key(gen_tuple, 1), tyscm([t], GenTuple)}
-  ],
+  Sym = #{
+    test_key(guard_test) => tyscm([], GuardTest),
+    test_key(gen_tuple, 1) => tyscm([t], GenTuple)
+  },
 
   test_tally_satisfiable(
     true,

--- a/test/mono_tests.erl
+++ b/test/mono_tests.erl
@@ -8,14 +8,14 @@ string_contains(Full, Search) -> string:str(Full, Search) > 0.
 -spec check_mono_ty(ast:ty_scheme(), ast:ty() | [ast:ty()]| cyclic) -> ok.
 check_mono_ty(Input, cyclic) ->
     try
-        typing_common:mono_ty(ast:loc_auto(), Input, 0),
+        typing_common:mono_ty(ast:loc_auto(), Input, 0, symtab:empty()),
         ?assert(false, "expected exception")
     catch
         throw:{etylizer,ty_error, Msg} ->
             ?assert(string_contains(Msg, "Cyclic bounds in type spec"))
     end;
 check_mono_ty(Input, Expected) ->
-    {Given, _, _} = typing_common:mono_ty(ast:loc_auto(), Input, 0),
+    {Given, _, _} = typing_common:mono_ty(ast:loc_auto(), Input, 0, symtab:empty()),
     if
         is_list(Expected) ->
             lists:any(fun (T) -> T =:= Given end, Expected);

--- a/test/subst_tests.erl
+++ b/test/subst_tests.erl
@@ -136,24 +136,24 @@ clean_test() ->
         % a is in covariant position
         A = stdtypes:tvar('a'),
         B = stdtypes:tvar('b'),
-        E = subst:clean(A, sets:new()),
+        E = subst:clean(A, sets:new(), symtab:empty()),
 
         % intersection: covariant
-        E = subst:clean(stdtypes:tinter(A, B), sets:new()),
+        E = subst:clean(stdtypes:tinter(A, B), sets:new(), symtab:empty()),
 
         % union: covariant
-        E = subst:clean(stdtypes:tunion(A, B), sets:new()),
+        E = subst:clean(stdtypes:tunion(A, B), sets:new(), symtab:empty()),
 
         % negation: flip
-        E = subst:clean(stdtypes:tnegate(A), sets:new()),
+        E = subst:clean(stdtypes:tnegate(A), sets:new(), symtab:empty()),
 
         % function type flips argument variable position
         Arr = stdtypes:tfun1(stdtypes:tany(), stdtypes:tnone()),
-        Arr = subst:clean(stdtypes:tfun1(A, B), sets:new()),
+        Arr = subst:clean(stdtypes:tfun1(A, B), sets:new(), symtab:empty()),
 
         % function double flip
         Arr2 = stdtypes:tfun1(stdtypes:tfun1(stdtypes:tnone(), stdtypes:tany()), stdtypes:tnone()),
-        Arr2 = subst:clean(stdtypes:tfun1(stdtypes:tfun1(A, B), stdtypes:tnone()), sets:new())
+        Arr2 = subst:clean(stdtypes:tfun1(stdtypes:tfun1(A, B), stdtypes:tnone()), sets:new(), symtab:empty())
     end).
 
 clean_negate_var_test() ->
@@ -162,9 +162,9 @@ clean_negate_var_test() ->
         E = stdtypes:tnone(),
 
         % negation is covariant position
-        E = subst:clean(stdtypes:tnegate(A), sets:new()),
+        E = subst:clean(stdtypes:tnegate(A), sets:new(), symtab:empty()),
         % test nnf
-        E = subst:clean(stdtypes:tnegate(stdtypes:tunion(A, stdtypes:tnegate(stdtypes:tatom()))), sets:new())
+        E = subst:clean(stdtypes:tnegate(stdtypes:tunion(A, stdtypes:tnegate(stdtypes:tatom()))), sets:new(), symtab:empty())
     end).
 
 % TODO: better unparsing to ensure that (int, Bottom) = Bottom


### PR DESCRIPTION
Fixed cleaning of map types and named types:
  * Cleaning map types needs to be done on the internal representation to gather the co- and contravariant positions of variables properly
  * Cleaning of named types was skipped. This is incorrect, as we need to gather the positions of variables in that unfolding of that named type. This means cleaning now needs access to the symbol table, and needs to be implemented with memoization to handle recursive definitions
    * This has the consequence that `subst:apply` needs to have access to the symbol table now
    * ~~It's a bit unclean that `subst:apply` with the `no_clean` mode has to be supplied a symbol table, but doesn't need it~~

Finally, for tally satisfiability, we can use cleaning for the input constraints to remove polymorphic variables of little use, which greatly improves the time to check tally satisfiability.