### PR TITLE
Type annotations as Expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.plt
 erl_crash.dump
 .concrete/DEV_MODE
+**/rebar3.crashdump
 
 # etylizer
 _etylizer/

--- a/include/etylizer.hrl
+++ b/include/etylizer.hrl
@@ -1,0 +1,63 @@
+%% Syntax elements for type annotations
+%%
+%% The macro ?annotate_type/2 can be used to annotate an expression with a type. 
+%% This is useful to speed up type checking or as an assert that an expression should have the specified type. 
+%% The specified type must be compatible with the type detected by Etylizer. Otherwise a type error is reported.
+%%
+%%     N = ?annotate_type( 10, non_neg_integer() )
+%%
+%% The macro ?assert_type/2 can be used to refine (downcast) a type propagated
+%% by Etylizer. For example, the programmer may know that values stored in an ETS table
+%% have a more precise type than term()
+%%
+%%     % MyETSValue :: term()
+%%     Arity = ?assert_type( MyETSValue, {ok, any()} )
+%%
+%% The functions '::'/2 and ':::'/2 can also be used directly if the type is
+%% quoted:
+%%
+%%     N = '::'(Message, "non_neg_integer()")
+%%
+%% Etylizer detects occurrences of the functions '::'/2 and ':::'/2 and
+%% adjusts type checking accordingly. The macros are supplied only for
+%% convenience.
+%%
+%% By default, Etylizer checks for exhaustiveness in expressions.
+%% If you want to leverage the 'let it crash' behavior,
+%% the pattern assertion macro can be used to force exhaustiveness of a pattern:
+%%
+%%     ?assert_pattern({ok, _}, file:read_file_info("myfile"))
+%%
+%% To bind the result to variables, match the entire macro result:
+%%
+%%     {ok, Info} = ?assert_pattern({ok, _}, file:read_file_info("myfile"))
+%%
+%% Note: Variables bound inside Pattern do not leak into the surrounding scope.
+%% The macro uses a fun-call wrapper (IIFE) following the same convention as
+%% OTP's assert.hrl to avoid exporting local variables.
+%%
+-compile({inline, ['::'/2, ':::'/2]}).
+-compile({nowarn_unused_function, ['::'/2, ':::'/2]}).
+-ignore_xref(['::'/2, ':::'/2]).
+
+-spec '::'(A, _) -> A.
+'::'(Expr, _Type) -> Expr.
+
+-spec ':::'(A, _) -> A.
+':::'(Expr, _Type) -> Expr.
+
+%% Type annotation
+-define(annotate_type(Expr, Type), '::'(Expr, ??Type)).
+
+%% Type assertion
+-define(assert_type(Expr, Type), ':::'(Expr, ??Type)).
+
+%% Exhaustiveness cover to let it crash.
+%% Uses a fun-call wrapper to avoid leaking the internal variable into the
+%% surrounding scope. The X__V name follows OTP's assert.hrl convention.
+-define(assert_pattern(Pattern, Expr),
+    begin
+    ((fun (X__V) ->
+        case X__V of Pattern -> X__V; _ -> error(exhaustiveness_violated) end
+      end)(Expr))
+    end).

--- a/src/ast.erl
+++ b/src/ast.erl
@@ -74,6 +74,8 @@
     exp_tuple/0,
     exp_try/0,
     exp_var/0,
+    exp_annotate/0,
+    exp_assert/0,
     exp/0,
     exps/0,
     qual_list_gen/0,
@@ -319,6 +321,9 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 -type gen_var() :: {var, loc(), any_ref()}.
 -type exp_var() :: gen_var().
 
+-type exp_annotate() :: {annotate, loc(), exp(), ty()}.
+-type exp_assert() :: {assert, loc(), exp(), ty()}.
+
 % There is no match expression, because match expressions are represented as case expressions.
 -type exp() :: atomic_lit() | exp_bitstring_compr() | exp_bitstring_constr() | exp_block()
     | exp_case() | exp_catch() | exp_cons() | exp_fun_ref() | exp_fun_ref_dyn() | exp_fun()
@@ -326,7 +331,7 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
     | exp_map_create() | exp_map_update() | exp_map_compr()
     | exp_nil() | exp_binop() | exp_unop() | exp_recv() | exp_recv_after() | exp_record_create()
     | exp_record_access() | exp_record_index() | exp_record_update() | exp_tuple() | exp_try()
-    | exp_var().
+    | exp_var() | exp_annotate() | exp_assert().
 
 -type exps() :: [exp()].
 

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -6,6 +6,11 @@
 
 -export_type([trans_mode/0]).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+
 -compile([nowarn_shadow_vars]).
 
 -include("log.hrl").
@@ -457,6 +462,22 @@ trans_exp(Ctx, Env, Exp) ->
             {NewName, NewEnv} = varenv_local:insert(Name, Env),
             {{'fun', to_loc(Ctx, Anno), {local_bind, NewName},
               trans_fun_clauses(Ctx, NewEnv, FunClauses)}, Env};
