### PR TITLE
Support for nominal types: approximation

### DIFF
--- a/src/constr_error_locs.erl
+++ b/src/constr_error_locs.erl
@@ -12,7 +12,7 @@
 
 -include("etylizer.hrl").
 
--type constr_error_kind() :: tyerror | redundant_branch | non_exhaustive_case.
+-type constr_error_kind() :: tyerror | redundant_branch | non_exhaustive_case | nominal_incompatible.
 
 -type constr_blocks() :: list(constr_block()).
 

--- a/src/constr_solve.erl
+++ b/src/constr_solve.erl
@@ -77,6 +77,43 @@ has_dynamic_constr(Tab, Constrs) ->
         end,
         sets:to_list(Constrs)).
 
+% Nominal types present and structural check passed: check nominal compatibility.
+% Short-circuits on the common case: the flattened constraint set is a superset of every branch combination. 
+% Nominal checks are monotonic. 
+% If no conflict exists in the flattened set, no combination can have one either. 
+% Only when the flattened check finds a conflict do we enumerate combinations to rule out false positives
+% caused by mixing constraints from mutually exclusive branches.
+-spec check_nominal_after_structural(symtab:t(), constr:simp_constrs(), constr:collected_constrs()) ->
+    ok | {error, error()}.
+check_nominal_after_structural(Tab, Ds, SubtyConstrs) ->
+    case constr_solve_nominal:check_nominal_constrs(Tab, SubtyConstrs) of
+        ok -> ok;
+        {error, _} ->
+            SubtyConstrsDisj = constr_collect:collect_constrs_all_combinations(Ds),
+            ?LOG_DEBUG("Nominal conflict on flattened set, checking ~w combinations", length(SubtyConstrsDisj)),
+            constr_solve_nominal:check_nominal_combinations_only(Tab, SubtyConstrsDisj)
+    end.
+
+% Check for redundant branches.
+-spec check_redundancy(symtab:t(), sets:set(ast:ty_varname()), constr:simp_constrs(), constr:collected_constrs()) ->
+    ok | {error, error()}.
+check_redundancy(Tab, FixedTyvars, Ds, SubtyConstrs) ->
+    ReduDs = constr_collect:collect_matching_cond_constrs(Ds),
+    ?LOG_DEBUG("Constraints are satisfiable, now checking ~w branches for redundancy",
+        length(ReduDs)),
+    case has_dynamic_constr(Tab, SubtyConstrs) of
+        true ->
+            ?LOG_DEBUG("Skipping all redundancy checks (dynamic() found in constraints)"),
+            ok;
+        false ->
+            lists:foldl(
+                fun (LocAndConstrs, Acc) ->
+                    check_redundant_branch(Tab, FixedTyvars, SubtyConstrs, LocAndConstrs, Acc)
+                end,
+                ok,
+                ReduDs)
+    end.
+
 -spec check_redundant_branch(symtab:t(), sets:set(ast:ty_varname()), constr:subty_constrs(),
     {ast:loc(), constr:subty_constrs()}, ok | {error, error()}) -> ok | {error, error()}.
 check_redundant_branch(_Tab, _FixedTyvars, _SubtyConstrs, _LocAndConstrs, Acc = {error, _}) -> Acc;
@@ -119,23 +156,19 @@ check_simp_constrs(Tab, FixedTyvars, Ds, What) ->
     SubtyConstrs = constr_collect:collect_constrs_no_matching_cond(Ds),
     ?LOG_DEBUG("Checking constraints for satisfiability to type check ~s:~n~s~nFixed: ~s",
         What, pretty:render_constr(SubtyConstrs), pretty:render_set(fun pretty:atom/1, FixedTyvars)),
+    % Run structural check once on the flattened constraint set
     case is_satisfiable(Tab, SubtyConstrs, FixedTyvars, "satisfiability check") of
         true ->
-            % check for redundant branches
-            ReduDs = constr_collect:collect_matching_cond_constrs(Ds),
-            ?LOG_DEBUG("Constraints are satisfiable, now checking ~w branches for redundancy",
-                length(ReduDs)),
-            case has_dynamic_constr(Tab, SubtyConstrs) of
+            % Structurally satisfiable; now check for nominal conflicts if needed
+            NomResult = case symtab:has_any_nominals(Tab) andalso constr_solve_nominal:has_nominal_constrs(Tab, SubtyConstrs) of
                 true ->
-                    ?LOG_DEBUG("Skipping all redundancy checks (dynamic() found in constraints)"),
-                    ok;
+                    check_nominal_after_structural(Tab, Ds, SubtyConstrs);
                 false ->
-                    lists:foldl(
-                        fun (LocAndConstrs, Acc) ->
-                            check_redundant_branch(Tab, FixedTyvars, SubtyConstrs, LocAndConstrs, Acc)
-                        end,
-                        ok,
-                        ReduDs)
+                    ok
+            end,
+            case NomResult of
+                ok -> check_redundancy(Tab, FixedTyvars, Ds, SubtyConstrs);
+                {error, _} = Err -> Err
             end;
         false ->
             locate_unsat_error(Tab, FixedTyvars, Ds)

