### PR TITLE
Record Improvements

### DIFF
--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -654,8 +654,9 @@ trans_exp(Ctx, Env, Exp) ->
                     end
                   end
                  ),
-            % fill in default expressions for omitted fields
-            AllFields = fill_record_defaults(Ctx, Name, to_loc(Ctx, Anno), NewFields),
+            % expand _ = Expr into individual fields, then fill in defaults for the rest
+            ExpandedFields = expand_record_field_other(Ctx, Name, NewFields),
+            AllFields = fill_record_defaults(Ctx, Name, to_loc(Ctx, Anno), ExpandedFields),
             {{record_create, to_loc(Ctx, Anno), Name, AllFields}, NewEnv};
         {record_field, Anno, E, Name, {'atom', _, Field}} ->
             {NewE, NewEnv} = trans_exp(Ctx, Env, E),
@@ -1048,6 +1049,39 @@ trans_map_assoc(Ctx, Env, Assoc) ->
                 end,
             {{NewK, to_loc(Ctx, Anno), NewExpKey, NewExpVal}, Env2};
         X -> errors:uncovered_case(?FILE, ?LINE, X)
+    end.
+
+% Expands record_field_other (the _ = Expr syntax) into individual record_field entries
+% for each field not explicitly given. The record_field_other entry is removed.
+-spec expand_record_field_other(ctx(), atom(), [ast:exp_record_create_field()]) ->
+    [{record_field, ast:loc(), atom(), ast:exp()}].
+expand_record_field_other(Ctx, RecName, Fields) ->
+    % Split into explicit fields and the optional wildcard
+    {Explicit, Other} = lists:partition(
+        fun({record_field, _, _, _}) -> true;
+           ({record_field_other, _, _}) -> false
+        end,
+        Fields),
+    case Other of
+        [] -> Explicit;
+        [{record_field_other, Loc, Exp}] ->
+            case maps:find(RecName, Ctx#ctx.records) of
+                error -> Explicit;
+                {ok, {_, DefFields}} ->
+                    GivenNames = sets:from_list(
+                        [N || {record_field, _, N, _} <- Explicit],
+                        [{version, 2}]),
+                    WildcardFields =
+                        lists:filtermap(
+                            fun({FieldName, _}) ->
+                                case sets:is_element(FieldName, GivenNames) of
+                                    true -> false;
+                                    false -> {true, {record_field, Loc, FieldName, Exp}}
+                                end
+                            end,
+                            DefFields),
+                    Explicit ++ WildcardFields
+            end
     end.
 
 % Extracts default expressions from transformed record field declarations.

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -21,7 +21,10 @@
           funenv :: funenv(),
           % The records seen so far. We need the record definitions to rewrite record types
           % into tuple types.
-          records :: #{ atom() => records:record_ty() }
+          records :: #{ atom() => records:record_ty() },
+          % Default expressions for record fields, used to fill in omitted fields during
+          % record construction.
+          record_defaults = #{} :: #{ atom() => #{ atom() => ast:exp() } }
         }).
 -type ctx() :: #ctx{}.
 
@@ -126,7 +129,7 @@ trans_form(Ctx, Form, Mode) ->
                 Loc = to_loc(Ctx, Anno),
                 {attribute, Loc, callback, Name, Arity, trans_spec_ty(Ctx, Loc, FunTys),
                  without_mod};
-            {attribute, Anno, record, {Name, Fields}} ->
+            {attribute, Anno, record, {Name, Fields}} when is_atom(Name) ->
                 % FIXME: this is a dirty hack to work around #152 (support for recursive record
                 % types). We temporarly register the name of the record with an empty record
                 % type, so that fields of the record can refer to the record itself.
@@ -135,7 +138,11 @@ trans_form(Ctx, Form, Mode) ->
                 NewFields = trans_record_fields(TmpCtx, varenv:empty("type variable"), Fields),
                 NewForm = {attribute, to_loc(TmpCtx, Anno), record, {Name, NewFields}},
                 RecordTy = records:record_ty_from_decl(Name, NewFields),
