### PR TITLE
More precise unmatched branches detection

### DIFF
--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -49,7 +49,7 @@ check_all_report(Ctx, FileName, Env, Decls) ->
 
 % Checks a function against its spec, skips timeouts and does not report errors.
 -spec check_report(ctx(), ast:fun_decl(), ast:ty_scheme()) -> success | timeout.
-check_report(Ctx, Decl = {function, Loc, Name, Arity, _}, PolyTy) ->
+check_report(Ctx, Decl = {function, Loc, Name, Arity, Clauses}, PolyTy) ->
     ?LOG_INFO("Type checking ~w/~w at ~s against type ~s",
               Name, Arity, ast:format_loc(Loc), pretty:render_tyscheme(PolyTy)),
     Timeout = Ctx#ctx.report_timeout,
@@ -76,7 +76,8 @@ check_report(Ctx, Decl = {function, Loc, Name, Arity, _}, PolyTy) ->
                     end
               end,
               AltTys),
-            UnmatchedEverywhere = sets:intersection(UnmatchedList),
+
+            UnmatchedEverywhere = intersect_unmatched(Clauses, UnmatchedList),
             case sets:to_list(UnmatchedEverywhere) of
                 [] -> success;
                 [First | _Rest] -> report_tyerror(FunStr, redundant_branch, First, "")
@@ -109,7 +110,7 @@ check_all(Ctx, FileName, Env, Decls) ->
     end.
 
 % Ensures that a mono type used as a spec is supported. Throws a ty_error if not.
--spec ensure_type_supported(ast:loc(), ast:ty()) -> ok.
+-spec ensure_type_supported(ast:loc(), ast:ty()) -> _.
 ensure_type_supported(Loc, T) ->
     utils:everywhere(
         fun(InnerT) ->
@@ -130,7 +131,7 @@ ensure_type_supported(Loc, T) ->
 % The type scheme comes from a type annotation, that it has the form
 % FORALL A . T1 /\ ... /\/ Tn where the Ti are function types
 -spec check(ctx(), ast:fun_decl(), ast:ty_scheme()) -> ok.
-check(Ctx, Decl = {function, Loc, Name, Arity, _}, PolyTy) ->
+check(Ctx, Decl = {function, Loc, Name, Arity, Clauses}, PolyTy) ->
     ?LOG_INFO("Type checking ~w/~w at ~s against type ~s",
               Name, Arity, ast:format_loc(Loc), pretty:render_tyscheme(PolyTy)),
     FunStr = utils:sformat("~w/~w", Name, Arity),
@@ -162,7 +163,8 @@ check(Ctx, Decl = {function, Loc, Name, Arity, _}, PolyTy) ->
             end
       end,
       AltTys),
-    UnmatchedEverywhere = sets:intersection(UnmatchedList),
+
+    UnmatchedEverywhere = intersect_unmatched(Clauses, UnmatchedList),
     case sets:to_list(UnmatchedEverywhere) of
         [] ->
             ?LOG_INFO("Type ok for ~w/~w at ~s", Name, Arity, ast:format_loc(Loc)),
@@ -170,6 +172,7 @@ check(Ctx, Decl = {function, Loc, Name, Arity, _}, PolyTy) ->
         [First | _Rest] ->
             report_tyerror(FunStr, redundant_branch, First, "")
     end.
+
 
 -type unmatched_branch_mode() ::
     unmatched_branch_fail       % throw a type error if a branch never matches
@@ -249,4 +252,52 @@ report_tyerror(FunName, Kind, Loc, Hint) ->
     case Hint of
         "" -> errors:ty_error(Loc, "in ~s, ~s~n~s", [FunName, tyerror_msg(Kind), SrcCtx]);
         _ -> errors:ty_error(Loc, "in ~s, ~s~n~s~n~n  ~s", [FunName, tyerror_msg(Kind), SrcCtx, Hint])
