### PR TITLE
`maybe` Expression Support

### DIFF
--- a/src/ast_erl.erl
+++ b/src/ast_erl.erl
@@ -64,6 +64,7 @@
     exp_map_update/0,
     exp_map_compr/0,
     exp_match/0,
+    exp_maybe_match/0,
     exp_nil/0,
     exp_binop/0,
     exp_unop/0,
@@ -76,6 +77,8 @@
     exp_tuple/0,
     exp_try/0,
     exp_var/0,
+    exp_maybe/0,
+    exp_maybe_else/0,
     exp/0,
     exps/0,
     qual_list_gen/0,
@@ -95,6 +98,7 @@
     catch_clause/0,
     fun_clause/0,
     if_clause/0,
+    maybe_else_clause/0,
     guard/0,
     guard_test_bitstring_constr/0,
     guard_test_cons/0,
@@ -270,6 +274,7 @@
 -type exp_map_update() :: gen_map_update(exp()).
 -type exp_map_compr() :: {mc, anno(), map_assoc_opt(), [qualifier()]}.
 -type exp_match() :: {match, anno(), pat(), exp()}.
+-type exp_maybe_match() :: {maybe_match, anno(), pat(), exp()}.
 -type gen_nil() ::  {nil, anno()}.
 -type exp_nil() :: gen_nil().
 -type gen_binop(T) :: {op, anno(), Op::binop(), T, T}.
@@ -293,6 +298,8 @@
                     After::exps()}.
 -type gen_var() :: {var, anno(), Var::atom()}.
 -type exp_var() :: gen_var().
+-type exp_maybe() :: {'maybe', anno(), exps()}.
+-type exp_maybe_else() :: {'maybe', anno(), exps(), {'else', anno(), Clauses :: [maybe_else_clause()]}}.
 
 -type exp() :: atomic_lit() | exp_bitstring_compr() | exp_bitstring_constr() | exp_block()
     | exp_case() | exp_catch() | exp_cons() | exp_fun_ref() | exp_fun_qref() | exp_fun()
@@ -300,7 +307,8 @@
     | exp_map_create() | exp_map_update() | exp_map_compr()
     | exp_match() | exp_nil() | exp_binop() | exp_unop()
     | exp_recv() | exp_recv_after() | exp_record_create() | exp_record_access()
-    | exp_record_index() | exp_record_update() | exp_tuple() | exp_try() | exp_var().
+    | exp_record_index() | exp_record_update() | exp_tuple() | exp_try() | exp_var() 
+    | exp_maybe() | exp_maybe_else() | exp_maybe_match().
 
 -type exps() :: [exp()].
 
@@ -331,9 +339,10 @@
                                  % - P is a pattern
                                  % - S is a wildcard or variable for the stacktrace.
 
--type case_clause()  :: {clause, anno(), Pats::list1(pat()), Guards::[guard()], Body::exps()}.
--type fun_clause()   :: {clause, anno(), Pats::[pat()],      Guards::[guard()], Body::exps()}.
--type if_clause()    :: {clause, anno(), Pats::[],           Guards::[guard()], Body::exps()}.
+-type maybe_else_clause()  :: {clause, anno(), Pats::list1(pat()), Guards::[guard()], Body::exps()}.
+-type case_clause()        :: {clause, anno(), Pats::list1(pat()), Guards::[guard()], Body::exps()}.
+-type fun_clause()         :: {clause, anno(), Pats::[pat()],      Guards::[guard()], Body::exps()}.
+-type if_clause()          :: {clause, anno(), Pats::[],           Guards::[guard()], Body::exps()}.
 
 % 8.6  Guards
 -type guard() :: list1(guard_test()).

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -534,6 +534,10 @@ trans_exp(Ctx, Env, Exp) ->
         {op, Anno, Op, E} ->
             {NewE, NewEnv} = trans_exp(Ctx, Env, E),
             {{op, to_loc(Ctx, Anno), Op, NewE}, NewEnv};
+        {'maybe', _Anno, _Exps} ->
+            trans_maybe(Ctx, Env, Exp, none);
+        {'maybe', Anno, Exps, Else = {'else', _ElseAnno, _Cs0}} ->
+            trans_maybe(Ctx, Env, {'maybe', Anno, Exps}, Else);
         {'receive', Anno, CaseClauses} ->
             {NewClauses, NewEnv} = trans_case_clauses(Ctx, Env, CaseClauses),
             {{'receive', to_loc(Ctx, Anno), NewClauses}, NewEnv};