-                NewCtx = Ctx#ctx { records = maps:put(Name, RecordTy, Ctx#ctx.records) },
+                FieldDefaults = extract_field_defaults(NewFields),
+                NewCtx = Ctx#ctx {
+                    records = maps:put(Name, RecordTy, Ctx#ctx.records),
+                    record_defaults = maps:put(Name, FieldDefaults, Ctx#ctx.record_defaults)
+                },
                 ?LOG_TRACE("Registered new record type: ~200p", RecordTy),
                 {NewForm, NewCtx};
             {attribute, Anno, type, Def} ->
@@ -612,7 +619,9 @@ trans_exp(Ctx, Env, Exp) ->
                     end
                   end
                  ),
-            {{record_create, to_loc(Ctx, Anno), Name, NewFields}, NewEnv};
+            % fill in default expressions for omitted fields
+            AllFields = fill_record_defaults(Ctx, Name, to_loc(Ctx, Anno), NewFields),
+            {{record_create, to_loc(Ctx, Anno), Name, AllFields}, NewEnv};
         {record_field, Anno, E, Name, {'atom', _, Field}} ->
             {NewE, NewEnv} = trans_exp(Ctx, Env, E),
             % record field access
@@ -1004,6 +1013,45 @@ trans_map_assoc(Ctx, Env, Assoc) ->
                 end,
             {{NewK, to_loc(Ctx, Anno), NewExpKey, NewExpVal}, Env2};
         X -> errors:uncovered_case(?FILE, ?LINE, X)
+    end.
+
+% Extracts default expressions from transformed record field declarations.
+% Returns a map from field name to the default expression.
+-spec extract_field_defaults([ast:record_field()]) -> #{ atom() => ast:exp() }.
+extract_field_defaults(Fields) ->
+    lists:foldl(
+        fun({record_field, _Loc, _Name, _Ty, no_default}, Acc) -> Acc;
+           ({record_field, _Loc, Name, _Ty, DefaultExp}, Acc) -> maps:put(Name, DefaultExp, Acc)
+        end,
+        #{},
+        Fields).
+
+% Fills in default expressions for record fields that are omitted during record creation.
+% For each field in the record definition that is not explicitly given and has a default
+% expression, a record_field entry with the default expression is appended.
+-spec fill_record_defaults(ctx(), atom(), ast:loc(),
+    [{record_field, ast:loc(), atom(), ast:exp()}]) ->
+    [{record_field, ast:loc(), atom(), ast:exp()}].
+fill_record_defaults(Ctx, RecName, Loc, GivenFields) ->
+    case maps:find(RecName, Ctx#ctx.record_defaults) of
+        error ->
+            % Record not known yet (shouldn't happen for well-formed code)
+            GivenFields;
+        {ok, Defaults} ->
+            GivenNames = sets:from_list(
+                [N || {record_field, _, N, _} <- GivenFields],
+                [{version, 2}]),
+            DefaultFields =
+                maps:fold(
+                    fun(FieldName, DefaultExp, Acc) ->
+                        case sets:is_element(FieldName, GivenNames) of
+                            true -> Acc;
+                            false -> [{record_field, Loc, FieldName, DefaultExp} | Acc]
+                        end
+                    end,
+                    [],
+                    Defaults),
+            GivenFields ++ DefaultFields
     end.
 
 -spec trans_record_fields(ctx(), tyenv(), [ast_erl:record_field()]) -> [ast:record_field()].

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -24,7 +24,12 @@
           records :: #{ atom() => records:record_ty() },
           % Default expressions for record fields, used to fill in omitted fields during
           % record construction.
-          record_defaults = #{} :: #{ atom() => #{ atom() => ast:exp() } }
+          record_defaults = #{} :: #{ atom() => #{ atom() => ast:exp() } },
+          % Extra type forms generated for record override variants (e.g., #rec{field :: any()})
+          extra_forms = [] :: [ast:form()],
+          % ETS table for accumulating record override variants during type transformation.
+          % Used because trans_ty cannot thread state through its return value.
+          record_variants :: ets:table() | undefined
         }).
 -type ctx() :: #ctx{}.
 
@@ -50,7 +55,8 @@ trans(Path, Forms, Mode) ->
 -spec trans(string(), [ast_erl:form()], trans_mode(), funenv()) -> [ast:form()].
 trans(Path, Forms, Mode, FunEnv) ->
     ModName = ast_utils:modname_from_path(Path),
-    {RevNewForms, _} =
+    VarTab = ets:new(record_variants, [bag]),
+    {RevNewForms, FinalCtx} =
         lists:foldl(
             fun(F, {NewForms, Ctx}) ->
                 case trans_form(Ctx, F, Mode) of
@@ -59,10 +65,12 @@ trans(Path, Forms, Mode, FunEnv) ->
                     NewForm -> {[NewForm | NewForms], Ctx}
                 end
             end,
-            {[], #ctx{ path = Path, module_name = ModName, funenv = FunEnv, records = #{} }},
+            {[], #ctx{ path = Path, module_name = ModName, funenv = FunEnv, records = #{},
+                        record_variants = VarTab }},
             Forms
             ),
-    lists:reverse(RevNewForms).
+    ets:delete(VarTab),
+    lists:reverse(RevNewForms) ++ FinalCtx#ctx.extra_forms.
 
 -spec build_funenv(file:filename(), [ast_erl:form()]) -> funenv().
 build_funenv(Path, Forms) ->
@@ -130,18 +138,29 @@ trans_form(Ctx, Form, Mode) ->
                 {attribute, Loc, callback, Name, Arity, trans_spec_ty(Ctx, Loc, FunTys),
                  without_mod};
             {attribute, Anno, record, {Name, Fields}} when is_atom(Name) ->
-                % FIXME: this is a dirty hack to work around #152 (support for recursive record
-                % types). We temporarly register the name of the record with an empty record
+                % We temporarily register the name of the record with an empty record
                 % type, so that fields of the record can refer to the record itself.