+    end.
+
+-spec intersect_unmatched([ast:fun_clause()], [sets:set(ast:loc())]) -> sets:set(ast:loc()).
+intersect_unmatched(Clauses, UnmatchedList) ->
+    SublocationMap = sublocation_map(Clauses),
+    UnmatchedListTransitive = lists:map(
+      fun(UnmatchedSet) ->
+          sets:fold(fun(LLoc, Acc) ->
+              Sublocs = sets:from_list(maps:get(LLoc, SublocationMap, [])),
+              sets:union(Acc, Sublocs)
+          end, UnmatchedSet, UnmatchedSet)
+      end,
+      UnmatchedList),
+    sets:intersection(UnmatchedListTransitive).
+
+% Builds a map from each branching location to all descendant locations.
+% Uses everything with {rec, _} to match branching constructs while continuing
+% recursion into their children to find nested constructs.
+% Entries are returned outermost-first, so foldr processes bottom-up,
+% allowing collect_locs to reuse cached results for inner constructs.
+-spec sublocation_map(any()) -> #{ast:loc() => [ast:loc()]}.
+sublocation_map(Term) ->
+    Entries = utils:everything(
+      fun({'case', Loc, Expr, Clauses}) -> {rec, {Loc, [Expr, Clauses]}};
+         ({'fun', Loc, _, Clauses}) -> {rec, {Loc, Clauses}};
+         ({case_clause, Loc, Pat, _Guards, Body}) -> {rec, {Loc, [Pat, Body]}};
+         ({fun_clause, Loc, Pats, _Guards, Body}) -> {rec, {Loc, [Pats, Body]}};
+         (_) -> error
+      end, Term),
+    lists:foldr(fun({Loc, Children}, Cache) ->
+        maps:put(Loc, collect_locs(Children, Cache), Cache)
+    end, #{}, Entries).
+
+-spec collect_locs(any(), #{ast:loc() => [ast:loc()]}) -> [ast:loc()].
+collect_locs(Term, Cache) ->
+    lists:flatten(utils:everything(
+      fun({loc, _, _, _} = Loc) -> {ok, Loc};
+         ({'case', Loc, _, _}) -> cached(Loc, Cache);
+         ({'fun', Loc, _, _}) -> cached(Loc, Cache);
+         ({case_clause, Loc, _, _, _}) -> cached(Loc, Cache);
+         ({fun_clause, Loc, _, _, _}) -> cached(Loc, Cache);
+         (_) -> error
+      end, Term)).
+
+cached(Loc, Cache) ->
+    case Cache of
+        #{Loc := Locs} -> {ok, [Loc | Locs]};
+        _ -> {rec, Loc}
     end.

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -115,20 +115,23 @@ everywhere(F, T) ->
     end.
 
 % Generically transforms the term given and collects all results T
-% where the given function returns {ok, T} for a term. No recursive calls
-% are made for such terms
--spec everything(fun((term()) -> t:opt(T)), term()) -> [T].
+% where the given function returns {ok, T} or {rec, T} for a term.
+% {ok, T} collects T and stops recursion; {rec, T} collects T and continues recursion.
+-spec everything(fun((term()) -> t:opt(T) | {rec, T}), term()) -> [T].
 everything(F, T) ->
     TransList = fun(L) -> lists:flatmap(fun(X) -> everything(F, X) end, L) end,
+    Recurse = fun() ->
+        case T of
+            X when is_list(X) -> TransList(X);
+            X when is_tuple(X) -> TransList(tuple_to_list(X));
+            X when is_map(X) -> TransList(maps:to_list(X));
+            _ -> []
+        end
+    end,
     case F(T) of
-        error ->
-            case T of
-                X when is_list(X) -> TransList(X);
-                X when is_tuple(X) -> TransList(tuple_to_list(X));
-                X when is_map(X) -> TransList(maps:to_list(X));
-                _ -> []
-            end;
-        {ok, X} -> [X]
+        error -> Recurse();
+        {ok, X} -> [X];
+        {rec, X} -> [X | Recurse()]
     end.
 
 -spec if_true(boolean(), fun(() -> _T)) -> ok.

--- a/test_files/tycheck_simple/intersection.erl
+++ b/test_files/tycheck_simple/intersection.erl
@@ -192,3 +192,11 @@ branch_unmatched_in_all_intersections_fail(X) ->
         2 -> 20;
         3 -> 30
     end.
+
+-spec branch_unmatched_in_nested_expression_fail(foo) -> boolean(); (bar) -> boolean().
+branch_unmatched_in_nested_expression_fail(foo) ->
+    case bar of
+        [] -> true;
+        _  -> false
+    end;
+branch_unmatched_in_nested_expression_fail(_) -> true.


### PR DESCRIPTION
Fixes #294.
Fixes #55.
Fixes #291.

This is a crude implementation that recalculates the transitive closure of sub-locations that belong to a location. It could be pre-calculated in the ast transformation phase for better efficiency.


Depends on #283