@@ -596,6 +600,65 @@ trans_exp(Ctx, Env, Exp) ->
             Loc = to_loc(Ctx, Anno),
             {{var, Loc, {local_ref, varenv_local:lookup(Loc, Name, Env)}}, Env};
         X -> errors:uncovered_case(?FILE, ?LINE, Ctx#ctx.path, X)
+    end.
+
+-spec mk_maybe_expr
+    (ast_erl:anno(), ast_erl:exps(), none) -> ast_erl:exp_maybe();
+    (ast_erl:anno(), ast_erl:exps(), {'else', ast_erl:anno(), [ast_erl:maybe_else_clause()]}) -> ast_erl:exp_maybe_else().
+mk_maybe_expr(A, M, none) -> {'maybe', A, M}; 
+mk_maybe_expr(A, M, Else) -> {'maybe', A, M, Else}.
+
+-spec trans_maybe(ctx(), varenv_local:t(), ast_erl:exp(), none | {'else', ast_erl:anno(), [ast_erl:maybe_else_clause()]}) -> {ast:exp(), varenv_local:t()}.
+trans_maybe(Ctx, Env, {'maybe', Anno, [Exp]}, Else) -> 
+    case Exp of
+        {'maybe_match', L, P, E} ->
+            case Else of
+                none ->
+                    % validate that P can match E's type, then return E
+                    FreshVar = {var, L, '$maybe'},
+                    SuccessClause = {clause, L, [{match, L, P, FreshVar}], [], [FreshVar]},
+                    FailClause = {clause, L, [FreshVar], [], [FreshVar]},
+                    Case = {'case', L, E, [SuccessClause, FailClause]},
+                    trans_exp(Ctx, Env, Case);
+                {'else', _ElseAnno, Cs0} ->
+                    FreshVar = {var, Anno, '$maybe'},
+                    SuccessClause = {clause, Anno, [{match, Anno, P, FreshVar}], [], [FreshVar]},
+                    Case = {'case', Anno, E, [SuccessClause | Cs0]},
+                    trans_exp(Ctx, Env, Case)
+            end;
+        _ ->
+            case Else of
+                none ->
+                    trans_exp(Ctx, Env, Exp);
+                {'else', _ElseAnno, Cs0} ->
+                    % else clauses are semantically unreachable without ?=,
+                    % but we keep them so the type checker sees all branches
+                    SuccessClause = {clause, Anno, [{var, Anno, '_'}], [], [Exp]},
+                    Case = {'case', Anno, Exp, [SuccessClause | Cs0]},
+                    trans_exp(Ctx, Env, Case)
+            end
+    end;
+trans_maybe(Ctx, Env, {'maybe', Anno, [Exp | Exps]}, Else) -> 
+    case Exp of
+        {'maybe_match', L, P, E} -> 
+            % pattern matches -> continue with remaining Exps
+            SuccessClause = {clause, L, [P], [], [mk_maybe_expr(Anno, Exps, Else)]},
+            
+            % pattern doesn't match -> return original E or do the else clauses
+            FailClauses =
+            case Else of
+                % need to create a fresh variable to avoid binding variables by accident
+                none ->
+                    FreshVar = {var, L, '$maybe'},
+                    [{clause, L, [FreshVar], [], [FreshVar]}];
+                {'else', _ElseAnno, Cs0} -> Cs0
+            end,
+            NewExp = {'case', L, E, [SuccessClause | FailClauses]},
+            trans_exp(Ctx, Env, NewExp);
+        _ -> 
+            NewExp = {block, Anno, [Exp, mk_maybe_expr(Anno, Exps, Else)]},
+            % not a maybe match, then it's just a block
+            trans_exp(Ctx, Env, NewExp)
     end.
 
 -spec trans_exp_bin_elem(ctx(), varenv_local:t(), ast_erl:exp_bitstring_elem()) ->
@@ -895,3 +958,4 @@ arity(Loc, L) ->
     if Len < 256 -> Len;
        true -> errors:ty_error(Loc, "too many arguments: ~w", Len)
     end.
+

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -182,7 +182,10 @@ simple_test_() ->
     "op_08",
     % TODO inferred type is less general than spec?
     "lc_10",
-    "zip_01"
+    "zip_01",
+    % TODO slow maybe inference
+    "maybe_08",
+    "maybe_09"
   ],
 
   %What = ["atom_03_fail"],

