### PR TITLE
Better Comprehensions

### DIFF
--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -218,8 +218,25 @@ resolve_ety_ty(_, intersection, Tys) ->
         _ -> {intersection, Tys}
     end;
 resolve_ety_ty(_, without, [T, U]) -> {intersection, [T, {negation, U}]};
+resolve_ety_ty(_, mu, [Body]) ->
+    Name = list_to_atom("$mu_" ++ integer_to_list(erlang:unique_integer([positive]))),
+    {mu, {mu_var, Name}, replace_mu_var(Body, Name)};
+resolve_ety_ty(_, mu_var, []) -> {mu_var, '$mu_placeholder'};
 resolve_ety_ty(L, Name, _) ->
     errors:ty_error(L, "Invalid use of builtin type etylizer:~w", Name).
+
+-spec replace_mu_var(ast:ty(), atom()) -> ast:ty().
+replace_mu_var({mu_var, '$mu_placeholder'}, Name) -> {mu_var, Name};
+replace_mu_var(T, Name) when is_tuple(T) ->
+    list_to_tuple(replace_mu_var_list(tuple_to_list(T), Name));
+replace_mu_var(L, Name) when is_list(L) ->
+    replace_mu_var_list(L, Name);
+replace_mu_var(T, _Name) -> T.
+
+-spec replace_mu_var_list([term()], atom()) -> [term()].
+replace_mu_var_list([], _Name) -> [];
+replace_mu_var_list([H | T], Name) ->
+    [replace_mu_var(H, Name) | replace_mu_var_list(T, Name)].
 
 -spec eval_const_ty(erl_parse:abstract_expr(), ast:loc()) -> {singleton, integer()}.
 eval_const_ty(Ty, Loc) ->
@@ -919,18 +936,22 @@ trans_qualifiers(Ctx, Env, Qs) ->
     -> {ast:qualifier(), varenv_local:t()}.
 trans_qualifier(Ctx, Env, Q) ->
     case Q of
-        {K, Anno, Pat, Exp} when (K == generate_strict orelse K == generate orelse K == b_generate) -> % generator "Pat <- Exp"
+         % generator patterns for lists and bitstrings Pat <- / <:- / <= / <:= Exp
+        {K, Anno, Pat, Exp} when
+              (K == generate orelse K == generate_strict orelse K == b_generate orelse K == b_generate_strict) ->
             NewExp = trans_exp_noenv(Ctx, Env, Exp),
             {NewPat, NewEnv} = trans_pat(Ctx, Env, Pat, shadow),
             {{K, to_loc(Ctx, Anno), NewPat, NewExp}, NewEnv};
+         % map generate patterns  KeyPattern := ValuePattern <- / <:- MapExpression
+        {K, Anno, {map_field_exact, _Anno2, KeyPat, ValPat}, Exp} when (K == m_generate orelse K == m_generate_strict)->
+            NewExp = trans_exp_noenv(Ctx, Env, Exp),
+            {NewK, NewEnv1} = trans_pat(Ctx, Env, KeyPat, shadow),
+            {NewV, NewEnv2} = trans_pat(Ctx, NewEnv1, ValPat, shadow),
+            {{K, to_loc(Ctx, Anno), NewK, NewV, NewExp}, NewEnv2};
+        % zip generator
         {zip, Anno, Qs} ->
             {NewQ, NewEnv} = trans_qualifiers(Ctx, Env, Qs),
             {{zip, to_loc(Ctx, Anno), NewQ}, NewEnv};
-        {m_generate, Anno, {map_field_exact, _Anno2, K, V}, Exp} ->
-            NewExp = trans_exp_noenv(Ctx, Env, Exp),
-            {NewK, NewEnv1} = trans_pat(Ctx, Env, K, shadow),
-            {NewV, NewEnv2} = trans_pat(Ctx, NewEnv1, V, shadow),
-            {{m_generate, to_loc(Ctx, Anno), NewK, NewV, NewExp}, NewEnv2};
         Exp -> % filter
             trans_exp(Ctx, Env, Exp)
     end.

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -451,29 +451,101 @@ process_qualifiers(Ctx, Loc, [Q | Qs], Env, Cs) ->
         {generate_strict, LGen, Pat, Exp} ->
             Alpha = fresh_tyvar(Ctx),
             ExpCs = exp_constrs(Ctx, Exp, stdtypes:tlist(Alpha)),
