### PR TITLE
Typing dynamic function calls with `dynamic()`

### DIFF
--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -213,8 +213,8 @@ exp_constrs(Ctx, E, T) ->
             var_funcall_constrs(Ctx, L, Var, Args, T);
         {call, L, FunExp, Args} ->
             gen_funcall_constrs(Ctx, L, FunExp, Args, T);
-        {call_remote, L, _ModExp, _FunExp, _Args} ->
-            errors:unsupported(L, "function calls with dynamically computed modules");
+        {call_remote, L, ModExp, FunExp, Args} ->
+            dyncall_constrs(Ctx, L, ModExp, FunExp, Args, T);
         ({'if', _, _} = IfExp) ->
             exp_constrs(Ctx, if_exp_to_case_exp(IfExp), T);
         {lc, L, Exp, Qs} ->
@@ -680,6 +680,22 @@ var_as_global_ref({var, _, Ref}) ->
         {escaped_ref, _, _} -> error;
         _ -> {ok, Ref}
     end.
+
+% Generates constraints for a dynamic function call (Mod:Fun(Args)).
+% Arguments are constrained to dynamic(), result is dynamic().
+-spec dyncall_constrs(ctx(), ast:loc(), ast:exp(), ast:exp(), [ast:exp()], ast:ty()) -> constr:constrs().
+dyncall_constrs(Ctx, L, ModExp, FunExp, Args, T) ->
+    ModCs = exp_constrs(Ctx, ModExp, {predef, dynamic}),
+    FunCs = exp_constrs(Ctx, FunExp, {predef, dynamic}),
+    ArgCs = lists:foldr(
+        fun(ArgExp, AccCs) ->
+            Cs = exp_constrs(Ctx, ArgExp, {predef, dynamic}),
+            sets:union(AccCs, Cs)
+        end,
+        sets:new([{version, 2}]),
+        Args),
+    ResultCs = utils:single({csubty, mk_locs("result of dynamic call", L), {predef, dynamic}, T}),
+    sets:union([ModCs, FunCs, ArgCs, ResultCs]).
 
 -spec ty_without(ast:ty(), ast:ty()) -> ast:ty().
 ty_without(T1, T2) -> ast_lib:mk_intersection([T1, ast_lib:mk_negation(T2)]).

--- a/test_files/tycheck_simple/gradual.erl
+++ b/test_files/tycheck_simple/gradual.erl
@@ -271,3 +271,36 @@ mater_trans_01(F) -> F.
 -spec mater_trans_02(fun((dynamic()) -> fun((dynamic()) -> dynamic()))) ->
     fun((integer()) -> fun((atom()) -> boolean())).
 mater_trans_02(F) -> F.
+
+% Dynamic call with 0 args
+-spec dyn_call_01(atom(), atom()) -> integer().
+dyn_call_01(M, F) ->
+  M:F().
+
+% Dynamic call with 1 arg
+-spec dyn_call_02(atom(), atom(), integer()) -> integer().
+dyn_call_02(M, F, Arg) ->
+  M:F(Arg).
+
+% Dynamic call with 2 args
+-spec dyn_call_03(atom(), atom(), integer(), atom()) -> integer().
+dyn_call_03(M, F, Arg1, Arg2) ->
+  M:F(Arg1, Arg2).
+
+% Dynamic call result bound to variable, 0 args
+-spec dyn_call_eval_01(atom(), atom()) -> integer().
+dyn_call_eval_01(M, F) ->
+  Res = M:F(),
+  Res.
+
+% Dynamic call result bound to variable, 1 arg
+-spec dyn_call_eval_02(atom(), atom(), integer()) -> integer().
+dyn_call_eval_02(M, F, Arg) ->
+  Res = M:F(Arg),
+  Res.
+
+% Dynamic call result bound to variable, 2 args
+-spec dyn_call_eval_03(atom(), atom(), integer(), atom()) -> integer().
+dyn_call_eval_03(M, F, Arg1, Arg2) ->
+  Res = M:F(Arg1, Arg2),
+  Res.


### PR DESCRIPTION
In our case study, we need to type dynamic function calls.

Implemented dynamic function calls to be type with `dynamic()` instead of throwing an unsupported error.

For example:

```erlang
-spec new(atom()) -> internal_crdt().                                                                                             
new(Type) ->                                                                                                                      
    case valid(Type) of                                                                                                           
        true -> Type:new();                                                                                                       
        false -> error({invalid_crdt_type, Type})                                                                                 
    end. 
```

Depends on #315, draft until merged.