+                % Self-references in field types emit named references (see trans_ty).
                 EmptyRecordTy = {Name, []},
                 TmpCtx = Ctx#ctx { records = maps:put(Name, EmptyRecordTy, Ctx#ctx.records) },
                 NewFields = trans_record_fields(TmpCtx, varenv:empty("type variable"), Fields),
                 NewForm = {attribute, to_loc(TmpCtx, Anno), record, {Name, NewFields}},
                 RecordTy = records:record_ty_from_decl(Name, NewFields),
                 FieldDefaults = extract_field_defaults(NewFields),
+                % Generate type forms for override variants created during field processing
+                OverrideVariants = collect_record_variants(Ctx, Name),
+                Loc = to_loc(Ctx, Anno),
+                VariantForms = lists:map(
+                    fun ({VariantName, VOverrides}) ->
+                        VariantBody = records:encode_record_ty(RecordTy, VOverrides),
+                        {attribute, Loc, type, transparent,
+                            {VariantName, {ty_scheme, [], VariantBody}}}
+                    end,
+                    OverrideVariants),
                 NewCtx = Ctx#ctx {
                     records = maps:put(Name, RecordTy, Ctx#ctx.records),
-                    record_defaults = maps:put(Name, FieldDefaults, Ctx#ctx.record_defaults)
+                    record_defaults = maps:put(Name, FieldDefaults, Ctx#ctx.record_defaults),
+                    extra_forms = Ctx#ctx.extra_forms ++ VariantForms
                 },
                 ?LOG_TRACE("Registered new record type: ~200p", RecordTy),
                 {NewForm, NewCtx};
@@ -306,17 +325,33 @@ trans_ty(Ctx, Env, Ty) ->
             eval_const_ty(Ty, to_loc(Ctx, Anno));
         {type, Anno, record, [{'atom', _, Name} | Fields]} ->
             Loc = to_loc(Ctx, Anno),
-            Overrides =
-                lists:map(
-                    fun ({type, _, field_type, [{'atom', _, FieldName}, FieldTy]}) ->
-                            {FieldName, trans_ty(Ctx, Env, FieldTy)}
-                    end,
-                    Fields),
             case maps:find(Name, Ctx#ctx.records) of
                 error ->
                     errors:name_error(Loc, "record ~w not defined", [Name]);
                 {ok, RecTy} ->
-                    records:encode_record_ty(RecTy, Overrides)
+                    case Fields of
+                        [] ->
+                            % Use named reference (enables recursive records)
+                            RecRef = {ty_ref, Ctx#ctx.module_name, records:record_type_name(Name), 0},
+                            {named, Loc, RecRef, []};
+                        _ ->
+                            Overrides =
+                                lists:map(
+                                    fun ({type, _, field_type, [{'atom', _, FieldName}, FieldTy]}) ->
+                                            {FieldName, trans_ty(Ctx, Env, FieldTy)}
+                                    end,
+                                    Fields),
+                            case RecTy of
+                                {Name, []} ->
+                                    % Self-referencing record with field overrides.
+                                    % Emit a named reference to an override variant type.
+                                    VariantName = store_record_variant(Ctx, Name, Overrides),
+                                    VariantRef = {ty_ref, Ctx#ctx.module_name, VariantName, 0},
+                                    {named, Loc, VariantRef, []};
+                                _ ->
+                                    records:encode_record_ty(RecTy, Overrides)
+                            end
+                    end
             end;
         {type, _, tuple, any} -> {tuple_any};
         {type, _, tuple, ArgTys} -> {tuple, trans_tys(Ctx, Env, ArgTys)};
@@ -1096,11 +1131,30 @@ parse_type(Ctx, Src) ->
         _ -> error
     end.
 
+% Stores a record override variant in the ETS table for later retrieval.
+% Used when a self-referencing record has field overrides (e.g., #rr{name :: any()}).
+% Returns the generated variant type name.
+-spec store_record_variant(ctx(), atom(), [records:record_field()]) -> atom().
+store_record_variant(Ctx, RecName, Overrides) ->
+    Tab = Ctx#ctx.record_variants,
+    N = length(ets:lookup(Tab, RecName)) + 1,
+    VariantName = list_to_atom("$record$" ++ atom_to_list(RecName) ++ "$v" ++ integer_to_list(N)),
+    ets:insert(Tab, {RecName, VariantName, Overrides}),
+    VariantName.
+
+% Collects and removes all record override variants for a record from the ETS table.
+-spec collect_record_variants(ctx(), atom()) -> [{atom(), [records:record_field()]}].
+collect_record_variants(Ctx, RecName) ->
+    Tab = Ctx#ctx.record_variants,
+    Results = [{VName, Ov} || {_, VName, Ov} <- ets:lookup(Tab, RecName)],
+    ets:delete(Tab, RecName),
+    Results.
 
 -ifdef(TEST).
 
 test_ctx() ->
-    #ctx{ path = ".", module_name = ast_transform, funenv = varenv:empty("function"), records = #{} }.
+    #ctx{ path = ".", module_name = ast_transform, funenv = varenv:empty("function"), records = #{},
+          record_variants = ets:new(test_record_variants, [bag]) }.
 
 parse_type_test() ->
     Ctx = test_ctx(),

--- a/src/erlang_types/ty_variable.erl
+++ b/src/erlang_types/ty_variable.erl
@@ -107,18 +107,18 @@ leq(V1, V2) ->
 -spec fresh_from(type()) -> type().
 fresh_from(#var{id = name, name = Name}) ->
   Id = get_new_id(),
-  #var{id = Id, name = Name, type = default};
+  #var{id = Id, name = Name};
 fresh_from(#var{id = _Id, name = Name}) ->
   new(Name).
 
 -spec new(atom()) -> type().
 new(Name) when is_atom(Name) ->
   NewId = ets:update_counter(?VAR_ETS, variable_id, {2,1}),
-  #var{id = NewId, name = Name, type = default}.
+  #var{id = NewId, name = Name}.
 
 -spec new_with_name(atom()) -> type().
 new_with_name(Name) when is_atom(Name) ->
-  #var{id = name, name = Name, type = default}.
+  #var{id = name, name = Name}.
 
 -spec new_as_frame() -> type().
 new_as_frame() ->
@@ -132,7 +132,7 @@ is_frame(V = #var{type = frame}) -> {true, V}.
 % used in ty_parser to convert already known variables
 -spec with_name_and_id(integer(), atom()) -> type().
 with_name_and_id(Id, Name) when is_atom(Name) ->
-  #var{id = Id, name = Name, type = default}.
+  #var{id = Id, name = Name}.
 
 -spec get_new_id() -> non_neg_integer().
 get_new_id() ->

--- a/src/records.erl
+++ b/src/records.erl
@@ -4,6 +4,7 @@
     encode_record_ty/2,
     encode_record_ty/1,
     record_ty_from_decl/2,
+    record_type_name/1,
     lookup_field_ty/3,
     lookup_field_index/3
 ]).
@@ -63,3 +64,7 @@ lookup_field_index({RecName, DefFields}, FieldName, L) ->
         {ok, FieldTy, I} ->
             {FieldTy, I}
     end.
+
+-spec record_type_name(atom()) -> atom().
+record_type_name(RecName) ->
+    list_to_atom("$record$" ++ atom_to_list(RecName)).

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -248,7 +248,13 @@ extend_symtab_internal(Filename, Forms, RefType, Tab, OverlaySymtab) ->
                     AccTab#tab { types = maps:put({ty_key, ModuleName, Name, Arity}, TyScm, AccTab#tab.types) };
                 {attribute, _, record, {RecordName, Fields}} ->
                     RecordTy = records:record_ty_from_decl(RecordName, Fields),
-                    AccTab#tab { records = maps:put(RecordName, RecordTy, AccTab#tab.records) };
+                    RecTypeName = records:record_type_name(RecordName),
+                    RecTupleType = records:encode_record_ty(RecordTy),
+                    RecTyScheme = {ty_scheme, [], RecTupleType},
+                    AccTab#tab {
+                        records = maps:put(RecordName, RecordTy, AccTab#tab.records),
+                        types = maps:put({ty_key, ModuleName, RecTypeName, 0}, RecTyScheme, AccTab#tab.types)
+                    };
                 _ ->
                     AccTab
             end

--- a/test_files/tycheck_simple/records.erl
+++ b/test_files/tycheck_simple/records.erl
@@ -136,6 +136,20 @@ get_name_from_invoice_02(X) -> X#invoice.person#person.name.
 -spec get_name_from_invoice_02_fail(#invoice{ person :: #person { name :: integer() }}) -> string().
 get_name_from_invoice_02_fail(X) -> X#invoice.person#person.name.
 
+%%%%%%%%%%%%%%%%%%%%%%%% DEFAULT VALUES %%%%%%%%%%%%%%%%%%%%%%%
+
+% Omitting a field with a default value should work
+-spec default_01() -> #item{}.
+default_01() -> #item{value=1, label="hello"}.
+
+% Providing all fields including the defaulted one should also work
+-spec default_02() -> #item{}.
+default_02() -> #item{value=1, label="hello", count=5}.
+
+% Omitting a field without a default should fail
+-spec default_03_fail() -> #item{}.
+default_03_fail() -> #item{value=1}.
+
 %% recursive
 
 % Deactived because of #152

--- a/test_files/tycheck_simple/records.erl
+++ b/test_files/tycheck_simple/records.erl
@@ -1,4 +1,4 @@
--module(maps).
+-module(records).
 
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -152,11 +152,18 @@ default_03_fail() -> #item{value=1}.
 
 %% recursive
 
-% Deactived because of #152
-%-record(rr, {name :: string(), recursive :: [#rr{}] }).
-%
-%-spec add1(string(), #rr{}) -> #rr{}.
-%add1(Name, R) -> #rr{name=Name, recursive=[R]}.
-%
-%-spec add2(string(), #rr{}) -> #rr{}.
-%add2(Name, R) -> R#rr{ recursive = [#rr{name=Name, recursive=[]} | R#rr.recursive]}.
+-record(rr, {name :: string(), recursive :: [#rr{}] }).
+-spec add1(string(), #rr{}) -> #rr{}.
+add1(Name, R) -> #rr{name=Name, recursive=[R]}.
+
+-spec add2(string(), #rr{}) -> #rr{}.
+add2(Name, R) -> R#rr{ recursive = [#rr{name=Name, recursive=[]} | R#rr.recursive]}.
+
+-record(rr2, {name :: string(), recursive :: [#rr2{name :: any()}] }).
+-spec add3(string(), #rr2{}) -> #rr2{}.
+add3(Name, R) -> #rr2{name=Name, recursive=[R]}.
+
+% while the definition is OK, the usage is not and causes a type error
+-record(rr3, {name :: string(), recursive :: [#rr3{name :: integer()}] }).
+-spec add4_fail(string(), #rr3{}) -> #rr3{}.
+add4_fail(Name, R) -> #rr3{name=Name, recursive=[R]}.

--- a/test_files/tycheck_simple/records.erl
+++ b/test_files/tycheck_simple/records.erl
@@ -150,6 +150,20 @@ default_02() -> #item{value=1, label="hello", count=5}.
 -spec default_03_fail() -> #item{}.
 default_03_fail() -> #item{value=1}.
 
+%%%%%%%%%%%%%%%%%%%%%%%% WILDCARD FIELD (record_field_other) %%%%%%%%%%%%%%%%%%%%%%%
+
+% Using _ = Expr fills all unspecified fields
+-spec wildcard_01() -> #config{}.
+wildcard_01() -> #config{host = "localhost", _ = "default"}.
+
+% All fields explicitly given, _ = Expr is a no-op
+-spec wildcard_02() -> #config{}.
+wildcard_02() -> #config{host = "localhost", port = "80", path = "/", _ = "unused"}.
+
+% _ = Expr with wrong type for the remaining fields should fail
+-spec wildcard_03_fail() -> #config{}.
+wildcard_03_fail() -> #config{host = "localhost", _ = 42}.
+
 %% recursive
 
 -record(rr, {name :: string(), recursive :: [#rr{}] }).

--- a/test_files/tycheck_simple/records.hrl
+++ b/test_files/tycheck_simple/records.hrl
@@ -2,3 +2,7 @@
                  age :: integer(),
                  address :: string()}).
 
+-record(item, {value :: integer(),
+               label :: string(),
+               count = 0 :: integer()}).
+

--- a/test_files/tycheck_simple/records.hrl
+++ b/test_files/tycheck_simple/records.hrl
@@ -6,3 +6,7 @@
                label :: string(),
                count = 0 :: integer()}).
 
+-record(config, {host :: string(),
+                 port :: string(),
+                 path :: string()}).
+


### PR DESCRIPTION
Fixed default record values which appear quite a lot in the case study and added support for recursive record types.

Default values are implemented as preprocessing during ast transformation.

Recursive records make use the mechanism of named types and are encoded as such.
When e.g. `#rr2{name :: any()}` appears in a record's own declaration, we can't inline the tuple encoding (the record fields aren't known yet). Before, we created an empty record inline as a workaround, which causes false positives. Instead, we now generate a named type variant for the override pattern and register it as an extra type form.

They are a bit messy, as they can have variants with overrides. I have never seen recursive records with overrides before, but our test cases support it. I also can't recall seeing just normal recursive records anywhere. 

* [x] `record_field_other` still needs to be implemented

Fixes #153. Fixes #152.

Depends on #267, draft until merged.