### PR TITLE
Fixed clean bug

### DIFF
--- a/src/subst.erl
+++ b/src/subst.erl
@@ -185,10 +185,10 @@ collect_vars(M = {map, _}, CPos, Pos, Fix) ->
     collect_vars(ty_parser:rewrite_map_to_representation(M), CPos, Pos, Fix);
 collect_vars({K, Components}, CPos, Pos, Fix) when K == union; K == intersection; K == tuple ->
     VPos = lists:map(fun(Ty) -> collect_vars(Ty, CPos, Pos, Fix) end, Components),
-    lists:foldl(fun(FPos, Current) -> maps:merge_with(fun combine_vars/3, FPos, Current) end, #{}, VPos);
+    lists:foldl(fun(FPos, Current) -> maps:merge_with(fun combine_vars/3, FPos, Current) end, Pos, VPos);
 collect_vars({fun_full, Components, Target}, CPos, Pos, Fix) ->
     VPos = lists:map(fun(Ty) -> collect_vars(Ty, 1 - CPos, Pos, Fix) end, Components),
-    M1 = lists:foldl(fun(FPos, Current) -> maps:merge_with(fun combine_vars/3, FPos, Current) end, #{}, VPos),
+    M1 = lists:foldl(fun(FPos, Current) -> maps:merge_with(fun combine_vars/3, FPos, Current) end, Pos, VPos),
     M2 = collect_vars(Target, CPos, Pos, Fix),
     maps:merge_with(fun combine_vars/3, M1, M2);
 collect_vars({negation, Ty}, CPos, Pos, Fix) -> collect_vars(Ty, 1 - CPos, Pos, Fix);


### PR DESCRIPTION
Fixed a bug where collecting variables during cleaning get lost. The test case is type checking the `erlang_types` library. I opened #304 to write a small unit test for this edge case at some point.


Depends on #283