+        % annotate type
+        {call, _, {'atom', _, '::'}, [Exp0, {string, Anno, TypeStr}]} -> 
+            case parse_type(Ctx, TypeStr) of
+                error -> errors:ty_error(to_loc(Ctx, Anno), "Invalid type annotation");
+                {ok, TypeOfExp} -> 
+                    {NewExp, NewEnv} = trans_exp(Ctx, Env, Exp0), 
+                    {{annotate, to_loc(Ctx, Anno), NewExp, TypeOfExp}, NewEnv}
+            end;
+        % force type
+        {call, _, {'atom', _, ':::'}, [Exp0, {string, Anno, TypeStr}]} -> 
+            case parse_type(Ctx, TypeStr) of
+                error -> errors:ty_error(to_loc(Ctx, Anno), "Invalid type assert");
+                {ok, TypeOfExp} -> 
+                    {NewExp, NewEnv} = trans_exp(Ctx, Env, Exp0), 
+                    {{assert, to_loc(Ctx, Anno), NewExp, TypeOfExp}, NewEnv}
+            end;
         {call, Anno, {'atom', AnnoName, FunName}, Args} -> % special case
             LocName = to_loc(Ctx, AnnoName),
             {NewArgs, NewEnv} = trans_exps(Ctx, Env, Args),
@@ -960,3 +981,45 @@ arity(Loc, L) ->
        true -> errors:ty_error(Loc, "too many arguments: ~w", Len)
     end.
 
+% similar to what Gradualizer does
+% ctx used for locations
+-spec parse_type(ctx(), string()) -> error | {ok, ast:ty()}.
+parse_type(Ctx, Src) ->
+    AttrSrc = "-type t() :: " ++ Src ++ ".",
+    {ok, Tokens, _EndLocation} = erl_scan:string(AttrSrc),
+    % the variables in the outer function -type definition are not in scope in the annotation
+    % at some point, we could extend this like Haskell's ScopeTypeVariables, if there is any need
+    case erl_parse:parse_form(Tokens) of
+        {ok, {attribute, _, type, Def = {t, _Type, []}}} ->
+            {_, {ty_scheme, [], TyNew}} = trans_tydef(Ctx, Def),
+            {ok, TyNew};
+        _ -> error
+    end.
+
+
+-ifdef(TEST).
+
+test_ctx() ->
+    #ctx{ path = ".", module_name = ast_transform, funenv = varenv:empty("function"), records = #{} }.
+
+parse_type_test() ->
+    Ctx = test_ctx(),
+    {ok, {predef_alias, string}} = parse_type(Ctx, "string()"),
+    {ok, {singleton, a}} = parse_type(Ctx, "a"),
+
+    % user types are supported (no locations, though)
+    {ok, {named, _, _, [{named, _, _, _}]}} = parse_type(Ctx, "parser(command())"),
+
+    % type error
+    error = parse_type(Ctx, "not a type"),
+
+    % free type variables not supported
+    ?assertThrow({etylizer, name_error, _}, parse_type(Ctx, "A")),
+
+    % type variables are only bound in the -spec annotation
+    % therefore, no type variables are supported in annotations
+    ?assertThrow({etylizer, name_error, _}, parse_type(Ctx, "fun((A) -> A)")),
+
+    ok.
+
+-endif.

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -410,8 +410,25 @@ exp_constrs(Ctx, E, T) ->
             Mater = {cvarmater, Locs, AnyRef, AlphaName},
             Link = {csubty, Locs, {var, AlphaName}, T},
             sets:from_list([Mater, Link]);
+        {assert, Loc, Exp, TargetType} ->
+            % Γ ⊢ e : alpha   TargetType <: alpha   TargetType <: T
+            % --------------------------------------- constr-downcast
+            % Γ ⊢ (e ::: TargetType) : T
+            Alpha = fresh_tyvar(Ctx), 
+            Cons = exp_constrs(Ctx, Exp, Alpha),
+            DowncastConstr = {csubty, mk_locs("downcast", Loc), TargetType, Alpha},
+            SubsumConstr = {csubty, mk_locs("downcast result", Loc), TargetType, T},
+            sets:add_element(SubsumConstr, sets:add_element(DowncastConstr, Cons));
+        {annotate, L, Exp, Type} ->
+            % Γ ⊢ e : τ   τ <: T
+            % ------------------- constr-annot
+            % Γ ⊢ (e :: τ) : T
+            Cons = exp_constrs(Ctx, Exp, Type),
+            Annot = {csubty, mk_locs("type annotation", L), Type, T},
+            sets:add_element(Annot, Cons);
         X -> errors:uncovered_case(?FILE, ?LINE, X)
     end.