--- a/test_files/tycheck_simple/maybe_expr.erl
+++ b/test_files/tycheck_simple/maybe_expr.erl
@@ -1,0 +1,144 @@
+-module(maybe_expr).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+% Each top-level definition of this module is typechecked in isolation
+% against its spec, inference is also tested.
+% If the name ends with _fail, the test must fail
+
+%%%%%%%%%%%%%%%%%%%%%%%% IF %%%%%%%%%%%%%%%%%%%%%%%
+
+-spec maybe_01() -> ok.
+maybe_01() ->
+    maybe ok end.
+
+-spec maybe_02() -> ok.
+maybe_02() ->
+    maybe nok, ok end.
+
+-spec maybe_03() -> ok.
+maybe_03() ->
+    maybe nok, begin okk, ok end end.
+
+-spec maybe_04_fail() -> ok.
+maybe_04_fail() ->
+    maybe ok, nok end.
+
+% pattern nok never matches ok
+-spec maybe_match_01_fail() -> ok.
+maybe_match_01_fail() ->
+    maybe nok ?= ok end.
+
+-spec maybe_match_01b_fail() -> ok.
+maybe_match_01b_fail() ->
+    case ok of
+        (nok = Maybe) -> Maybe;
+        Maybe -> Maybe
+    end.
+
+% exhaustive pattern: fail branch is unreachable (same as multi-expression case)
+-spec maybe_match_02_fail() -> ok.
+maybe_match_02_fail() ->
+    maybe ok ?= ok end.
+
+% maybe_match never matches
+-spec maybe_match_03_fail() -> ok.
+maybe_match_03_fail() ->
+    maybe nok ?= ok, bad end.
+
+-spec maybe_match_04(some | error) -> ok | error.
+maybe_match_04(Arg) ->
+    maybe some ?= Arg, ok end.
+
+-spec maybe_match_05_fail(some | err) -> ok | error.
+maybe_match_05_fail(Arg) ->
+    maybe some ?= Arg, ok end.
+
+-spec maybe_match_06(some | error, some2 | error) -> ok | error.
+maybe_match_06(Arg, Arg2) ->
+    maybe 
+        some ?= Arg, 
+        some2 ?= Arg2, 
+        ok 
+    end.
+
+-spec maybe_match_07(some | error, some2 | error, some3 | error) -> ok | error.
+maybe_match_07(Arg, Arg2, Arg3) ->
+    maybe 
+        some ?= maybe
+                    some ?= Arg,
+                    some3 ?= Arg3,
+                    some
+                end, 
+        some2 ?= Arg2, 
+        ok 
+    end.
+
+-spec maybe_match_08_fail() -> ok.
+maybe_match_08_fail() ->
+    maybe bad ?= ok end.
+
+
+-spec maybe_else_01_fail() -> ok.
+maybe_else_01_fail() ->
+    maybe ok else _ -> error(badarg) end.
+
+-spec maybe_else_02_fail() -> ok.
+maybe_else_02_fail() ->
+    maybe ok ?= bad else _ -> error(badarg) end.
+
+-spec maybe_else_03(foo | bar) -> foo.
+maybe_else_03(X) ->
+    maybe foo ?= X else _ -> error(badarg) end.
+
+-spec maybe_else_04(foo | bar) -> foo.
+maybe_else_04(X) ->
+    maybe foo ?= X else bar -> foo end.
+
+-spec maybe_else_05(foo | bar) -> foo.
+maybe_else_05(X) ->
+    maybe foo, bar, foo ?= X else bar -> foo end.
+
+-spec maybe_else_06_fail() -> ok.
+maybe_else_06_fail() ->
+    maybe ok else bad -> bad end.
+
+-spec maybe_07(string(), fun((string()) -> {ok, integer()} | {error, bad_int})) -> {ok, string()} | {error, bad_int}.
+maybe_07(Str, Convert) ->
+    maybe
+        {ok, _} ?= Convert(Str),
+        {ok, "ok"}
+    end.
+
+% from eqwalizer #55
+-spec maybe_08(string()) -> {ok, string()} | {error, bad_int}.
+maybe_08(Str) ->
+    maybe
+        {ok, Int} ?= convert_to_int(Str),
+        {ok, integer_to_list(Int*2)}
+    end.
+
+-spec convert_to_int(string()) -> {ok, integer()} | {error, bad_int}.
+convert_to_int(_) -> error('fun').
+
+% from eqwalizer #51
+% not possible to reason on length of lists without encoding it in the type itself
+% last needs an nonempty list
+-spec maybe_09_fail(list(binary())) -> {ok, binary()} | {error, any()}.
+maybe_09_fail(Args) ->
+    maybe
+        true ?= (length(Args) =/= 0) orelse {error, empty_args},
+        true ?= is_binary(lists:last(Args)) orelse {error, badargs},
+        {ok, <<"ok">>}
+    end.
+
+% proposed alternative; other alternative is cast Args after the check to nonempty_list(binary())
+-spec maybe_09(list(binary())) -> {ok, binary()} | {error, any()}.
+maybe_09([]) -> {error, empty_args};
+maybe_09(Args) ->
+    maybe
+        true ?= is_binary(lists:last(Args)) orelse {error, badargs},
+        {ok, <<"ok">>}
+    end.
+


### PR DESCRIPTION
Implemented `maybe` expression support as a transformation of syntax: https://www.erlang.org/doc/system/expressions.html#maybe. Else clauses also supported.

Fixes #148 

* Extended the expression and clause definitions
* Added tests

Basic idea:

* maybe expressions are nested case clauses
* expressions that are not `?=` expressions are transformed into a block
* expressions that are `A ?= B` expressions are transformed into a case expression `case B of A -> ...; Rest -> Rest end`


Depends on #283