### PR TITLE
Send & Receive Expressions

### DIFF
--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -310,10 +310,10 @@ exp_constrs(Ctx, E, T) ->
                      [{cop, mk_locs(MsgTy, L), Op, 1, {fun_full, [Alpha], Beta}},
                       {csubty, mk_locs(MsgRes, L), Beta, T}], [{version, 2}]),
             sets:union(ArgCs, OpCs);
-        {'receive', L, _CaseClauses} ->
-            errors:unsupported(L, "receive expression", []);
-        {receive_after, L, _CauseClauses, _TimeoutExp, _Body} ->
-            errors:unsupported(L, "receive_after expression", []);
+        {'receive', L, CaseClauses} ->
+            receive_constrs(Ctx, L, CaseClauses, T);
+        {receive_after, L, CaseClauses, TimeoutExp, AfterBody} ->
+            receive_after_constrs(Ctx, L, CaseClauses, TimeoutExp, AfterBody, T);
         {record_create, L, Name, GivenFields} ->
             {_, DefFields} = symtab:lookup_record(Name, L, Ctx#ctx.symtab),
             VarFields =
@@ -683,6 +683,65 @@ var_as_global_ref({var, _, Ref}) ->
 
 -spec ty_without(ast:ty(), ast:ty()) -> ast:ty().
 ty_without(T1, T2) -> ast_lib:mk_intersection([T1, ast_lib:mk_negation(T2)]).
+
+% Generates constraints for a receive expression.
+% Pattern variables are bound to dynamic() since we don't know message types.
+% Guards override dynamic with specific types (e.g., is_integer(X) makes X :: integer()).
+-spec receive_constrs(ctx(), ast:loc(), [ast:case_clause()], ast:ty()) ->
+    constr:constrs().
+receive_constrs(Ctx, _L, CaseClauses, T) ->
+    ClauseCs = lists:map(
+        fun(Clause) -> receive_clause_constrs(Ctx, Clause, T) end,
+        CaseClauses),
+    sets:union(ClauseCs).
+
+% Generates constraints for a receive...after expression.
+% Combines receive clause constraints with the after body constraints.
+-spec receive_after_constrs(ctx(), ast:loc(), [ast:case_clause()], ast:exp(), [ast:exp()], ast:ty()) ->
+    constr:constrs().
+receive_after_constrs(Ctx, L, CaseClauses, TimeoutExp, AfterBody, T) ->
+    % Generate constraints for timeout expression
+    TimeoutCs = exp_constrs(Ctx, TimeoutExp, {union, [{predef, integer}, {singleton, infinity}]}),
+    % Generate constraints for the after body
+    Beta = fresh_tyvar(Ctx),
+    AfterCs = exps_constrs(Ctx, L, AfterBody, Beta),
+    AfterResultCs = utils:single({csubty, mk_locs("receive after result", L), Beta, T}),
+    % Generate constraints for receive clauses
+    ClauseCs = lists:map(
+        fun(Clause) -> receive_clause_constrs(Ctx, Clause, T) end,
+        CaseClauses),
+    sets:union([TimeoutCs, AfterCs, AfterResultCs | ClauseCs]).
+
+% Generates constraints for a single receive clause.
+% Pattern variables get type dynamic(). Guards override with specific types.
+-spec receive_clause_constrs(ctx(), ast:case_clause(), ast:ty()) -> constr:constrs().
+receive_clause_constrs(Ctx, {case_clause, L, Pat, Guards, Exps}, T) ->
+    % Bind pattern variables to dynamic
+    BoundVars = bound_vars_pat(Pat),
+    DynamicPatEnv = sets:fold(
+        fun(V, Acc) -> maps:put({local_ref, V}, {predef, dynamic}, Acc) end,
+        #{},
+        BoundVars),
+    {GuardEnv, _} = guard_seq_env(Guards),
+    % #FIXME HACK until #329 is fixed
+    % Guard refinements override dynamic(), not intersect with it.
+    % Overriding ensures guarded variables get only the guard type.
+    % Unguarded variables remain dynamic().
+    VarEnv = maps:merge(DynamicPatEnv, GuardEnv),
+    % Generate guard constraints to evaluate to boolean()
+    GuardCs = sets:union(
+        lists:map(
+            fun(Guard) ->
+                exps_constrs(Ctx, L, Guard, {predef_alias, boolean})
+            end,
+            Guards)),
+    % Generate body constraints
+    Beta = fresh_tyvar(Ctx),
+    BodyCs = exps_constrs(Ctx, L, Exps, Beta),
+    ResultCs = utils:single({csubty, mk_locs("receive clause result", L), Beta, T}),
+    % Wrap in cdef with variable bindings
+    InnerCs = sets:union([GuardCs, BodyCs, ResultCs]),
+    utils:single({cdef, mk_locs("receive clause", L), VarEnv, InnerCs}).
 
 -spec needs_unmatched_check(list(ast:case_clause())) -> boolean().
 needs_unmatched_check(Clauses) ->

--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -358,8 +358,10 @@ builtin_ops() ->
                           tfun([tnonempty_list(tvar(a)), tnonempty_list(tvar(a))], tnonempty_list(tvar(a)))
                                ])
                        )},