+
 
 -spec process_qualifiers(ctx(), ast:loc(), [ast:qualifier()], constr:constr_env(), constr:constrs()) ->
           {constr:constr_env(), constr:constrs()}.

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -5,6 +5,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("log.hrl").
 -include("etylizer_main.hrl").
+-include("parse.hrl").
 
 -spec check_ok_fun(string(), symtab:t(), symtab:t(), ast:fun_decl(), ast:ty_scheme()) -> ok.
 check_ok_fun(Filename, Tab, OverlayTab, Decl = {function, L, Name, Arity, _}, Ty) ->
@@ -82,7 +83,7 @@ has_intersection({ty_scheme, _, _}) -> false.
 
 -spec check_decls_in_file(string(), what(), sets:set(string())) -> list().
 check_decls_in_file(F, What, NoInfer) ->
-  RawForms = parse:parse_file_or_die(F),
+  {ok, RawForms} = parse:parse_file(F, #parse_opts{includes = ["include"]}),
   Forms = ast_transform:trans(F, RawForms),
   SearchPath = paths:compute_search_path(#opts{}),
   OverlayTab = symtab:empty(),

--- a/test_files/tycheck_simple/type_annotation.erl
+++ b/test_files/tycheck_simple/type_annotation.erl
@@ -1,0 +1,81 @@
+-module(type_annotation).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("etylizer.hrl").
+
+% Each top-level definition of this module is typechecked in isolation
+% against its spec, inference is also tested.
+% If the name ends with _fail, the test must fail.
+
+%%%%%%%%%%%%%%%%%%%%%%%% TYPE ANNOTATIONS    %%%%%%%%%%%%%%%%%%%%%%%%
+ 
+% user-defined type
+-spec annot_01() -> atom().
+annot_01() -> ?annotate_type(foobar, atom()).
+
+-spec annot_02(integer()) -> any().
+annot_02(N) -> ?annotate_type(N, number()).
+
+-spec annot_03_fail(integer()) -> atom().
+annot_03_fail(N) -> ?annotate_type(N, atom()).
+
+-type annot_user_04() :: {foo}.
+-spec annot_04({foo}) -> {foo}.
+annot_04(N) -> ?annotate_type(N, annot_user_04()).
+
+-spec annot_05_fail(integer()) -> atom().
+annot_05_fail(N) -> ?annotate_type(N, pos_integer()).
+
+-spec assert_01() -> atom().
+assert_01() ->
+    X = {a, b},
+    % does not fail as type of X is inferred to be 
+    % {a | b} U atom()
+    ?assert_type(X, atom()). 
+
+-spec assert_02_fail() -> {a, b}.
+assert_02_fail() ->
+    X = {a, b},
+    ?assert_type(X, atom()). 
+
+-spec assert_03_fail() -> {foo, bar}.
+assert_03_fail() ->
+    X = {a, b},
+    % fails because return type atom() does not match spec {foo, bar}
+    ?assert_type(X, atom()).
+
+-spec assert_04(term()) -> atom().
+assert_04(N) -> ?assert_type(N, atom()). % downcast
+
+% check 0 branches for redundancy???
+-spec to_upper([byte()]) -> Result when Result :: [byte()] ; (char()) -> char().
+%-spec to_upper([byte()]) -> [byte()] ; (char()) -> char().
+to_upper(_) -> error(impl).
+-spec assert_05() -> nonempty_string().
+assert_05() ->
+    to_upper(?assert_type("FOO", [byte()])).
+
+-spec assert_06(integer(), tuple()) -> [integer()].
+assert_06(V, Graph) ->
+    ?assert_type(element(?assert_type(V + 1, pos_integer()), Graph), [integer()]).
+
+%%%%%%%%%%%%%%%%%%%%%%%% PATTERN ASSERTIONS  %%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec assert_pattern_01({ok, foo|hello}) -> {ok, atom()}.
+assert_pattern_01(Z) ->
+    ?assert_pattern({ok, foo}, Z).
+
+-spec assert_pattern_02_fail({ok, foo}) -> {ok, atom()}.
+assert_pattern_02_fail(Z) ->
+    ?assert_pattern({ok, foo}, Z). % we can't make something exhaustive if it's already exhaustive
+
+-spec assert_pattern_03(ok | error) -> ok.
+assert_pattern_03(X) ->
+    ?assert_pattern(ok, X).
+
+-spec assert_pattern_04({ok | foo, atom()}) -> {ok, atom()}.
+assert_pattern_04(Z) ->
+    {ok, Val} = ?assert_pattern({ok, _}, Z),
+    {ok, Val}.


### PR DESCRIPTION
Added type annotations and type assertions as extension to the AST. We provide an include file to use these, similar to how Gradualizer does.

Type annotations are mainly used to speed up type checking, and type assertions are used as escape hatches (e.g. when working with ETS tables).

There is also a macro to force pattern exhaustiveness for convenience. This will fix #12.

Depends on #283