--- a/src/constr_solve_nominal.erl
+++ b/src/constr_solve_nominal.erl
@@ -1,0 +1,635 @@
+-module(constr_solve_nominal).
+
+-include("log.hrl").
+
+-export([
+    has_nominal_constrs/2,
+    check_nominal_constrs/2,
+    check_nominal_combinations_only/2
+]).
+
+-type error() :: constr_solve:error().
+
+% Result of a nominal pair check:
+% - ok: types are nominally compatible (no conflict found, types could overlap)
+% - skip: types cannot structurally overlap, so nominal checking is not applicable
+% - {error, _}: nominal conflict found
+-type nominal_result() :: ok | skip | {error, error()}.
+
+%% ============================================================
+%% Record definitions
+%% ============================================================
+
+% Variable subtyping graph: captures variable-to-variable edges from constraints,
+% including edges nested inside matching compound types (tuples, lists, etc.).
+% Compound types are positionally decomposed to extract all variable relationships.
+-record(var_graph, {
+    forward = #{} :: #{ast:ty_varname() => [ast:ty_varname()]},  % A <: B edges
+    reverse = #{} :: #{ast:ty_varname() => [ast:ty_varname()]}   % B <: A edges (reverse of forward)
+}).
+-type var_graph() :: #var_graph{}.
+
+% Precomputed derivation map: for each nominal type key, the set of nominal
+% type keys it derives from (transitively). A nominal A derives from B if
+% A's body contains B (directly or through non-nominal aliases).
+% The relation is symmetric for compatibility checking.
+-type derivation_map() :: #{symtab:ty_key() => sets:set(symtab:ty_key())}.
+
+-record(var_info, {
+    mater_map = #{} :: #{ast:ty_varname() => ast:ty()},     % scmater: T materializes into Alpha
+    graph = #var_graph{} :: var_graph(),                     % variable-to-variable subtyping edges
+    lower = #{} :: #{ast:ty_varname() => [ast:ty()]},        % concrete lower bounds (T <: var)
+    upper = #{} :: #{ast:ty_varname() => [ast:ty()]},        % concrete upper bounds (var <: T)
+    derivations = #{} :: derivation_map()                    % nominal derivation relationships
+}).
+-type var_info() :: #var_info{}.
+
+%% ============================================================
+%% Detection: does a constraint set involve nominal types?
+%% ============================================================
+
+% Check if any nominal types appear in the constraint set,
+% including nominals hidden inside non-nominal type alias definitions.
+% symtab:is_nominal could implement the recursive transitive check,
+% but we implement it like this to keep symtab more simple.
+-spec has_nominal_constrs(symtab:t(), constr:collected_constrs()) -> boolean().
+has_nominal_constrs(Tab, Constrs) ->
+    lists:any(
+        fun ({scsubty, _, T1, T2}) ->
+                ty_has_nominal(Tab, T1, sets:new()) orelse ty_has_nominal(Tab, T2, sets:new());
+            ({scmater, _, T1, _}) -> ty_has_nominal(Tab, T1, sets:new());
+            (_) -> false
+        end,
+        sets:to_list(Constrs)).
+
+% Check if a type contains a nominal, either directly or transitively
+% through non-nominal type alias definitions.
+-spec ty_has_nominal(symtab:t(), ast:ty(), sets:set(ast:ty_ref())) -> boolean().
+ty_has_nominal(Tab, Ty, Visited) ->
+    utils:everything(
+        fun ({named, _, Ref, _} = N) ->
+                case symtab:is_nominal(Ref, Tab) of
+                    true -> {ok, true};
+                    false ->
+                        case named_contains_nominal(Tab, N, Visited) of
+                            true -> {ok, true};
+                            false -> error
+                        end
+                end;
+            (_) -> error
+        end, Ty) =/= [].
+
+% Check if a non-nominal named type transitively contains any nominal types.
+% Unfolds one level and recursively checks non-nominal aliases found in the body.
+-spec named_contains_nominal(symtab:t(), ast:ty(), sets:set(ast:ty_ref())) -> boolean().
+named_contains_nominal(Tab, {named, Loc, Ref, Args}, Visited) ->
+    case sets:is_element(Ref, Visited) of
+        true -> false;
+        false ->
+            {ty_scheme, Vars, Body} = symtab:lookup_ty(Ref, Loc, Tab),
+            VarNames = [V || {V, _Bound} <- Vars],
+            case length(VarNames) =:= length(Args) of
+                true ->
+                    Map = subst:from_list(lists:zip(VarNames, Args)),
+                    Expanded = subst:apply(Map, Body, no_clean),
+                    ty_has_nominal(Tab, Expanded, sets:add_element(Ref, Visited));
+                false -> false
+            end
+    end.
+
+%% ============================================================
+%% Per-combination nominal checking
+%% ============================================================
+
+% Check if any combination is nominally compatible (no structural check).
+% Used after the flattened structural check has already passed.
+-spec check_nominal_combinations_only(symtab:t(), constr_collect:all_combinations()) ->
+    ok | {error, error()}.
+check_nominal_combinations_only(_Tab, []) ->
+    {error, {nominal_incompatible, ast:loc_auto(), "all branch combinations have nominal conflicts"}};
+check_nominal_combinations_only(Tab, [{_SwitchedOff, SubtyConstrs} | Rest]) ->
+    case check_nominal_constrs(Tab, SubtyConstrs) of
+        ok -> ok;
+        {error, _} -> check_nominal_combinations_only(Tab, Rest)
+    end.
+
+%% ============================================================
+%% Nominal constraint checking
+%% ============================================================
+
+% Checks for nominal type incompatibilities in the collected constraints.
+% Two nominal types with different names are never compatible.
+% A nominal type is compatible with a non-nominal structural type (both directions).
+%
+% This check handles:
+% - Variable chains: nominal types connected through scsubty variable chains
+%   (e.g. meter() <: $1 <: $A <: foot() from polymorphic function calls)
+% - Deep named types: nominal types hidden inside non-nominal type aliases
+%   (e.g. wrapper(meter()) vs wrapper(foot()) where wrapper is not nominal)
+% - Variables inside compound types: e.g. {tuple, [{var, $A}]} where $A
+%   resolves to a nominal type through transitive chains
+-spec check_nominal_constrs(symtab:t(), constr:collected_constrs()) -> ok | {error, error()}.
+check_nominal_constrs(Tab, Constrs) ->
+    ConstrList = sets:to_list(Constrs),
+    VarInfo0 = build_var_info(Tab, ConstrList),
+    VarInfo = VarInfo0#var_info{derivations = build_derivation_map(Tab)},
+    lists:foldl(
+        fun
+            (_, {error, _} = Err) -> Err;
+            ({scsubty, Loc, T1, T2}, ok) ->
+                case check_nominal_pair(Tab, Loc, T1, T2, VarInfo, sets:new()) of
+                    {error, _} = Err -> Err;
+                    _ -> ok  % ok or skip both mean no conflict
+                end;
+            (_, ok) -> ok
+        end,
+        ok,
+        ConstrList).
+
+%% ============================================================
+%% Variable bound analysis
+%% ============================================================
+
+-spec build_var_info(symtab:t(), [constr:simp_constr_subty() | constr:simp_constr_mater()]) -> var_info().
+build_var_info(Tab, ConstrList) ->
+    lists:foldl(fun(C, VI) ->
+        case C of
+            {scmater, _, T, Alpha} ->
+                VI#var_info{mater_map = maps:put(Alpha, T, VI#var_info.mater_map)};
+            {scsubty, _, T1, T2} ->
+                add_type_pair(Tab, T1, T2, VI, sets:new());
+            _ ->
+                VI
+        end
+    end, #var_info{}, ConstrList).
+
+% Process a type pair, extracting variable edges and concrete bounds.
+% Recursively decomposes matching compound types to capture variable
+% relationships at all nesting depths. Unfolds named types and mu types.
+% The Visited set tracks type pairs to prevent infinite recursion.
+-spec add_type_pair(symtab:t(), ast:ty(), ast:ty(), var_info(), sets:set()) -> var_info().
+add_type_pair(_Tab, {var, A}, {var, B}, VI = #var_info{graph = G}, _Visited) ->
+    % Use ty_variable ordering to determine edge direction:
+    % the smaller variable (leq) is the lower bound.
+    VA = ty_variable:new_with_name(A),
+    VB = ty_variable:new_with_name(B),
+    {Lo, Hi} = case ty_variable:leq(VA, VB) of
+        true  -> {A, B};
+        false -> {B, A}
+    end,
+    VI#var_info{graph = G#var_graph{
+        forward = map_add(Lo, Hi, G#var_graph.forward),
+        reverse = map_add(Hi, Lo, G#var_graph.reverse)}};
+add_type_pair(_Tab, {var, V}, T, VI, _Visited) ->
+    VI#var_info{upper = map_add(V, T, VI#var_info.upper)};
+add_type_pair(_Tab, T, {var, V}, VI, _Visited) ->
+    VI#var_info{lower = map_add(V, T, VI#var_info.lower)};
+add_type_pair(Tab, {tuple, Elems1}, {tuple, Elems2}, VI, Visited)
+        when length(Elems1) =:= length(Elems2) ->
+    add_type_pairs(Tab, Elems1, Elems2, VI, Visited);
+add_type_pair(Tab, {list, E1}, {list, E2}, VI, Visited) ->
+    add_type_pair(Tab, E1, E2, VI, Visited);
+add_type_pair(Tab, {nonempty_list, E1}, {nonempty_list, E2}, VI, Visited) ->
+    add_type_pair(Tab, E1, E2, VI, Visited);
+add_type_pair(Tab, {cons, H1, T1}, {cons, H2, T2}, VI, Visited) ->
+    add_type_pairs(Tab, [H1, T1], [H2, T2], VI, Visited);
+add_type_pair(Tab, {improper_list, H1, T1}, {improper_list, H2, T2}, VI, Visited) ->
+    add_type_pairs(Tab, [H1, T1], [H2, T2], VI, Visited);
+add_type_pair(Tab, {nonempty_improper_list, H1, T1}, {nonempty_improper_list, H2, T2}, VI, Visited) ->
+    add_type_pairs(Tab, [H1, T1], [H2, T2], VI, Visited);
+add_type_pair(Tab, {fun_full, Args1, Ret1}, {fun_full, Args2, Ret2}, VI, Visited)
+        when length(Args1) =:= length(Args2) ->
+    add_type_pairs(Tab, Args1 ++ [Ret1], Args2 ++ [Ret2], VI, Visited);
+add_type_pair(Tab, {map, Assocs1}, {map, Assocs2}, VI, Visited)
+        when length(Assocs1) =:= length(Assocs2) ->
+    add_map_assoc_pairs(Tab, Assocs1, Assocs2, VI, Visited);
+% Unions/intersections: pair each element against the other side.
+% When both sides are unions/intersections, the one-sided clauses compose
+% to produce all pairs transitively.
+add_type_pair(Tab, {union, Elems}, T2, VI, Visited) ->
+    lists:foldl(fun(E, Acc) -> add_type_pair(Tab, E, T2, Acc, Visited) end, VI, Elems);
+add_type_pair(Tab, T1, {union, Elems}, VI, Visited) ->
+    lists:foldl(fun(E, Acc) -> add_type_pair(Tab, T1, E, Acc, Visited) end, VI, Elems);
+add_type_pair(Tab, {intersection, Elems}, T2, VI, Visited) ->
+    lists:foldl(fun(E, Acc) -> add_type_pair(Tab, E, T2, Acc, Visited) end, VI, Elems);
+add_type_pair(Tab, T1, {intersection, Elems}, VI, Visited) ->
+    lists:foldl(fun(E, Acc) -> add_type_pair(Tab, T1, E, Acc, Visited) end, VI, Elems);
+% Mu types: unwrap and recurse into body
+add_type_pair(Tab, {mu, _, Body1}, T2, VI, Visited) ->
+    add_type_pair(Tab, Body1, T2, VI, Visited);
+add_type_pair(Tab, T1, {mu, _, Body2}, VI, Visited) ->
+    add_type_pair(Tab, T1, Body2, VI, Visited);
+% Negation types: recurse into body (nominal check is symmetric)
+add_type_pair(Tab, {negation, T1}, {negation, T2}, VI, Visited) ->
+    add_type_pair(Tab, T1, T2, VI, Visited);
+add_type_pair(Tab, {negation, T1}, T2, VI, Visited) ->
+    add_type_pair(Tab, T1, T2, VI, Visited);
+add_type_pair(Tab, T1, {negation, T2}, VI, Visited) ->
+    add_type_pair(Tab, T1, T2, VI, Visited);
+% Both named types
+add_type_pair(Tab, {named, L1, Ref1, Args1}, {named, L2, Ref2, Args2}, VI, Visited) ->
+    case symtab:ref_to_key(Ref1) =:= symtab:ref_to_key(Ref2) andalso length(Args1) =:= length(Args2) of
+        true ->
+            % Same type constructor: decompose args pairwise
+            add_type_pairs(Tab, Args1, Args2, VI, Visited);
+        false ->
+            % Different refs: unfold non-nominals and recurse
+            unfold_and_add(Tab, {named, L1, Ref1, Args1}, {named, L2, Ref2, Args2}, VI, Visited)
+    end;
+% One side is a named type: unfold if non-nominal and recurse
+add_type_pair(Tab, {named, L, Ref, Args}, T2, VI, Visited) ->
+    unfold_left(Tab, {named, L, Ref, Args}, T2, VI, Visited);
+add_type_pair(Tab, T1, {named, L, Ref, Args}, VI, Visited) ->
+    unfold_right(Tab, T1, {named, L, Ref, Args}, VI, Visited);
+add_type_pair(_Tab, _, _, VI, _Visited) -> VI.
+
+-spec unfold_left(symtab:t(), ast:ty(), ast:ty(), var_info(), sets:set()) -> var_info().
+unfold_left(Tab, {named, _, Ref, _} = N, T2, VI, Visited) ->
+    Key = {N, T2},
+    case sets:is_element(Key, Visited) orelse symtab:is_nominal(Ref, Tab) of
+        true -> VI;
+        false ->
+            U = try_unfold(Tab, N),
+            add_type_pair(Tab, U, T2, VI, sets:add_element(Key, Visited))
+    end.
+
+-spec unfold_right(symtab:t(), ast:ty(), ast:ty(), var_info(), sets:set()) -> var_info().
+unfold_right(Tab, T1, {named, _, Ref, _} = N, VI, Visited) ->
+    Key = {T1, N},
+    case sets:is_element(Key, Visited) orelse symtab:is_nominal(Ref, Tab) of
+        true -> VI;
+        false ->
+            U = try_unfold(Tab, N),
+            add_type_pair(Tab, T1, U, VI, sets:add_element(Key, Visited))
+    end.
+
+-spec unfold_and_add(symtab:t(), ast:ty(), ast:ty(), var_info(), sets:set()) -> var_info().
+unfold_and_add(Tab, {named, _, Ref1, _} = N1, {named, _, Ref2, _} = N2, VI, Visited) ->
+    Key = {N1, N2},
+    case sets:is_element(Key, Visited) of
+        true -> VI;
+        false ->
+            Visited1 = sets:add_element(Key, Visited),
+            case {symtab:is_nominal(Ref1, Tab), symtab:is_nominal(Ref2, Tab)} of
+                {true, true} -> VI;
+                {false, false} ->
+                    add_type_pair(Tab, try_unfold(Tab, N1), try_unfold(Tab, N2), VI, Visited1);
+                {true, false} ->
+                    add_type_pair(Tab, N1, try_unfold(Tab, N2), VI, Visited1);
+                {false, true} ->
+                    add_type_pair(Tab, try_unfold(Tab, N1), N2, VI, Visited1)
+            end
+    end.
+
+-spec add_type_pairs(symtab:t(), [ast:ty()], [ast:ty()], var_info(), sets:set()) -> var_info().
+add_type_pairs(_Tab, [], [], VI, _Visited) -> VI;
+add_type_pairs(Tab, [T1 | R1], [T2 | R2], VI, Visited) ->
+    add_type_pairs(Tab, R1, R2, add_type_pair(Tab, T1, T2, VI, Visited), Visited).
+
+-spec add_map_assoc_pairs(symtab:t(), [ast:ty_map_assoc()], [ast:ty_map_assoc()], var_info(), sets:set()) -> var_info().
+add_map_assoc_pairs(_Tab, [], [], VI, _Visited) -> VI;
+add_map_assoc_pairs(Tab, [{_, K1, V1} | R1], [{_, K2, V2} | R2], VI, Visited) ->
+    VI1 = add_type_pair(Tab, K1, K2, add_type_pair(Tab, V1, V2, VI, Visited), Visited),
+    add_map_assoc_pairs(Tab, R1, R2, VI1, Visited).
+
+-spec map_add(K, V, #{K => [V]}) -> #{K => [V]}.
+map_add(Key, Val, Map) ->
+    maps:update_with(Key, fun(L) -> [Val | L] end, [Val], Map).
+
+%% ============================================================
+%% Nominal derivation map
+%% ============================================================
+
+% Build a map from each nominal type to the set of nominals it derives from
+% (transitively). A nominal A derives from B if A's body contains B, either
+% directly or through non-nominal aliases.
+-spec build_derivation_map(symtab:t()) -> derivation_map().
+build_derivation_map(Tab) ->
+    Nominals = sets:to_list(symtab:get_nominals(Tab)),
+    lists:foldl(fun(Key, Map) ->
+        Derives = find_derived_nominals(Tab, Key, sets:new()),
+        maps:put(Key, Derives, Map)
+    end, #{}, Nominals).
+
+% Find all nominal types that Key derives from (transitively).
+-spec find_derived_nominals(symtab:t(), symtab:ty_key(), sets:set(symtab:ty_key())) -> sets:set(symtab:ty_key()).
+find_derived_nominals(Tab, {ty_key, M, N, A} = Key, Visited) ->
+    case sets:is_element(Key, Visited) of
+        true -> sets:new();
+        false ->
+            Ref = {ty_ref, M, N, A},
+            {ty_scheme, Vars, Body} = symtab:lookup_ty(Ref, ast:loc_auto(), Tab),
+            VarNames = [V || {V, _Bound} <- Vars],
+            % Use empty args for arity-0 types, placeholder anys for parameterized
+            Args = [{predef, any} || _ <- VarNames],
+            SubstBody = case length(VarNames) =:= length(Args) andalso Args =/= [] of
+                true ->
+                    Map = subst:from_list(lists:zip(VarNames, Args)),
+                    subst:apply(Map, Body, no_clean);
+                false -> Body
+            end,
+            % Find all nominal refs in the body
+            Visited1 = sets:add_element(Key, Visited),
+            DirectNominals = collect_nominal_refs(Tab, SubstBody),
+            % Transitively find derivations of each direct nominal
+            sets:fold(fun(DerivedKey, Acc) ->
+                Transitive = find_derived_nominals(Tab, DerivedKey, Visited1),
+                sets:union(sets:add_element(DerivedKey, Transitive), Acc)
+            end, DirectNominals, DirectNominals)
+    end.
+
+% Collect all nominal type keys referenced in a type expression.
+-spec collect_nominal_refs(symtab:t(), ast:ty()) -> sets:set(symtab:ty_key()).
+collect_nominal_refs(Tab, Ty) ->
+    Refs = utils:everything(
+        fun ({named, _, Ref, _}) ->
+                case symtab:is_nominal(Ref, Tab) of
+                    true -> {ok, symtab:ref_to_key(Ref)};
+                    false -> error
+                end;
+            (_) -> error
+        end, Ty),
+    sets:from_list(Refs).
+
+% Check if two nominal types are compatible: same type or one derives from the other.
+-spec are_nominals_compatible(symtab:ty_key(), symtab:ty_key(), derivation_map()) -> boolean().
+are_nominals_compatible(Key, Key, _) -> true;
+are_nominals_compatible(Key1, Key2, DerivMap) ->
+    derives_from(Key1, Key2, DerivMap) orelse derives_from(Key2, Key1, DerivMap).
+
+-spec derives_from(symtab:ty_key(), symtab:ty_key(), derivation_map()) -> boolean().
+derives_from(Key1, Key2, DerivMap) ->
+    case maps:find(Key1, DerivMap) of
+        {ok, Derives} -> sets:is_element(Key2, Derives);
+        error -> false
+    end.
+
+% Compute transitive lower bounds of a variable: all concrete types T
+% such that T <: ... <: V through scsubty variable chains, scmater, and
+% direct scsubty(_, ConcreteT, {var,V}) constraints.
+-spec trans_lower(ast:ty_varname(), var_info(), sets:set(ast:ty_varname())) -> [ast:ty()].
+trans_lower(V, VarInfo = #var_info{mater_map = MM, graph = G, lower = CL}, Visited) ->
+    case sets:is_element(V, Visited) of
+        true -> [];
+        false ->
+            Visited1 = sets:add_element(V, Visited),
+            Direct = maps:get(V, CL, []) ++
+                case maps:find(V, MM) of
+                    {ok, T} -> [T];
+                    error -> []
+                end,
+            % Follow reverse edges: for each P where P <: V, include P's lower bounds
+            Preds = maps:get(V, G#var_graph.reverse, []),
+            Indirect = lists:flatmap(fun(P) ->
+                trans_lower(P, VarInfo, Visited1)
+            end, Preds),
+            Direct ++ Indirect
+    end.
+
+% Compute transitive upper bounds of a variable: all concrete types T
+% such that V <: ... <: T through scsubty variable chains and
+% direct scsubty(_, {var,V}, ConcreteT) constraints.
+-spec trans_upper(ast:ty_varname(), var_info(), sets:set(ast:ty_varname())) -> [ast:ty()].
+trans_upper(V, VarInfo = #var_info{graph = G, upper = CU}, Visited) ->
+    case sets:is_element(V, Visited) of
+        true -> [];
+        false ->
+            Visited1 = sets:add_element(V, Visited),
+            Direct = maps:get(V, CU, []),
+            % Follow forward edges: for each S where V <: S, include S's upper bounds
+            Succs = maps:get(V, G#var_graph.forward, []),
+            Indirect = lists:flatmap(fun(S) ->
+                trans_upper(S, VarInfo, Visited1)
+            end, Succs),
+            Direct ++ Indirect
+    end.
+
+%% ============================================================
+%% Pairwise nominal compatibility checking
+%% ============================================================
+
+% Check a pair of types for nominal incompatibility.
+% Returns ok (compatible), skip (types can't overlap, not applicable),
+% or {error, _} (nominal conflict found).
+% When a type variable is encountered, ALL its transitive bounds are checked:
+% lower bounds for LHS variables, upper bounds for RHS variables.
+% Recurses into compound types and unfolds non-nominal named types.
+% The Seen set tracks (T1, T2) pairs to detect cycles in recursive types.
+-spec check_nominal_pair(symtab:t(), ast:loc(), ast:ty(), ast:ty(), var_info(), sets:set()) ->
+    nominal_result().
+check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen) ->
+    Key = {T1, T2},
+    case sets:is_element(Key, Seen) of
+        true -> ok; % cycle in recursive types: can't prove incompatibility
+        false ->
+            check_nominal_pair_inner(Tab, Loc, T1, T2, VarInfo, sets:add_element(Key, Seen))
+    end.
+
+-spec check_nominal_pair_inner(symtab:t(), ast:loc(), ast:ty(), ast:ty(), var_info(), sets:set()) ->
+    nominal_result().
+% LHS is a variable: resolve to all transitive lower bounds and check each
+check_nominal_pair_inner(Tab, Loc, {var, Alpha}, T2, VarInfo, Seen) ->
+    Lowers = trans_lower(Alpha, VarInfo, sets:new()),
+    check_any_against(Tab, Loc, Lowers, T2, VarInfo, Seen);
+% RHS is a variable: resolve to all transitive upper bounds and check each
+check_nominal_pair_inner(Tab, Loc, T1, {var, Beta}, VarInfo, Seen) ->
+    Uppers = trans_upper(Beta, VarInfo, sets:new()),
+    check_against_any(Tab, Loc, T1, Uppers, VarInfo, Seen);
+% LHS is a union: each element must be compatible with RHS
+check_nominal_pair_inner(Tab, Loc, {union, Elems}, T2, VarInfo, Seen) ->
+    check_any_against(Tab, Loc, Elems, T2, VarInfo, Seen);
+% RHS is a union: LHS must be compatible with at least one element
+check_nominal_pair_inner(Tab, Loc, T1, {union, Elems}, VarInfo, Seen) ->
+    check_against_some(Tab, Loc, T1, Elems, VarInfo, Seen);
+% LHS is an intersection: every element must be compatible with RHS,
+% because a value in the intersection carries all nominal identities simultaneously
+check_nominal_pair_inner(Tab, Loc, {intersection, Elems}, T2, VarInfo, Seen) ->
+    check_any_against(Tab, Loc, Elems, T2, VarInfo, Seen);
+% RHS is an intersection: LHS must be compatible with every element
+check_nominal_pair_inner(Tab, Loc, T1, {intersection, Elems}, VarInfo, Seen) ->
+    check_against_any(Tab, Loc, T1, Elems, VarInfo, Seen);
+% Mu types: unwrap and check the body (Seen set handles cycles)
+check_nominal_pair_inner(Tab, Loc, {mu, _, Body1}, T2, VarInfo, Seen) ->
+    check_nominal_pair(Tab, Loc, Body1, T2, VarInfo, Seen);
+check_nominal_pair_inner(Tab, Loc, T1, {mu, _, Body2}, VarInfo, Seen) ->
+    check_nominal_pair(Tab, Loc, T1, Body2, VarInfo, Seen);
+% Negation types: recurse into body (nominal check is symmetric)
+check_nominal_pair_inner(Tab, Loc, {negation, T1}, {negation, T2}, VarInfo, Seen) ->
+    check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen);
+check_nominal_pair_inner(Tab, Loc, {negation, T1}, T2, VarInfo, Seen) ->
+    check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen);
+check_nominal_pair_inner(Tab, Loc, T1, {negation, T2}, VarInfo, Seen) ->
+    check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen);
+% Both named types
+check_nominal_pair_inner(Tab, Loc, {named, _, Ref1, Args1}, {named, _, Ref2, Args2}, VarInfo, Seen) ->
+    case symtab:ref_to_key(Ref1) =:= symtab:ref_to_key(Ref2) of
+        true when length(Args1) =:= length(Args2) ->
+            % Same type constructor (nominal or not): check args pairwise
+            check_nominal_pairs(Tab, Loc, Args1, Args2, VarInfo, Seen);
+        true ->
+            ok;
+        false ->
+            case {symtab:is_nominal(Ref1, Tab), symtab:is_nominal(Ref2, Tab)} of
+                {true, true} ->
+                    % Two different nominal types: check derivation via precomputed map
+                    Key1 = symtab:ref_to_key(Ref1),
+                    Key2 = symtab:ref_to_key(Ref2),
+                    case are_nominals_compatible(Key1, Key2, VarInfo#var_info.derivations) of
+                        true -> ok;
+                        false ->
+                            nominal_error(Loc, {named, Loc, Ref1, Args1}, {named, Loc, Ref2, Args2})
+                    end;
+                {false, false} ->
+                    % Both non-nominal, different refs: unfold both and check
+                    U1 = try_unfold(Tab, {named, Loc, Ref1, Args1}),
+                    U2 = try_unfold(Tab, {named, Loc, Ref2, Args2}),
+                    check_nominal_pair(Tab, Loc, U1, U2, VarInfo, Seen);
+                {true, false} ->
+                    U2 = try_unfold(Tab, {named, Loc, Ref2, Args2}),
+                    check_nominal_pair(Tab, Loc, {named, Loc, Ref1, Args1}, U2, VarInfo, Seen);
+                {false, true} ->
+                    U1 = try_unfold(Tab, {named, Loc, Ref1, Args1}),
+                    check_nominal_pair(Tab, Loc, U1, {named, Loc, Ref2, Args2}, VarInfo, Seen)
+            end
+    end;
+% Compound types with matching shapes: recurse into components
+check_nominal_pair_inner(Tab, Loc, {tuple, Elems1}, {tuple, Elems2}, VarInfo, Seen)
+        when length(Elems1) =:= length(Elems2) ->
+    check_nominal_pairs(Tab, Loc, Elems1, Elems2, VarInfo, Seen);
+check_nominal_pair_inner(Tab, Loc, {list, E1}, {list, E2}, VarInfo, Seen) ->
+    check_nominal_pair(Tab, Loc, E1, E2, VarInfo, Seen);
+check_nominal_pair_inner(Tab, Loc, {nonempty_list, E1}, {nonempty_list, E2}, VarInfo, Seen) ->
+    check_nominal_pair(Tab, Loc, E1, E2, VarInfo, Seen);
+check_nominal_pair_inner(Tab, Loc, {cons, H1, T1}, {cons, H2, T2}, VarInfo, Seen) ->
+    case check_nominal_pair(Tab, Loc, H1, H2, VarInfo, Seen) of
+        {error, _} = Err -> Err;
+        R1 -> combine_results(R1, check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen))
+    end;
+check_nominal_pair_inner(Tab, Loc, {improper_list, H1, T1}, {improper_list, H2, T2}, VarInfo, Seen) ->
+    case check_nominal_pair(Tab, Loc, H1, H2, VarInfo, Seen) of
+        {error, _} = Err -> Err;
+        R1 -> combine_results(R1, check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen))
+    end;
+check_nominal_pair_inner(Tab, Loc, {nonempty_improper_list, H1, T1}, {nonempty_improper_list, H2, T2}, VarInfo, Seen) ->
+    case check_nominal_pair(Tab, Loc, H1, H2, VarInfo, Seen) of
+        {error, _} = Err -> Err;
+        R1 -> combine_results(R1, check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen))
+    end;
+check_nominal_pair_inner(Tab, Loc, {fun_full, Args1, Ret1}, {fun_full, Args2, Ret2}, VarInfo, Seen)
+        when length(Args1) =:= length(Args2) ->
+    case check_nominal_pairs(Tab, Loc, Args1, Args2, VarInfo, Seen) of
+        {error, _} = Err -> Err;
+        R1 -> combine_results(R1, check_nominal_pair(Tab, Loc, Ret1, Ret2, VarInfo, Seen))
+    end;
+% Map types: check association keys and values pairwise
+check_nominal_pair_inner(Tab, Loc, {map, Assocs1}, {map, Assocs2}, VarInfo, Seen)
+        when length(Assocs1) =:= length(Assocs2) ->
+    {Ks1, Vs1} = lists:unzip([{K, V} || {_, K, V} <- Assocs1]),
+    {Ks2, Vs2} = lists:unzip([{K, V} || {_, K, V} <- Assocs2]),
+    check_nominal_pairs(Tab, Loc, Ks1 ++ Vs1, Ks2 ++ Vs2, VarInfo, Seen);
+% One side is a non-nominal named type, other is structural: unfold and re-check
+check_nominal_pair_inner(Tab, Loc, {named, _, Ref, _Args} = N, T2, VarInfo, Seen) ->
+    case symtab:is_nominal(Ref, Tab) of
+        true -> ok; % nominal vs non-named structural: no conflict
+        false ->
+            U = try_unfold(Tab, N),
+            check_nominal_pair(Tab, Loc, U, T2, VarInfo, Seen)
+    end;
+check_nominal_pair_inner(Tab, Loc, T1, {named, _, Ref, _Args} = N, VarInfo, Seen) ->
+    case symtab:is_nominal(Ref, Tab) of
+        true -> ok; % non-named structural vs nominal: no conflict
+        false ->
+            U = try_unfold(Tab, N),
+            check_nominal_pair(Tab, Loc, T1, U, VarInfo, Seen)
+    end;
+% Types with no nominal content or incompatible shapes: nothing to check
+check_nominal_pair_inner(_Tab, _Loc, _T1, _T2, _VarInfo, _Seen) -> skip.
+
+% Combine two nominal results: error always propagates, ok + ok = ok,
+% skip + ok = ok, skip + skip = skip.
+% The first argument is always ok | skip (callers short-circuit errors).
+-spec combine_results(ok | skip, nominal_result()) -> nominal_result().
+combine_results(_, {error, _} = Err) -> Err;
+combine_results(ok, _) -> ok;
+combine_results(skip, R) -> R.
+
+%% ============================================================
+%% List checking helpers
+%% ============================================================
+
+% Check each type in the list against T2. All must be compatible.
+% Returns ok if all return ok, skip if any returns skip (and none error),
+% error on first error.
+-spec check_any_against(symtab:t(), ast:loc(), [ast:ty()], ast:ty(), var_info(), sets:set()) ->
+    nominal_result().
+check_any_against(_Tab, _Loc, [], _T2, _VarInfo, _Seen) -> ok;
+check_any_against(Tab, Loc, [T1 | Rest], T2, VarInfo, Seen) ->
+    case check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen) of
+        {error, _} = Err -> Err;
+        R1 -> combine_results(R1, check_any_against(Tab, Loc, Rest, T2, VarInfo, Seen))
+    end.
+
+% Check T1 against each type in the list. All must be compatible.
+-spec check_against_any(symtab:t(), ast:loc(), ast:ty(), [ast:ty()], var_info(), sets:set()) ->
+    nominal_result().
+check_against_any(_Tab, _Loc, _T1, [], _VarInfo, _Seen) -> ok;
+check_against_any(Tab, Loc, T1, [T2 | Rest], VarInfo, Seen) ->
+    case check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen) of
+        {error, _} = Err -> Err;
+        R1 -> combine_results(R1, check_against_any(Tab, Loc, T1, Rest, VarInfo, Seen))
+    end.
+
+% Check T1 against a union: find a compatible element.
+% - ok: found a structurally plausible element with no nominal conflict -> accept
+% - skip: types can't overlap with this element -> try next
+% - error: nominal conflict with this element -> try next, but remember the error
+% If all plausible elements have conflicts, return the last error.
+% If no plausible elements exist (all skip), return ok (no nominal concern).
+-spec check_against_some(symtab:t(), ast:loc(), ast:ty(), [ast:ty()], var_info(), sets:set()) ->
+    nominal_result().
+check_against_some(Tab, Loc, T1, Elems, VarInfo, Seen) ->
+    check_against_some(Tab, Loc, T1, Elems, VarInfo, Seen, no_match).
+
+-spec check_against_some(symtab:t(), ast:loc(), ast:ty(), [ast:ty()], var_info(), sets:set(),
+    no_match | {error, error()}) -> nominal_result().
+check_against_some(_Tab, _Loc, _T1, [], _VarInfo, _Seen, no_match) -> ok;
+check_against_some(_Tab, _Loc, _T1, [], _VarInfo, _Seen, {error, _} = Err) -> Err;
+check_against_some(Tab, Loc, T1, [T2 | Rest], VarInfo, Seen, LastErr) ->
+    case check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen) of
+        ok -> ok;
+        skip -> check_against_some(Tab, Loc, T1, Rest, VarInfo, Seen, LastErr);
+        {error, _} = Err -> check_against_some(Tab, Loc, T1, Rest, VarInfo, Seen, Err)
+    end.
+
+-spec check_nominal_pairs(symtab:t(), ast:loc(), [ast:ty()], [ast:ty()], var_info(), sets:set()) ->
+    nominal_result().
+check_nominal_pairs(_Tab, _Loc, [], [], _VarInfo, _Seen) -> ok;
+check_nominal_pairs(Tab, Loc, [T1 | Rest1], [T2 | Rest2], VarInfo, Seen) ->
+    case check_nominal_pair(Tab, Loc, T1, T2, VarInfo, Seen) of
+        {error, _} = Err -> Err;
+        R1 -> combine_results(R1, check_nominal_pairs(Tab, Loc, Rest1, Rest2, VarInfo, Seen))
+    end.
+
+
+%% ============================================================
+%% Type unfolding helpers
+%% ============================================================
+
+% Unfold a non-nominal named type one step by substituting args into the body.
+-spec try_unfold(symtab:t(), ast:ty()) -> ast:ty().
+try_unfold(Tab, {named, Loc, Ref, Args}) ->
+    {ty_scheme, Vars, Body} = symtab:lookup_ty(Ref, Loc, Tab),
+    VarNames = [V || {V, _Bound} <- Vars],
+    case length(VarNames) =:= length(Args) of
+        true ->
+            Map = subst:from_list(lists:zip(VarNames, Args)),
+            subst:apply(Map, Body, no_clean);
+        false -> {named, Loc, Ref, Args}
+    end.
+
+
+-spec nominal_error(ast:loc(), ast:ty(), ast:ty()) -> {error, error()}.
+nominal_error(Loc, T1, T2) ->
+    Hint = utils:sformat("~s is not compatible with ~s",
+        pretty:render_ty(T1), pretty:render_ty(T2)),
+    {error, {nominal_incompatible, Loc, Hint}}.

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -8,6 +8,7 @@
 
 -export_type([
     t/0,
+    ty_key/0,
     fun_env/0,
     ty_env/0,
     record_env/0,
@@ -26,7 +27,11 @@
     empty/0,
     extend_symtab_with_module_list/4,
     dump_symtab/2, overlay_symtab/1,
-    get_types/1
+    get_types/1,
+    has_any_nominals/1,
+    is_nominal/2,
+    get_nominals/1,
+    ref_to_key/1
 ]).
 
 -ifdef(TEST). % for tally tests
@@ -48,13 +53,29 @@
               ops :: op_env(),
               types :: ty_env(),
               records :: record_env(),
-              modules :: mod_env()
+              modules :: mod_env(),
+              nominals :: sets:set(ty_key())
 }).
 
 -type t() :: #tab{}.
 
 -spec get_types(t()) -> ty_env().
 get_types(#tab{types = Types}) -> Types.
+
+-spec ref_to_key(ast:ty_ref()) -> ty_key().
+ref_to_key({ty_ref, M, N, A}) -> {ty_key, M, N, A};
+ref_to_key({ty_qref, M, N, A}) -> {ty_key, M, N, A}.
+
+-spec has_any_nominals(t()) -> boolean().
+has_any_nominals(Tab) ->
+    sets:size(Tab#tab.nominals) > 0.
+
+-spec is_nominal(ast:ty_ref(), t()) -> boolean().
+is_nominal(Ref, Tab) ->
+    sets:is_element(ref_to_key(Ref), Tab#tab.nominals).
+
+-spec get_nominals(t()) -> sets:set(ty_key()).
+get_nominals(#tab{nominals = Nominals}) -> Nominals.
 
 -spec dump_symtab(string(), t()) -> ok.
 dump_symtab(Msg, Tab) ->
@@ -119,11 +140,7 @@ lookup_ty(Ref, Loc, Tab) ->
 
 -spec find_ty(ast:ty_ref(), t()) -> t:opt(ast:ty_scheme()).
 find_ty(Ref, Tab) ->
-    TyRef = case Ref of
-                {ty_ref, M, N, A} -> {ty_key, M, N, A};
-                {ty_qref, M, N ,A} -> {ty_key, M, N, A}
-            end ,
-    maps:find(TyRef, Tab#tab.types).
+    maps:find(ref_to_key(Ref), Tab#tab.types).
 
 -spec lookup_record(atom(), ast:loc(), t()) -> records:record_ty().
 lookup_record(Name, Loc, Tab) ->
@@ -151,7 +168,7 @@ symbols_for_module(Mod, Tab) ->
         ).
 
 -spec empty() -> t().
-empty() -> #tab { funs = #{}, ops = #{}, types = #{}, records = #{}, modules = #{} }.
+empty() -> #tab { funs = #{}, ops = #{}, types = #{}, records = #{}, modules = #{}, nominals = sets:new() }.
 
 -spec std_symtab(paths:search_path(), t()) -> t().
 std_symtab(SearchPath, OverlaySymtab) ->
@@ -178,7 +195,7 @@ build_std_symtab(SearchPath, OverlaySymtab) ->
         lists:foldl(fun({Name, Arity, T}, Map) -> maps:put({Name, Arity}, T, Map) end,
                     #{},
                     stdtypes:builtin_ops()),
-    Tab = #tab { funs = Funs, ops = Ops, types = #{}, records = #{}, modules = #{} },
+    Tab = #tab { funs = Funs, ops = Ops, types = #{}, records = #{}, modules = #{}, nominals = sets:new() },
     ExtTab = extend_symtab_with_module_list(Tab, SearchPath, [erlang], OverlaySymtab),
     % Merge overlay types into the main symtab so they are available for type resolution
     ExtTab2 = ExtTab#tab { types = maps:merge(ExtTab#tab.types, OverlaySymtab#tab.types) },
@@ -203,9 +220,9 @@ overlay_symtab(OverlayForms) ->
 -spec overlay_process_form(ast:form(), t(), atom() | undefined) -> t().
 overlay_process_form({attribute, _, spec, Name, Arity, T, _}, Tab, _ModuleName) ->
     overlay_add_spec(Name, Arity, T, Tab);
-overlay_process_form({attribute, _, type, _Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, Tab, ModuleName) when ModuleName =/= undefined ->
+overlay_process_form({attribute, _, type, Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, Tab, ModuleName) when ModuleName =/= undefined ->
     Arity = length(TyVars),
-    overlay_add_type(ModuleName, Name, Arity, TyScm, Tab);
+    overlay_add_type(ModuleName, Name, Arity, TyScm, Visibility, Tab);
 overlay_process_form(_, Tab, _ModuleName) -> Tab.
 
 -spec overlay_add_spec(atom(), arity(), ast:ty_scheme(), t()) -> t().
@@ -214,11 +231,15 @@ overlay_add_spec(Name, Arity, T, Tab) ->
     [Module, FunName] = string:split(atom_to_list(Name), ":"),
     Tab#tab { funs = maps:put(create_ref_tuple({qref, list_to_atom(Module)}, list_to_atom(FunName), Arity), T, Tab#tab.funs) }.
 
--spec overlay_add_type(atom(), atom(), arity(), ast:ty_scheme(), t()) -> t().
-overlay_add_type(ModuleName, Name, Arity, TyScm, Tab) ->
+-spec overlay_add_type(atom(), atom(), arity(), ast:ty_scheme(), atom(), t()) -> t().
+overlay_add_type(ModuleName, Name, Arity, TyScm, Visibility, Tab) ->
     Key = {ty_key, ModuleName, Name, Arity},
     ?LOG_DEBUG("Overlay type added: ~w/~p", Name, Arity),
-    Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) }.
+    Tab1 = Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) },
+    case Visibility of
+        nominal -> Tab1#tab { nominals = sets:add_element(Key, Tab1#tab.nominals) };
+        _ -> Tab1
+    end.
 
 -type ref() :: ref | {qref, ModuleName::atom()}.
 
@@ -262,8 +283,8 @@ extend_symtab_internal(Filename, Forms, RefType, Tab, OverlaySymtab) ->
 -spec extend_process_form(ast:form(), t(), ref(), atom(), ast:forms(), t()) -> t().
 extend_process_form({attribute, _, spec, Name, Arity, T, _}, AccTab, RefType, ModuleName, Forms, OverlaySymtab) ->
     extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymtab);
-extend_process_form({attribute, _, type, _, {Name, TyScm = {ty_scheme, TyVars, _}}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
-    extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab);
+extend_process_form({attribute, _, type, Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
+    extend_add_type(Name, TyScm, TyVars, ModuleName, Visibility, AccTab);
 extend_process_form({attribute, _, record, {RecordName, Fields}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
     extend_add_record(RecordName, Fields, ModuleName, AccTab);
 extend_process_form(_, AccTab, _RefType, _ModuleName, _Forms, _OverlaySymtab) ->
@@ -284,10 +305,15 @@ extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymta
             AccTab#tab { funs = maps:put(create_ref_tuple(RefType, Name, Arity), OverlayT, AccTab#tab.funs) }
     end.
 
--spec extend_add_type(atom(), ast:ty_scheme(), [{atom(), any()}], atom(), t()) -> t().
-extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab) ->
+-spec extend_add_type(atom(), ast:ty_scheme(), [{atom(), any()}], atom(), atom(), t()) -> t().
+extend_add_type(Name, TyScm, TyVars, ModuleName, Visibility, AccTab) ->
     Arity = length(TyVars),
-    AccTab#tab { types = maps:put({ty_key, ModuleName, Name, Arity}, TyScm, AccTab#tab.types) }.
+    Key = {ty_key, ModuleName, Name, Arity},
+    AccTab1 = AccTab#tab { types = maps:put(Key, TyScm, AccTab#tab.types) },
+    case Visibility of
+        nominal -> AccTab1#tab { nominals = sets:add_element(Key, AccTab1#tab.nominals) };
+        _ -> AccTab1
+    end.
 
 -spec extend_add_record(atom(), list(), atom(), t()) -> t().
 extend_add_record(RecordName, Fields, ModuleName, AccTab) ->

--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -247,7 +247,8 @@ tyerror_msg(Kind) ->
     case Kind of
         tyerror -> "expression failed to type check";
         redundant_branch -> "this branch never matches";
-        non_exhaustive_case -> "not all cases are covered"
+        non_exhaustive_case -> "not all cases are covered";
+        nominal_incompatible -> "incompatible nominal types"
     end.
 
 -spec report_tyerror(string(), constr_error_locs:constr_error_kind(), ast:loc(), string()) -> no_return().


### PR DESCRIPTION
Adds a `check_nominal_constrs` pass that runs before the regular satisfiability check. The nominal checker (`constr_solve_nominal.erl`) is the self-contained module doing the actual analysis. It inspects subtype constraints, resolves variables via the materialization map, and checks that two nominal types with different names are never used interchangeably (if one nominal is not derived form another). Two nominals with the same name are fine, and a nominal paired with a structural type is fine. The nominal check happens before the actual constraint solving, basically. After that, nominal types behave the same as non-nominal types.

It should be noted that Dialyzer only implements, by design, an approximation of nominal typing.

Finally, we differ in one aspect of the interpretation of nominal types. In the thesis's lattice, derivation is directional: container <: state but not state <: container. This is also why we don't check for variance in this implementation.

There is no performance hit when no nominal types are present, and no performance hit if nominal types are present. If we modify all `-type` definitions to `-nominal` one (worst case), the performance impact is negligible.

 The variable graph connects lower bounds (concrete types from scmater and T <: {var, V} constraints) to upper bounds  (concrete types from {var, V} <: T constraints) through transitive variable chains. The nominal check then verifies that every LB-UB pair reachable through the graph is nominally compatible. 

Example:

Red nodes contain nominals. The checker follows chains like `meter() → $1 → $4 → $6 → $7 → $9 → foot()` and flags the meter/foot conflict. The `int() → ... → int()` paths are fine (no nominals on both ends).


```mermaid
 graph LR
      LB1["meter()"] --> V1["$1"]
      LB2["{meter(), int()}"] --> V2["$2"]
      LB3["int()"] --> V3["$3"]

      V1 --> V4["$4"]
      V2 --> V5["$5"]
      V3 --> V4
      V4 --> V6["$6"]
      V5 --> V6
      V6 --> V7["$7"]
      V5 --> V8["$8"]
      V7 --> V9["$9"]
      V8 --> V9

      V9 --> UB1["foot()"]
      V7 --> UB2["int()"]
      V9 --> UB3["{foot(), int()}"]

      style LB1 fill:#f66,color:#fff
      style LB2 fill:#f66,color:#fff
      style LB3 fill:#99f
      style UB1 fill:#f66,color:#fff
      style UB2 fill:#99f
      style UB3 fill:#f66,color:#fff
```

We avoid cycles the same way as in `erlang_types`. Variables have an order, so a DAG is guaranteed.

Runs on the same tests as #338.

Finally, the nominal check can have false positives when nominal types appear in structurally dead parts of compound types. For example, it will flag `foot() & none() <: meter() & none()` as incompatible. 

Currently, there are 11 nominal type declarations across 5 files in the standard library of Erlang.

<details>
A nice utility function that results out of the analysis is a complete variable graph on constraints:

<img width="1888" height="442" alt="image" src="https://github.com/user-attachments/assets/eb09507d-8888-4c00-90c7-535a46d1c918" />

I have used this previously to reason about tally splitting, but not including the graph building in the code base. Now it's integrated in the code base.
</details>

<details>
All types replaced by nominals

Interesting to note: including include files with -nominal types present won't be type safe, as nominals are module-scoped and even with same names, will be treated differently.

```erlang
Ok: dnf_ty_function:'::'/2 (185 ms)
Ok: dnf_ty_function:':::'/2 (23 ms)
Ok: dnf_ty_function:reorder/1 (504 ms)
Ok: dnf_ty_function:reorder_check_neg/4 (124 ms)
Ok: dnf_ty_function:push_down/3 (25 ms)
Ok: dnf_ty_function:assert_valid/1 (23 ms)
Ok: dnf_ty_function:is_ordered/1 (108 ms)
Ok: dnf_ty_function:check_branch/2 (216 ms)
Ok: dnf_ty_function:any/0 (23 ms)
Ok: dnf_ty_function:empty/0 (23 ms)
Ok: dnf_ty_function:singleton/1 (26 ms)
Ok: dnf_ty_function:negated_singleton/1 (23 ms)
Ok: dnf_ty_function:leaf/1 (24 ms)
Ok: dnf_ty_function:equal/2 (279 ms)
Ok: dnf_ty_function:compare/2 (1409 ms)
Ok: dnf_ty_function:negate/1 (119 ms)
Ok: dnf_ty_function:normalize/1 (134 ms)
Ok: dnf_ty_function:leaf_op_eq/9 (193 ms)
Ok: dnf_ty_function:union/2 (26 ms)
Ok: dnf_ty_function:intersect/2 (25 ms)
Ok: dnf_ty_function:difference/2 (25 ms)
Ok: dnf_ty_function:dnf/1 (24 ms)
Ok: dnf_ty_function:dnf_acc/4 (983 ms)
Ok: dnf_ty_function:is_empty/2 (1021 ms)
Ok: dnf_ty_function:normalize/3 (5085 ms)
Ok: dnf_ty_function:all_variables/2 (444 ms)
Ok: dnf_ty_function:minimize_dnf/1 (24 ms)
Ok: dnf_ty_function:minimize_node_dnf/1 (2170 ms)
Ok: dnf_ty_function:'_minimize_vars_from_dnf'/1 (363 ms)
Ok: dnf_ty_function:'_minimize_outputs_from_dnf'/1 (10209 ms)
Ok: dnf_ty_function:'_minimize_indices_from_variables'/1 (682 ms)
Ok: dnf_ty_function:espresso_split_line_into_elements_and_result/1 (47 ms)
Ok: dnf_ty_function:'_minimize_get_result'/5 (126 ms)
Ok: dnf_ty_function:extract_integer_lines/2 (78 ms)
Ok: dnf_ty_function:is_integer_start/1 (122 ms)
Ok: dnf_ty_function:has_negative_only_line/1 (112 ms)
Ok: dnf_ty_function:is_empty_cont/3 (134 ms)
Ok: dnf_ty_function:explore_function/4 (541 ms)
Ok: dnf_ty_function:phi/4 (3864 ms)
Ok: dnf_ty_function:normalize_line/3 (258 ms)
Ok: dnf_ty_function:normalize_line_cont/5 (1002 ms)
Ok: dnf_ty_function:explore_function_norm/5 (2538 ms)
Ok: dnf_ty_function:all_variables_line/4 (99 ms)
Ok: dnf_ty_function:unparse_any/0 (37 ms)
Ok: dnf_ty_function:unparse_any/1 (3244 ms)
Ok: dnf_ty_interval:reorder/1 (284 ms)
Ok: dnf_ty_interval:empty/0 (29 ms)
Ok: dnf_ty_interval:any/0 (46 ms)
Ok: dnf_ty_interval:interval/2 (1028 ms)
Ok: dnf_ty_interval:cointerval/2 (29 ms)
Ok: dnf_ty_interval:is_empty/2 (103 ms)
Ok: dnf_ty_interval:is_any/1 (57 ms)
Ok: dnf_ty_interval:negate_start_with/2 (2818 ms)
Ok: dnf_ty_interval:union/2 (34 ms)
Ok: dnf_ty_interval:intersect/2 (30 ms)
Ok: dnf_ty_interval:difference/2 (30 ms)
Ok: dnf_ty_interval:interval_add/2 (355 ms)
Ok: dnf_ty_interval:normalize/3 (98 ms)
Ok: dnf_ty_interval:unparse/2 (53 ms)
Ok: dnf_ty_interval:unp/1 (4660 ms)
Ok: dnf_ty_interval:all_variables/2 (54 ms)
Ok: dnf_ty_interval:has_negative_only_line/1 (35 ms)
Ok: dnf_ty_list:'::'/2 (182 ms)
Ok: dnf_ty_list:':::'/2 (24 ms)
Ok: dnf_ty_list:reorder/1 (475 ms)
Ok: dnf_ty_list:reorder_check_neg/4 (122 ms)
Ok: dnf_ty_list:push_down/3 (26 ms)
Ok: dnf_ty_list:assert_valid/1 (23 ms)
Ok: dnf_ty_list:is_ordered/1 (95 ms)
Ok: dnf_ty_list:check_branch/2 (205 ms)
Ok: dnf_ty_list:any/0 (24 ms)
Ok: dnf_ty_list:empty/0 (24 ms)
Ok: dnf_ty_list:singleton/1 (26 ms)
Ok: dnf_ty_list:negated_singleton/1 (25 ms)
Ok: dnf_ty_list:leaf/1 (24 ms)
Ok: dnf_ty_list:equal/2 (270 ms)
Ok: dnf_ty_list:compare/2 (1375 ms)
Ok: dnf_ty_list:negate/1 (116 ms)
Ok: dnf_ty_list:normalize/1 (116 ms)
Ok: dnf_ty_list:leaf_op_eq/9 (191 ms)
Ok: dnf_ty_list:union/2 (26 ms)
Ok: dnf_ty_list:intersect/2 (26 ms)
Ok: dnf_ty_list:difference/2 (26 ms)
Ok: dnf_ty_list:dnf/1 (25 ms)
Ok: dnf_ty_list:dnf_acc/4 (581 ms)
Ok: dnf_ty_list:is_empty/2 (942 ms)
Ok: dnf_ty_list:normalize/3 (3897 ms)
Ok: dnf_ty_list:all_variables/2 (442 ms)
Ok: dnf_ty_list:minimize_dnf/1 (23 ms)
Ok: dnf_ty_list:minimize_node_dnf/1 (3194 ms)
Ok: dnf_ty_list:'_minimize_vars_from_dnf'/1 (358 ms)
Ok: dnf_ty_list:'_minimize_outputs_from_dnf'/1 (7666 ms)
Ok: dnf_ty_list:'_minimize_indices_from_variables'/1 (665 ms)
Ok: dnf_ty_list:espresso_split_line_into_elements_and_result/1 (45 ms)
Ok: dnf_ty_list:'_minimize_get_result'/5 (115 ms)
Ok: dnf_ty_list:extract_integer_lines/2 (79 ms)
Ok: dnf_ty_list:is_integer_start/1 (125 ms)
Ok: dnf_ty_list:has_negative_only_line/1 (109 ms)
Ok: dnf_ty_list:is_empty_line/2 (26 ms)
Ok: dnf_ty_list:normalize_line/3 (29 ms)
Error: dnf_ty_list:all_variables_line/4 (33 ms)
  :0:0: Type error: in all_variables_line/4, incompatible nominal types


  all branch combinations have nominal conflicts
Ok: dnf_ty_map:'::'/2 (183 ms)
Ok: dnf_ty_map:':::'/2 (23 ms)
Ok: dnf_ty_map:reorder/1 (467 ms)
Ok: dnf_ty_map:reorder_check_neg/4 (121 ms)
Ok: dnf_ty_map:push_down/3 (26 ms)
Ok: dnf_ty_map:assert_valid/1 (24 ms)
Ok: dnf_ty_map:is_ordered/1 (98 ms)
Ok: dnf_ty_map:check_branch/2 (216 ms)
Ok: dnf_ty_map:any/0 (24 ms)
Ok: dnf_ty_map:empty/0 (23 ms)
Ok: dnf_ty_map:singleton/1 (24 ms)
Ok: dnf_ty_map:negated_singleton/1 (23 ms)
Ok: dnf_ty_map:leaf/1 (23 ms)
Ok: dnf_ty_map:equal/2 (270 ms)
Ok: dnf_ty_map:compare/2 (1354 ms)
Ok: dnf_ty_map:negate/1 (113 ms)
Ok: dnf_ty_map:normalize/1 (113 ms)
Ok: dnf_ty_map:leaf_op_eq/9 (194 ms)
Ok: dnf_ty_map:union/2 (26 ms)
Ok: dnf_ty_map:intersect/2 (25 ms)
Ok: dnf_ty_map:difference/2 (25 ms)
Ok: dnf_ty_map:dnf/1 (25 ms)
Ok: dnf_ty_map:dnf_acc/4 (1594 ms)
Ok: dnf_ty_map:is_empty/2 (611 ms)
Ok: dnf_ty_map:normalize/3 (3550 ms)
Ok: dnf_ty_map:all_variables/2 (439 ms)
Ok: dnf_ty_map:minimize_dnf/1 (23 ms)
Ok: dnf_ty_map:minimize_node_dnf/1 (2260 ms)
Ok: dnf_ty_map:'_minimize_vars_from_dnf'/1 (355 ms)
Ok: dnf_ty_map:'_minimize_indices_from_variables'/1 (666 ms)
Ok: dnf_ty_map:espresso_split_line_into_elements_and_result/1 (48 ms)
Ok: dnf_ty_map:'_minimize_get_result'/5 (117 ms)
Ok: dnf_ty_map:extract_integer_lines/2 (77 ms)
Ok: dnf_ty_map:is_integer_start/1 (143 ms)
Ok: dnf_ty_map:has_negative_only_line/1 (110 ms)
Ok: dnf_ty_map:is_empty_line/2 (1416 ms)
Ok: dnf_ty_map:normalize_line/3 (1483 ms)
Error: dnf_ty_map:all_variables_line/4 (34 ms)
  :0:0: Type error: in all_variables_line/4, incompatible nominal types


  all branch combinations have nominal conflicts
Ok: dnf_ty_predefined:reorder/1 (267 ms)
Ok: dnf_ty_predefined:compare/2 (104 ms)
Ok: dnf_ty_predefined:predefined/1 (158 ms)
Ok: dnf_ty_predefined:empty/0 (30 ms)
Ok: dnf_ty_predefined:any/0 (28 ms)
Ok: dnf_ty_predefined:negate/1 (45 ms)
Ok: dnf_ty_predefined:union/2 (51 ms)
Ok: dnf_ty_predefined:intersect/2 (41 ms)
Ok: dnf_ty_predefined:difference/2 (29 ms)
Ok: dnf_ty_predefined:normalize/3 (108 ms)
Ok: dnf_ty_predefined:all_variables/2 (53 ms)
Ok: dnf_ty_predefined:has_negative_only_line/1 (28 ms)
Ok: dnf_ty_tuple:'::'/2 (189 ms)
Ok: dnf_ty_tuple:':::'/2 (24 ms)
Ok: dnf_ty_tuple:reorder/1 (480 ms)
Ok: dnf_ty_tuple:reorder_check_neg/4 (123 ms)
Ok: dnf_ty_tuple:push_down/3 (25 ms)
Ok: dnf_ty_tuple:assert_valid/1 (23 ms)
Ok: dnf_ty_tuple:is_ordered/1 (96 ms)
Ok: dnf_ty_tuple:check_branch/2 (202 ms)
Ok: dnf_ty_tuple:any/0 (24 ms)
Ok: dnf_ty_tuple:empty/0 (23 ms)
Ok: dnf_ty_tuple:singleton/1 (25 ms)
Ok: dnf_ty_tuple:negated_singleton/1 (24 ms)
Ok: dnf_ty_tuple:leaf/1 (24 ms)
Ok: dnf_ty_tuple:equal/2 (275 ms)
Ok: dnf_ty_tuple:compare/2 (1396 ms)
Ok: dnf_ty_tuple:negate/1 (118 ms)
Ok: dnf_ty_tuple:normalize/1 (131 ms)
Ok: dnf_ty_tuple:leaf_op_eq/9 (190 ms)
Ok: dnf_ty_tuple:union/2 (27 ms)
Ok: dnf_ty_tuple:intersect/2 (26 ms)
Ok: dnf_ty_tuple:difference/2 (28 ms)
Ok: dnf_ty_tuple:dnf/1 (26 ms)
Ok: dnf_ty_tuple:dnf_acc/4 (632 ms)
Ok: dnf_ty_tuple:is_empty/2 (774 ms)
Ok: dnf_ty_tuple:normalize/3 (3571 ms)
Ok: dnf_ty_tuple:all_variables/2 (448 ms)
Ok: dnf_ty_tuple:minimize_dnf/1 (24 ms)
Ok: dnf_ty_tuple:minimize_node_dnf/1 (2236 ms)
Ok: dnf_ty_tuple:'_minimize_vars_from_dnf'/1 (364 ms)
Ok: dnf_ty_tuple:'_minimize_outputs_from_dnf'/1 (11169 ms)
Ok: dnf_ty_tuple:'_minimize_indices_from_variables'/1 (667 ms)
Ok: dnf_ty_tuple:espresso_split_line_into_elements_and_result/1 (47 ms)
Ok: dnf_ty_tuple:'_minimize_get_result'/5 (116 ms)
Ok: dnf_ty_tuple:extract_integer_lines/2 (79 ms)
Ok: dnf_ty_tuple:is_integer_start/1 (144 ms)
Ok: dnf_ty_tuple:has_negative_only_line/1 (108 ms)
Ok: dnf_ty_tuple:is_empty_line/2 (909 ms)
Ok: dnf_ty_tuple:phi_solve/4 (4167 ms)
Ok: dnf_ty_tuple:normalize_line/3 (1697 ms)
Ok: dnf_ty_tuple:phi_norm_solve/5 (2491 ms)
Ok: dnf_ty_tuple:all_variables_line/4 (100 ms)
Ok: dnf_ty_tuple:unparse_any/0 (23 ms)
Ok: dnf_ty_tuple:unparse_any/1 (1937 ms)
Ok: dnf_ty_variable:'::'/2 (186 ms)
Ok: dnf_ty_variable:':::'/2 (24 ms)
Ok: dnf_ty_variable:reorder/1 (911 ms)
Ok: dnf_ty_variable:reorder_check_neg/4 (187 ms)
Ok: dnf_ty_variable:push_down/3 (37 ms)
Ok: dnf_ty_variable:assert_valid/1 (25 ms)
Ok: dnf_ty_variable:is_ordered/1 (170 ms)
Ok: dnf_ty_variable:check_branch/2 (287 ms)
Ok: dnf_ty_variable:any/0 (25 ms)
Ok: dnf_ty_variable:empty/0 (25 ms)
Ok: dnf_ty_variable:singleton/1 (27 ms)
Ok: dnf_ty_variable:negated_singleton/1 (25 ms)
Ok: dnf_ty_variable:leaf/1 (24 ms)
Ok: dnf_ty_variable:equal/2 (397 ms)
Ok: dnf_ty_variable:compare/2 (2048 ms)
Ok: dnf_ty_variable:negate/1 (135 ms)
Ok: dnf_ty_variable:normalize/1 (170 ms)
Ok: dnf_ty_variable:leaf_op_eq/9 (433 ms)
Ok: dnf_ty_variable:union/2 (35 ms)
Ok: dnf_ty_variable:intersect/2 (35 ms)
Ok: dnf_ty_variable:difference/2 (35 ms)
Ok: dnf_ty_variable:dnf/1 (26 ms)
Ok: dnf_ty_variable:dnf_acc/4 (1193 ms)
Ok: dnf_ty_variable:is_empty/2 (715 ms)
Ok: dnf_ty_variable:normalize/3 (5191 ms)
Ok: dnf_ty_variable:all_variables/2 (465 ms)
Ok: dnf_ty_variable:minimize_dnf/1 (24 ms)
Ok: dnf_ty_variable:minimize_node_dnf/1 (2706 ms)
Ok: dnf_ty_variable:'_minimize_vars_from_dnf'/1 (380 ms)
Ok: dnf_ty_variable:'_minimize_outputs_from_dnf'/1 (10282 ms)
Ok: dnf_ty_variable:'_minimize_indices_from_variables'/1 (691 ms)
Ok: dnf_ty_variable:espresso_split_line_into_elements_and_result/1 (49 ms)
Ok: dnf_ty_variable:'_minimize_get_result'/5 (125 ms)
Ok: dnf_ty_variable:extract_integer_lines/2 (79 ms)
Ok: dnf_ty_variable:is_integer_start/1 (151 ms)
Ok: dnf_ty_variable:has_negative_only_line/1 (140 ms)
Ok: dnf_ty_variable:atom/1 (25 ms)
Ok: dnf_ty_variable:interval/1 (25 ms)
Ok: dnf_ty_variable:functions/1 (25 ms)
Ok: dnf_ty_variable:tuples/1 (25 ms)
Ok: dnf_ty_variable:list/1 (25 ms)
Ok: dnf_ty_variable:predefined/1 (25 ms)
Ok: dnf_ty_variable:bitstring/1 (24 ms)
Ok: dnf_ty_variable:map/1 (24 ms)
Ok: dnf_ty_variable:tuple_to_map/1 (60 ms)
Ok: dnf_ty_variable:is_empty_line/2 (309 ms)
Ok: dnf_ty_variable:smallest/3 (7550 ms)
Ok: dnf_ty_variable:single/4 (262 ms)
Ok: dnf_ty_variable:all_variables_line/4 (47 ms)
Ok: etally:'::'/2 (223 ms)
Ok: etally:':::'/2 (28 ms)
Ok: etally:is_tally_satisfiable/2 (256 ms)
Ok: etally:is_satisfiable_v1/2 (33 ms)
Ok: etally:tally_saturate_until_satisfiable/2 (69 ms)
Ok: etally:is_satisfiable_v2/2 (1891 ms)
Ok: etally:is_satisfiable_v4/2 (292 ms)
Ok: etally:process_input_solutions/3 (275 ms)
Ok: etally:find_least_increasing_solutions/3 (720 ms)
Ok: etally:find_least_increasing_solutions/4 (106 ms)
Ok: etally:do_find/4 (1020 ms)
Ok: etally:tally/1 (30 ms)
Ok: etally:tally/2 (38 ms)
Ok: etally:tally_normalize/2 (240 ms)
Ok: etally:tally_saturate/2 (144 ms)
Ok: etally:tally_solve/2 (83 ms)
Ok: etally:solve/2 (36 ms)
Ok: etally:solve_single/3 (347 ms)
Ok: etally:unify/1 (3983 ms)
Ok: etally:apply_substitution/2 (2708 ms)
Ok: global_state:init/0 (201 ms)
Ok: global_state:clean/0 (25 ms)
Ok: global_state:with_new_state/1 (127 ms)
Ok: tarjan:'::'/2 (138 ms)
Ok: tarjan:':::'/2 (10 ms)
Ok: tarjan:scc/1 (208 ms)
Ok: tarjan:roots/3 (179 ms)
Ok: tarjan:dfs/1 (9306 ms)
Ok: tarjan:dfs_visit/4 (10852 ms)
Ok: tarjan:reverse_graph/1 (260 ms)
Ok: ty_bool:compare/2 (344 ms)
Ok: ty_bool:equal/2 (36 ms)
Ok: ty_bool:empty/0 (29 ms)
Ok: ty_bool:any/0 (29 ms)
Ok: ty_bool:union/2 (29 ms)
Ok: ty_bool:intersect/2 (29 ms)
Ok: ty_bool:difference/2 (67 ms)
Ok: ty_bool:negate/1 (50 ms)
Ok: ty_bool:is_any/1 (44 ms)
Ok: ty_bool:is_empty/2 (84 ms)
Ok: ty_bool:all_variables/2 (51 ms)
Ok: ty_bool:unparse/2 (3454 ms)
Ok: ty_bool:normalize/3 (94 ms)
Ok: ty_bool:assert_valid/1 (34 ms)
Ok: ty_bool:reorder/1 (28 ms)
Ok: ty:compare/2 (290 ms)
Ok: ty:any/0 (29 ms)
Ok: ty:empty/0 (29 ms)
Error: ty:all_variables/1 (42 ms)
  :0:0: Type error: in all_variables/1, incompatible nominal types


  all branch combinations have nominal conflicts
Ok: ty:is_empty/1 (29 ms)
Ok: ty:is_equivalent/2 (48 ms)
Ok: ty:normalize/2 (36 ms)
Error: ty:substitute/2 (29 ms)
  :0:0: Type error: in substitute/2, incompatible nominal types


  all branch combinations have nominal conflicts
Ok: ty:difference/2 (28 ms)
Ok: ty:union/2 (28 ms)
Ok: ty:intersect/2 (29 ms)
Ok: ty:atom/0 (34 ms)
Error: ty:variable/1 (29 ms)
  :0:0: Type error: in variable/1, incompatible nominal types


  all branch combinations have nominal conflicts
Ok: ty:tuples/1 (29 ms)
Ok: ty:functions/1 (30 ms)
Ok: ty_function:'::'/2 (180 ms)
Ok: ty_function:':::'/2 (29 ms)
Ok: ty_function:compare/2 (6379 ms)
Ok: ty_function:equal/2 (30 ms)
Ok: ty_function:function/2 (60 ms)
Ok: ty_function:domain/1 (83 ms)
Ok: ty_function:codomain/1 (55 ms)
Ok: ty_function:all_variables/2 (117 ms)
Ok: ty_functions:reorder/1 (622 ms)
Ok: ty_functions:assert_valid/1 (153 ms)
Ok: ty_functions:empty/0 (29 ms)
Ok: ty_functions:any/0 (29 ms)
Ok: ty_functions:singleton/2 (59 ms)
Ok: ty_functions:negate/1 (64 ms)
Ok: ty_functions:union/2 (1356 ms)
Ok: ty_functions:intersect/2 (1240 ms)
Ok: ty_functions:difference/2 (1271 ms)
Ok: ty_functions:remove_redundant/1 (80 ms)
Ok: ty_functions:normalize/3 (299 ms)
Ok: ty_functions:normalize_arities/3 (3602 ms)
Ok: ty_functions:all_variables/2 (318 ms)
Ok: ty_functions:has_negative_only_line/1 (277 ms)
Ok: ty_list:'::'/2 (181 ms)
Ok: ty_list:':::'/2 (30 ms)
Ok: ty_list:list/1 (190 ms)
Ok: ty_list:compare/2 (28 ms)
Ok: ty_list:equal/2 (29 ms)
Ok: ty_list:unparse/2 (3155 ms)
Ok: ty_map:compare/2 (291 ms)
Ok: ty_map:equal/2 (45 ms)
Ok: ty_map:map/2 (32 ms)
Ok: ty_map:unparse/2 (5151 ms)
Ok: ty_map:unparse_tuple_part/2 (2617 ms)
Ok: ty_map:split_into_associations/2 (1546 ms)
Ok: ty_map:split_into_associations_both/2 (803 ms)
Ok: ty_map:split_into_associations_only_optional/1 (112 ms)
Ok: ty_node:'::'/2 (210 ms)
Ok: ty_node:':::'/2 (29 ms)
Ok: ty_node:init/0 (226 ms)
Ok: ty_node:clean/0 (64 ms)
Ok: ty_node:make/1 (126 ms)
Ok: ty_node:is_consed/1 (86 ms)
Ok: ty_node:is_defined/1 (54 ms)
Ok: ty_node:new_ty_node/0 (28 ms)
Ok: ty_node:define/2 (165 ms)
Ok: ty_node:force_load/2 (402 ms)
Ok: ty_node:load/1 (65 ms)
Ok: ty_node:leq/2 (29 ms)
Ok: ty_node:leq/3 (38 ms)
Ok: ty_node:is_empty/1 (138 ms)
Ok: ty_node:is_empty/2 (468 ms)
Ok: ty_node:negate/1 (32 ms)
Ok: ty_node:intersect/2 (42 ms)
Ok: ty_node:union/2 (41 ms)
Ok: ty_node:difference/2 (42 ms)
Ok: ty_node:any/0 (29 ms)
Ok: ty_node:empty/0 (29 ms)
Ok: ty_node:disjunction/1 (32 ms)
Ok: ty_node:conjunction/1 (31 ms)
Ok: ty_node:dumpp/1 (30 ms)
Ok: ty_node:dump/1 (31 ms)
Ok: ty_node:do_dump/2 (1368 ms)
Ok: ty_node:dump_list/1 (292 ms)
Ok: ty_node:normalize/2 (195 ms)
Ok: ty_node:normalize/3 (739 ms)
Ok: ty_node:substitute/2 (2340 ms)
Ok: ty_node:all_variables/1 (30 ms)
Ok: ty_node:all_variables/2 (69 ms)
Ok: ty_node:opcache/2 (76 ms)
Ok: ty_node:next_id/0 (29 ms)
Ok: ty_rec:'::'/2 (184 ms)
Ok: ty_rec:':::'/2 (31 ms)
Ok: ty_rec:reorder/1 (361 ms)
Ok: ty_rec:assert_valid/1 (83 ms)
Ok: ty_rec:equal/2 (39 ms)
Ok: ty_rec:any0/0 (51 ms)
Ok: ty_rec:any/0 (29 ms)
Ok: ty_rec:empty0/0 (32 ms)
Ok: ty_rec:empty/0 (28 ms)
Ok: ty_rec:is_literal_empty/1 (140 ms)
Ok: ty_rec:negate/1 (180 ms)
Ok: ty_rec:union/2 (825 ms)
Ok: ty_rec:intersect/2 (801 ms)
Ok: ty_rec:difference/2 (842 ms)
Ok: ty_rec:simpl_to_repr/1 (69 ms)
Ok: ty_rec:functions/1 (31 ms)
Ok: ty_rec:tuples/1 (32 ms)
Ok: ty_rec:atom/1 (32 ms)
Ok: ty_rec:interval/1 (32 ms)
Ok: ty_rec:list/1 (31 ms)
Ok: ty_rec:predefined/1 (32 ms)
Ok: ty_rec:bitstring/1 (33 ms)
Ok: ty_rec:map/1 (32 ms)
Ok: ty_rec:tuple_to_map/1 (315 ms)
Ok: ty_rec:all_variables/2 (563 ms)
Ok: ty_rec:merge/3 (350 ms)
Ok: ty_rec:unparse/2 (5601 ms)
Ok: ty_tuple:'::'/2 (186 ms)
Ok: ty_tuple:':::'/2 (31 ms)
Ok: ty_tuple:compare/2 (350 ms)
Ok: ty_tuple:equal/2 (30 ms)
Ok: ty_tuple:tuple/1 (33 ms)
Ok: ty_tuple:empty/1 (30 ms)
Ok: ty_tuple:any/1 (29 ms)
Ok: ty_tuple:components/1 (51 ms)
Ok: ty_tuple:big_intersect/1 (8380 ms)
Ok: ty_tuple:all_variables/2 (85 ms)
Ok: ty_tuples:reorder/1 (638 ms)
Ok: ty_tuples:assert_valid/1 (157 ms)
Ok: ty_tuples:empty/0 (30 ms)
Ok: ty_tuples:any/0 (29 ms)
Ok: ty_tuples:singleton/2 (58 ms)
Ok: ty_tuples:negate/1 (64 ms)
Ok: ty_tuples:union/2 (1340 ms)
Ok: ty_tuples:intersect/2 (1264 ms)
Ok: ty_tuples:difference/2 (1286 ms)
Ok: ty_tuples:remove_redundant/1 (81 ms)
Ok: ty_tuples:normalize/3 (283 ms)
Ok: ty_tuples:normalize_arities/3 (4021 ms)
Ok: ty_tuples:all_variables/2 (341 ms)
Ok: ty_tuples:has_negative_only_line/1 (276 ms)
Ok: ty_variable:'::'/2 (177 ms)
Ok: ty_variable:':::'/2 (21 ms)
Ok: ty_variable:init/0 (181 ms)
Ok: ty_variable:clean/0 (39 ms)
Ok: ty_variable:equal/2 (36 ms)
Ok: ty_variable:id_of/1 (116 ms)
Ok: ty_variable:leq/2 (37 ms)
Ok: ty_variable:fresh_from/1 (115 ms)
Ok: ty_variable:new/1 (49 ms)
Ok: ty_variable:new_with_name/1 (38 ms)
Ok: ty_variable:new_as_frame/0 (30 ms)
Ok: ty_variable:is_frame/1 (100 ms)
Ok: ty_variable:with_name_and_id/2 (48 ms)
Ok: ty_variable:get_new_id/0 (28 ms)
Ok: ty_variable:unparse/2 (1150 ms)
```

</details>