-        {'--', 2, tyscm([a], tfun([tlist(tvar(a)), tlist(tvar(a))], tlist(tvar(a))))}
-        % {'!', 2,   FIXME
+        {'--', 2, tyscm([a], tfun([tlist(tvar(a)), tlist(tvar(a))], tlist(tvar(a))))},
+        % receiver must evaluate to a pid, an alias (reference), a port, a registered name (atom), or a tuple {Name,Node}.
+        % Name is an atom and Node is a node name, also an atom.
+        {'!', 2, tyscm([a], tfun([tunion([{predef, pid}, {predef, reference}, {predef, port}, {predef, atom}, {tuple, [{predef, atom}, {predef, atom}]}]), tvar(a)], tvar(a)))}
     ].
 
 %% Types for builtin functions

--- a/test_files/tycheck_simple/sendreceive.erl
+++ b/test_files/tycheck_simple/sendreceive.erl
@@ -1,0 +1,174 @@
+-module(sendreceive).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+% Each top-level definition of this module is typechecked in isolation
+% against its spec, inference is also tested.
+% If the name ends with _fail, the test must fail.
+
+%%%%%%%%%%%%%%%%%%%%%%%% SEND %%%%%%%%%%%%%%%%%%%%%%%
+
+-spec send_01(pid(), integer()) -> integer().
+send_01(Pid, Msg) -> Pid ! Msg.
+
+-spec send_02(pid(), atom()) -> atom().
+send_02(Pid, Msg) -> Pid ! Msg.
+
+-spec send_03_fail(pid(), integer()) -> atom().
+send_03_fail(Pid, Msg) -> Pid ! Msg.
+
+-spec send_04(atom(), {atom(), pid()}) -> {atom(), pid()}.
+send_04(RegName, Msg) -> RegName ! Msg.
+
+-spec send_05(pid()) -> ok.
+send_05(Pid) -> Pid ! ok.
+
+-spec send_06_fail(string()) -> ok.
+send_06_fail(Pid) -> Pid ! ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%% RECEIVE %%%%%%%%%%%%%%%%%%%%%%%
+
+-spec recv_01() -> ok.
+recv_01() ->
+    receive
+        ok -> ok
+    end.
+
+-spec recv_02() -> integer().
+recv_02() ->
+    receive
+        X when is_integer(X) -> X
+    end.
+
+-spec recv_03() -> atom().
+recv_03() ->
+    receive
+        hello -> hello;
+        world -> world
+    end.
+
+-spec recv_04() -> {atom(), integer()}.
+recv_04() ->
+    receive
+        {Tag, Val} -> {Tag, Val}
+    end.
+
+-spec recv_05_fail() -> {atom(), integer()}.
+recv_05_fail() ->
+    receive
+        Tag when is_integer(Tag) -> Tag
+    end.
+
+% shadowing
+-spec recv_06_fail(any()) -> {atom(), integer()}.
+recv_06_fail(Tag) ->
+    receive
+        Tag when is_integer(Tag) -> Tag
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%% RECEIVE WITH AFTER %%%%%%%%%%%%%%%%%%%%%%%
+
+-spec recv_after_01() -> ok | timeout.
+recv_after_01() ->
+    receive ok -> ok after 1000 -> timeout end.
+
+-spec recv_after_02() -> integer().
+recv_after_02() ->
+    receive
+        X when is_integer(X) -> X
+    after
+        5000 -> 0
+    end.
+
+-spec recv_after_03() -> ok.
+recv_after_03() ->
+    receive after 100 -> ok end.
+
+-spec recv_after_04_fail() -> integer().
+recv_after_04_fail() ->
+    receive ok -> ok after 1000 -> timeout end.
+
+-spec recv_after_05() -> any().
+recv_after_05() ->
+    receive ok -> ok after infinity -> timeout end.
+
+-spec recv_after_06_fail() -> any().
+recv_after_06_fail() ->
+    receive ok -> ok after bad -> timeout end.
+
+%%%%%%%%%%%%%%%%%%%%%%%% RECEIVE LOOPS %%%%%%%%%%%%%%%%%%%%%%%
+
+% Receive loop that returns ok
+-spec recv_loop_01() -> ok.
+recv_loop_01() ->
+  receive
+    quit ->
+      ok;
+    _Foo ->
+      recv_loop_01()
+  end.
+
+% Receive loop with wrong return type
+-spec recv_loop_02_fail() -> nok.
+recv_loop_02_fail() ->
+  receive
+    quit ->
+      ok;
+    _Foo ->
+      recv_loop_02_fail()
+  end.
+
+% Receive loop result bound to variable
+-spec recv_loop_03() -> ok.
+recv_loop_03() ->
+  A = receive
+    quit ->
+      ok;
+    _Foo ->
+      recv_loop_03()
+  end,
+  A.
+
+% Receive loop with timeout
+-spec recv_loop_after_01() -> ok.
+recv_loop_after_01() ->
+  receive
+    quit ->
+      ok;
+    _Foo ->
+      recv_loop_after_01()
+  after 1000 -> ok
+  end.
+
+% Receive loop with timeout, wrong return
+-spec recv_loop_after_02_fail() -> nok.
+recv_loop_after_02_fail() ->
+  receive
+    quit ->
+      nok;
+    _Foo ->
+      recv_loop_after_02_fail()
+  after 1000 -> ok
+  end.
+
+% Receive loop with timeout, bound result
+-spec recv_loop_after_03() -> ok.
+recv_loop_after_03() ->
+  A = receive
+    quit ->
+      ok;
+    _Foo ->
+      recv_loop_after_03()
+    after 1000 -> ok
+  end,
+  A.
+
+%%%%%%%%%%%%%%%%%%%%%%%% COMBINED %%%%%%%%%%%%%%%%%%%%%%%
+
+-spec send_recv_01(pid()) -> ok.
+send_recv_01(Pid) ->
+    Pid ! hello,
+    receive
+        ok -> ok
+    end.


### PR DESCRIPTION
Add supports for Erlang `!` and `receive` expressions.

Receive expressions are currently typed with pattern variables having the `dynamic()` type.

Send receiver is typed with the most precise type (as per documentation).

* [x] Why we can't intersect a pattern variable with `dynamic()`, but instead need to override and merge the variable environment? (I.e., difference between `dynamic() & integer()` vs `integer()`)
  * discussion at #329 

Depends on #314, draft until merged.