+
+            % For strict generators, the list element type must be a subtype of the pattern type
+            TyPat = ty_of_pat(Ctx#ctx.symtab, Env, Pat, upper),
+            StrictCs = sets:from_list([
+                {csubty, mk_locs("strict list generator", LGen), Alpha, TyPat}
+            ]),
+
             {PatCs, PatEnv} = pat_env(Ctx, LGen, Alpha, Pat),
             NewEnv = intersect_envs(Env, PatEnv),
-            process_qualifiers(Ctx, Loc, Qs, NewEnv, sets:union([Cs, ExpCs, PatCs]));
+            process_qualifiers(Ctx, Loc, Qs, NewEnv, sets:union([Cs, ExpCs, PatCs, StrictCs]));
         % list generator: Pat <- Exp
-        % FIXME we treat relaxed generators as strict currently
         {generate, LGen, Pat, Exp} ->
-            process_qualifiers(Ctx, Loc, [{generate_strict, LGen, Pat, Exp} | Qs], Env, Cs);
+            Alpha = fresh_tyvar(Ctx), % list elements
+            Beta = fresh_tyvar(Ctx), % pattern
+
+            ExpCs = exp_constrs(Ctx, Exp, stdtypes:tlist(Alpha)),
+
+            TyPat = ty_of_pat(Ctx#ctx.symtab, Env, Pat, upper),
+            {PatCs, PatEnv} = pat_env(Ctx, LGen, Beta, Pat),
+
+            GeneratorC = [
+                          {csubty, mk_locs("pattern lower bound", LGen), ast_lib:mk_intersection([Alpha, TyPat]), Beta},
+                          {csubty, mk_locs("pattern upper bound", LGen), Beta, Alpha}
+                         ],
+            NewEnv = intersect_envs(Env, PatEnv),
+            process_qualifiers(Ctx, Loc, Qs, NewEnv, sets:union([Cs, ExpCs, PatCs, sets:from_list(GeneratorC)]));
         {zip, LGen, NestedQualifiers} ->
             {NewEnv, NewCs} = process_qualifiers(Ctx, LGen, NestedQualifiers, Env, Cs),
             process_qualifiers(Ctx, Loc, Qs, NewEnv, NewCs);
+        % Pat <= Exp
         {b_generate, _, _, _} ->
             errors:unsupported(Loc, "generator ~w", Q);
-        {m_generate, _, _, _} ->
+        % Pat <:= Exp
+        {b_generate_strict, _, _, _} ->
             errors:unsupported(Loc, "generator ~w", Q);
+        % strict map generator: KeyPat := ValPat <:- Exp
+        {m_generate_strict, LGen, KeyPat, ValPat, Exp} ->
+            KeyAlpha = fresh_tyvar(Ctx),
+            ValAlpha = fresh_tyvar(Ctx),
+            ExpCs = exp_constrs(Ctx, Exp, stdtypes:tmap(KeyAlpha, ValAlpha)),
+
+            % For strict generators, the map element types must be subtypes of the pattern types
+            TyKeyPat = ty_of_pat(Ctx#ctx.symtab, Env, KeyPat, upper),
+            TyValPat = ty_of_pat(Ctx#ctx.symtab, Env, ValPat, upper),
+            StrictCs = sets:from_list([
+                {csubty, mk_locs("strict map generator key", LGen), KeyAlpha, TyKeyPat},
+                {csubty, mk_locs("strict map generator value", LGen), ValAlpha, TyValPat}
+            ]),
+
+            {KeyPatCs, KeyPatEnv} = pat_env(Ctx, LGen, KeyAlpha, KeyPat),
+            {ValPatCs, ValPatEnv} = pat_env(Ctx, LGen, ValAlpha, ValPat),
+            PatEnv = maps:merge(KeyPatEnv, ValPatEnv),
+            NewEnv = intersect_envs(Env, PatEnv),
+            process_qualifiers(Ctx, Loc, Qs, NewEnv, sets:union([Cs, ExpCs, KeyPatCs, ValPatCs, StrictCs]));
+        % map generator: KeyPat := ValPat <- Exp
+        {m_generate, LGen, KeyPat, ValPat, Exp} ->
+            KeyAlpha = fresh_tyvar(Ctx), % map key type
+            ValAlpha = fresh_tyvar(Ctx), % map value type
+            KeyBeta = fresh_tyvar(Ctx), % key pattern type
+            ValBeta = fresh_tyvar(Ctx), % value pattern type
+
+            ExpCs = exp_constrs(Ctx, Exp, stdtypes:tmap(KeyAlpha, ValAlpha)),
+
+            % Get upper bounds for filtering
+            TyKeyPat = ty_of_pat(Ctx#ctx.symtab, Env, KeyPat, upper),
+            TyValPat = ty_of_pat(Ctx#ctx.symtab, Env, ValPat, upper),
+
+            {KeyPatCs, KeyPatEnv} = pat_env(Ctx, LGen, KeyBeta, KeyPat),
+            {ValPatCs, ValPatEnv} = pat_env(Ctx, LGen, ValBeta, ValPat),
+
+            % Filtering constraints for both key and value
+            GeneratorC = [
+                          {csubty, mk_locs("key pattern lower bound", LGen), ast_lib:mk_intersection([KeyAlpha, TyKeyPat]), KeyBeta},
+                          {csubty, mk_locs("key pattern upper bound", LGen), KeyBeta, KeyAlpha},
+                          {csubty, mk_locs("value pattern lower bound", LGen), ast_lib:mk_intersection([ValAlpha, TyValPat]), ValBeta},
+                          {csubty, mk_locs("value pattern upper bound", LGen), ValBeta, ValAlpha}
+                         ],
+            PatEnv = maps:merge(KeyPatEnv, ValPatEnv),
+            NewEnv = intersect_envs(Env, PatEnv),
+            process_qualifiers(Ctx, Loc, Qs, NewEnv, sets:union([Cs, ExpCs, KeyPatCs, ValPatCs, sets:from_list(GeneratorC)]));
         % Filter expression
         % be careful here,
         % the catch-all will handle cases that are not supposed to be filters
         % this can happen when a new feature is introduced (e.g. zip, strict_generate)
         Filter ->
             % apply current environment to filter expression
-            FilterCs = sets:from_list([{cdef, mk_locs("filter", Loc), Env,
-                                      exps_constrs(Ctx, Loc, [Filter], stdtypes:tbool())}]),
-            process_qualifiers(Ctx, Loc, Qs, Env, sets:union(Cs, FilterCs))
+            FilterExpCs = exps_constrs(Ctx, Loc, [Filter], stdtypes:tbool()),
+            FilterCs = sets:from_list([{cdef, mk_locs("filter", Loc), Env, FilterExpCs}]),
+
+            % treat filter as if it is a guard to refine existing variable types
+            % guard_seq_env cannot be applied to any expression,
+            % but the default case is unsafe, so we do it anyway
+            {GuardEnv, _} = guard_seq_env([[Filter]]),
+            NewEnv = intersect_envs(Env, GuardEnv),
+            process_qualifiers(Ctx, Loc, Qs, NewEnv, sets:union(Cs, FilterCs))
     end.
 
 -spec gen_funcall_constrs(ctx(), ast:loc(), ast:exp(), [ast:exp()], ast:ty()) -> constr:constrs().

--- a/src/erlang_types/ty_parser.erl
+++ b/src/erlang_types/ty_parser.erl
@@ -113,9 +113,9 @@ parse(RawTy) ->
   % create a reference, check if it is inside the cache
   LocalRef = new_local_ref(Ty),
 
-  FinalResult = 
+  FinalResult =
   case ets:lookup(?CACHE, LocalRef) of
-    [{LocalRef, Node}] -> 
+    [{LocalRef, Node}] ->
       Node;
     _ ->
       % 1. Convert to temporary local representation
@@ -724,8 +724,8 @@ convert_back(Type) ->
   Result.
 
 -spec convert_back(ast_ty(), var_env(), non_neg_integer()) -> {ast_ty(), non_neg_integer()}.
-convert_back({mu, _, Body}, Env, Counter) ->
-  Name = make_fresh_name(Counter),
+convert_back({mu, _, Body} = MuTy, Env, Counter) ->
+  Name = make_fresh_name(Counter, MuTy),
   NewEnv = [Name | Env],
   {ConvertedBody, NewCounter} = convert_back(Body, NewEnv, Counter + 1),
   {{mu, {mu_var, Name}, ConvertedBody}, NewCounter};
@@ -797,9 +797,10 @@ convert_back_assocs([{Kind, K, V}|Rest], Env, Counter) ->
   {ConvertedRest, NewCounter} = convert_back_assocs(Rest, Env, Counter2),
   {[{Kind, ConvertedK, ConvertedV}|ConvertedRest], NewCounter}.
 
--spec make_fresh_name(non_neg_integer()) -> ast:ty_varname().
-make_fresh_name(Counter) ->
-  list_to_atom("$var_" ++ integer_to_list(Counter)).
+% we need to hash the body of the mu type otherwise the caching thinks two mu vars are the same just by looking at their counter
+-spec make_fresh_name(non_neg_integer(), ast_ty()) -> ast:ty_varname().
+make_fresh_name(Counter, MuTy) ->
+  list_to_atom("$var_" ++ integer_to_list(Counter) ++ "_" ++ integer_to_list(erlang:phash2(MuTy))).
 
 -spec assert_replaced_refs_have_good_order(#{temporary_ref() => type()}) -> ok.
 assert_replaced_refs_have_good_order(Refs) ->

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -158,11 +158,6 @@ simple_test_() ->
     % TODO better redundancy check detection for dynamic()
     "refine_times_02_fail",
     "refine_times_03_fail",
-    % TODO refinement for list comprehensions doesn't work (#279)
-    "lc_13",
-    % TODO unbound cariable in constraint simplification (#278)
-    "lc_11",
-    "lc_12_fail",
     % TODO for if expressions guards always reference outer scope variables
     %      lower is always none() for any non-trivial if guard
     %      see case_13_fail, maybe at some point we have better
@@ -184,6 +179,8 @@ simple_test_() ->
     "match_13",
     % TODO slow (tuple-encoded lists) inference #255
     % reason: recursive types parsing and unparsing in solving step (missing proper substitution implementation)
+    "list_as_tuple_12",
+    "list_as_tuple_rep_02",
     "list_as_tuple_08",
     "list_pattern_11",
     "list_pattern_10_fail_h",
@@ -192,9 +189,6 @@ simple_test_() ->
     "inter_04_ok",
     "foo",
     "op_08",
-    % TODO inferred type is less general than spec?
-    "lc_10",
-    "zip_01",
     % TODO slow maybe inference
     "maybe_08",
     "maybe_09"

--- a/test_files/etylizer-mini/changelog.txt
+++ b/test_files/etylizer-mini/changelog.txt
@@ -21,3 +21,4 @@ Document all changes necessary to get the source code working
 - build_funenv needs held with type guards, needs varenv instantiation
 - removed diff_terms/3, unused and buggy
 - mk_builtin_funs needs additional is_list guard and needs precise filtermap spec
+- ast_transform:trans_map_assoc has refinement now, branch redundant

--- a/test_files/etylizer-mini/src/ast_transform.erl
+++ b/test_files/etylizer-mini/src/ast_transform.erl
@@ -829,15 +829,18 @@ trans_qualifiers(Ctx, Env, Qs) ->
     -> {ast:qualifier(), varenv_local:t()}.
 trans_qualifier(Ctx, Env, Q) ->
     case Q of
-        {K, Anno, Pat, Exp} when (K == generate orelse K == b_generate) -> % generator "Pat <- Exp"
+         % generator patterns for lists and bitstrings Pat <- / <:- / <= / <:= Exp
+        {K, Anno, Pat, Exp} when 
+              (K == generate orelse K == generate_strict orelse K == b_generate orelse K == b_generate_strict) ->
             NewExp = trans_exp_noenv(Ctx, Env, Exp),
             {NewPat, NewEnv} = trans_pat(Ctx, Env, Pat, shadow),
             {{K, to_loc(Ctx, Anno), NewPat, NewExp}, NewEnv};
-        {m_generate, Anno, {map_field_exact, _Anno2, K, V}, Exp} ->
+         % map generate patterns  KeyPattern := ValuePattern <- / <:- MapExpression
+        {K, Anno, {map_field_exact, _Anno2, KeyPat, ValPat}, Exp} when (K == m_generate orelse K == m_generate_strict)->
             NewExp = trans_exp_noenv(Ctx, Env, Exp),
-            {NewK, NewEnv1} = trans_pat(Ctx, Env, K, shadow),
-            {NewV, NewEnv2} = trans_pat(Ctx, NewEnv1, V, shadow),
-            {{m_generate, to_loc(Ctx, Anno), NewK, NewV, NewExp}, NewEnv2};
+            {NewK, NewEnv1} = trans_pat(Ctx, Env, KeyPat, shadow),
+            {NewV, NewEnv2} = trans_pat(Ctx, NewEnv1, ValPat, shadow),
+            {{K, to_loc(Ctx, Anno), NewK, NewV, NewExp}, NewEnv2};
         Exp -> % filter
             trans_exp(Ctx, Env, Exp)
     end.
@@ -859,8 +862,8 @@ trans_map_assoc(Ctx, Env, Assoc) ->
                     map_field_assoc -> map_field_opt;
                     map_field_exact -> map_field_req
                 end,
-            {{NewK, to_loc(Ctx, Anno), NewExpKey, NewExpVal}, Env2};
-        X -> errors:uncovered_case(?FILE, ?LINE, X)
+            {{NewK, to_loc(Ctx, Anno), NewExpKey, NewExpVal}, Env2}
+        % X -> errors:uncovered_case(?FILE, ?LINE, X) refinement on K
     end.
 
 -spec trans_record_fields(ctx(), tyenv(), [ast_erl:record_field()]) -> [ast:record_field()].

--- a/test_files/tycheck_simple/comprehension.erl
+++ b/test_files/tycheck_simple/comprehension.erl
@@ -62,9 +62,30 @@ lc_11(Alts) -> [{S, A} || A <- Alts, S=A].
 -spec lc_12_fail(list(T)) -> list({T, T}).
 lc_12_fail(Alts) -> [{S, A} || A <- Alts, S=A].
 
--spec lc_13() -> [integer()].
-lc_13() -> 
+-spec lc_13_fail() -> [integer()].
+lc_13_fail() -> 
   [X || X <- [1,a,2,b,3], X > 3].
+
+-spec lc_13b() -> [integer()].
+lc_13b() -> 
+  [X || X <- [1,a,2,b,3], is_integer(X)].
+
+-spec lc_14(list(boolean())) -> list(boolean()).
+lc_14(Alts) -> [S || A <- Alts, case A of S -> S end].
+
+-spec lc_15([{fun_full, [A], B} | {other_type}]) -> [{A, B}].
+lc_15(Funs) -> [{A, B} || {fun_full, [A], B} <- Funs].
+
+-spec lc_15s_fail([{fun_full, [A], B} | {other_type}]) -> [{A, B}].
+lc_15s_fail(Funs) -> [{A, B} || {fun_full, [A], B} <:- Funs].
+
+-spec lc_16([{f, a} | b]) -> [a].
+lc_16(Funs) -> [A || {f, A} <- Funs].
+
+% strict list generator with constant pattern
+-spec lc_17_fail([atom()]) -> [ok].
+lc_17_fail(L) ->
+  [ok || ok <:- L].
 
 -spec mc_01() -> #{atom() => integer()}.
 mc_01() -> 
@@ -73,6 +94,18 @@ mc_01() ->
 -spec mc_02_fail() -> #{atom() => integer()}.
 mc_02_fail() -> 
   #{K => V || {K, V} <- [{hello, ok}]}.
+
+-spec mc_03() -> #{atom() => atom()}.
+mc_03() -> 
+  #{K => V || K := V <- #{foo => bar}}.
+
+-spec mc_04(#{atom() => atom()}) -> #{atom() => ok}.
+mc_04(M) -> 
+  #{K => ok || K := ok <- M}.
+
+-spec mc_05_fail(#{atom() => atom()}) -> #{atom() => ok}.
+mc_05_fail(M) ->
+  #{K => ok || K := ok <:- M}. % strictness causes exception
 
 -spec zip_01() -> [{integer(), atom(), integer()}].
 zip_01() ->

--- a/test_files/tycheck_simple/tuples.erl
+++ b/test_files/tycheck_simple/tuples.erl
@@ -80,6 +80,21 @@ list_as_tuple_07_fail() ->
   Fun = fun _F({_, Vs}) -> list_as_tuple_07_h(Vs) end,
   Fun({x, nil}).
 
+% lc_16: filter+extract from a tlist
+-spec list_as_tuple_09(tlist({f, a} | b)) -> tlist(a).
+list_as_tuple_09(nil) -> nil;
+list_as_tuple_09({{f, A}, Rest}) -> {A, list_as_tuple_09(Rest)};
+list_as_tuple_09({_, Rest}) -> list_as_tuple_09(Rest).
+
+% identity map over tlist
+-spec list_as_tuple_10(tlist(boolean())) -> tlist(boolean()).
+list_as_tuple_10(nil) -> nil;
+list_as_tuple_10({X, Rest}) -> {X, list_as_tuple_10(Rest)}.
+
+-spec list_as_tuple_12(etylizer:mu(nil | {boolean(), etylizer:mu_var()})) -> etylizer:mu(nil | {boolean(), etylizer:mu_var()}).
+list_as_tuple_12(nil) -> nil;
+list_as_tuple_12({X, Rest}) -> {X, list_as_tuple_12(Rest)}.
+
 -spec list_as_tuple_08(tlist(V)) -> {ok, V} | error | error2.
 list_as_tuple_08(nil) -> error;
 list_as_tuple_08({V, nil}) -> {ok, V};
@@ -89,3 +104,10 @@ list_as_tuple_08({_ , Rest}) ->
         _ -> error
     end.
 
+-spec list_as_tuple_rep_01(tlist(b)) -> tlist(a).
+list_as_tuple_rep_01({_, Rest}) -> {a, list_as_tuple_rep_01(Rest)};
+list_as_tuple_rep_01(nil) -> nil.
+
+-spec list_as_tuple_rep_02(etylizer:mu(nil | {b, etylizer:mu_var()})) -> etylizer:mu(nil | {a, etylizer:mu_var()}).
+list_as_tuple_rep_02({_, Rest}) -> {a, list_as_tuple_rep_02(Rest)};
+list_as_tuple_rep_02(_) -> nil.


### PR DESCRIPTION
Implemented all missing comprehension constructs (except for binaries)

It's a bit unclean that I used `guard_seq_env` to refine list comprehension filters. Filters can be any expression, not just a guard sequence. It's just a heuristic and maybe there is a better way, because it's not type spec conformant, but it works because of the catch-all. We could discuss this further in #312. 

List comprehension tests also revealed a bug in the handling of anonymous variables in the `ty_parser` module (and thus a bug in handling Erlang lists in general).
The `convert_back` function after debruijn used a deterministic counter (`$var_0, $var_1, ...`) to name mu variables. When two mu types with the same de Bruijn structure but different bodies were parsed in separate `parse/1` calls, they got the same mu variable name (`$var_0`). This caused `queue_if_new` to find a stale entry in the global `?CACHE ETS` table from the first mu type, making the second mu type's recursive reference point to the wrong node. The fix is to append append an identifier via hashing to distinguish different mu bodies.

To debug this issue, a new `etylizer:mu` type was needed so that it could be used in tests.

Fixes #20.
Fixes #149.