### PR TITLE
Better Test Framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,11 @@ all: build check test
 espresso:
 	cd c_src/espresso && make
 
-release: espresso
+release:
 	$(REBAR) as prod escriptize
-	cp _build/espresso _build/prod/bin/espresso
 
-build: espresso
+build:
 	$(REBAR) escriptize
-	cp _build/espresso _build/default/bin/espresso
 
 clean:
 	$(REBAR) clean
@@ -29,7 +27,7 @@ unit-tests: build
 
 test: unit-tests testtest
 	@echo "Checking syntax transformation for source code of type checker ..."
-	./_build/default/bin/etylizer --sanity --no-type-checking -I ./src ./src/*.erl
+	./_build/default/bin/etylizer --sanity --no-type-checking -I ./include -I ./src ./src/*.erl
 	@echo "Running case study ..."
 	ETYLIZER_CASE_STUDY_LOGLEVEL=warn test_files/etylizer-mini/check-orddict.sh
 	ETYLIZER_CASE_STUDY_LOGLEVEL=warn test_files/etylizer-mini/check-std.sh

--- a/rebar.config
+++ b/rebar.config
@@ -21,6 +21,8 @@
 {escript_name, etylizer}.
 {escript_emu_args, "%%! -escript main etylizer_main -pz etylizer/etylizer/ebin\n"}.
 
+{pre_hooks, [{compile, "make -C c_src/espresso"}]}.
+
 {erl_opts, [{i, "src"}, debug_info]}.
 
 {profiles,[

--- a/run_test.escript
+++ b/run_test.escript
@@ -1,0 +1,87 @@
+#!/usr/bin/env escript
+%% run_test.escript
+%% Usage: escript run_test.escript <pattern>
+%%
+%% Examples:
+%%   escript run_test.escript case_01
+%%   escript run_test.escript "guards.erl/case_01"
+%%   escript run_test.escript "(typecheck)"
+%%   escript run_test.escript "(infer)"
+
+-mode(compile).
+
+main([Pattern]) ->
+    compile_project(),
+    setup_paths(),
+    io:format("Evaluating generator...~n"),
+    Tests = tycheck_simple_tests:simple_test_(),
+    Filtered = filter_tests(Tests, Pattern),
+    case Filtered of
+        [] ->
+            io:format("No tests matching ~p~n", [Pattern]),
+            halt(1);
+        _ ->
+            io:format("Running ~b test(s) matching ~p~n",
+                       [count(Filtered), Pattern]),
+            case eunit:test(Filtered, [verbose]) of
+                ok -> halt(0);
+                _  -> halt(2)
+            end
+    end;
+main(_) ->
+    io:format("Usage: escript run_test.escript <pattern>~n"),
+    halt(1).
+
+compile_project() ->
+    io:format("Compiling (rebar3 as test compile)...~n"),
+    Port = open_port({spawn, "rebar3 as test compile"}, [stream, exit_status, use_stdio, stderr_to_stdout]),
+    compile_wait(Port).
+
+compile_wait(Port) ->
+    receive
+        {Port, {data, Data}} -> io:put_chars(Data), compile_wait(Port);
+        {Port, {exit_status, 0}} -> ok;
+        {Port, {exit_status, N}} -> io:format("rebar3 compile failed with exit code ~b~n", [N]), halt(1)
+    end.
+
+setup_paths() ->
+    Dirs = filelib:wildcard("_build/test/lib/*/ebin")
+        ++ filelib:wildcard("_build/test/lib/*/test")
+        ++ filelib:wildcard("_build/test/extras/test/ebin"),
+    [code:add_pathz(D) || D <- Dirs].
+
+filter_tests(Tests, Pat) when is_list(Tests) ->
+    lists:filtermap(fun(T) -> filter_test(T, Pat) end, Tests);
+filter_tests(Test, Pat) ->
+    case filter_test(Test, Pat) of
+        {true, T} -> [T];
+        false -> []
+    end.
+
+filter_test({timeout, N, T}, Pat) ->
+    case filter_test(T, Pat) of
+        {true, T1} -> {true, {timeout, N, T1}};
+        false -> false
+    end;
+filter_test({Desc, Fun}, Pat) when is_list(Desc), is_function(Fun, 0) ->
+    case string:find(Desc, Pat) of
+        nomatch -> false;
+        _ -> {true, {Desc, Fun}}
+    end;
+filter_test({Desc, Tests}, Pat) when is_list(Desc), is_list(Tests) ->
+    case filter_tests(Tests, Pat) of
+        [] -> false;
+        F -> {true, {Desc, F}}
+    end;
+filter_test(L, Pat) when is_list(L) ->
+    case filter_tests(L, Pat) of
+        [] -> false;
+        F -> {true, F}
+    end;
+filter_test(_, _) -> false.
+
+count(Tests) when is_list(Tests) -> lists:sum([count(T) || T <- Tests]);
+count({timeout, _, T}) -> count(T);
+count({_, Fun}) when is_function(Fun, 0) -> 1;
+count({_, Tests}) when is_list(Tests) -> count(Tests);
+count(_) -> 1.

--- a/src/erlang_types/dnf/bdd.hrl
+++ b/src/erlang_types/dnf/bdd.hrl
@@ -321,20 +321,28 @@ minimize_node_dnf(Dnf) ->
                          end, [], Dnf),
 
   StrInput = ".i " ++ integer_to_list(I) ++ "\n.o " ++ integer_to_list(O) ++ "\n" ++ lists:flatten(lists:join("\n", AllLines)),
-  
-  % TODO IMPORTANT make sure binary is available! wasted 2 hours searching for a non-issue
-  file:make_dir("/tmp/etylizer"),
-  ok = file:write_file("/tmp/etylizer/espresso_input.pla", StrInput),
-  % T0 = os:system_time(millisecond),
-  Result = os:cmd(etylizer_main:get_espresso_binary() ++ " < /tmp/etylizer/espresso_input.pla"),
-  % file:delete("/tmp/etylizer/espresso_input.pla"),
-
-  % io:format(user,"~p ms~n", [os:system_time(millisecond) - T0]),
+  Result = '_minimize_espresso'(StrInput),
   OnlyResultLines = extract_integer_lines(Result, I + 1 + O),
-  % Inn = [string:slice(L, 0, I + 1 + O) || L <- AllLines],
-  % Out = extract_integer_lines(Result, I + 1 + O),
-  E = [convert_back_to_repr(list_to_tuple(string:split(Line, " ")), RevVariableIndices, ReverseAllOutputs, 1, {[], [], to_replace}) || Line <- OnlyResultLines],
-  E.
+  [convert_back_to_repr(list_to_tuple(string:split(Line, " ")), RevVariableIndices, ReverseAllOutputs, 1, {[], [], to_replace}) || Line <- OnlyResultLines].
+
+-spec '_minimize_espresso'(string()) -> string().
+'_minimize_espresso'(StrInput) ->
+    Path = espresso_bin:get_path(),
+    Port = open_port({spawn_executable, Path}, [use_stdio, exit_status, stream, stderr_to_stdout]),
+    % Append .e marker so espresso stops reading without needing EOF on stdin
+    port_command(Port, [StrInput, "\n.e\n"]),
+    '_collect_port_output'(Port, []).
+
+-spec '_collect_port_output'(port(), iolist()) -> string().
+'_collect_port_output'(Port, Acc) ->
+    receive
+        {Port, {data, Data}} ->
+            '_collect_port_output'(Port, [Acc, Data]);
+        {Port, {exit_status, 0}} ->
+            lists:flatten(Acc);
+        {Port, {exit_status, Status}} ->
+            error({espresso_exit, Status})
+    end.
 
 -spec replace_index(string(), [A], Line, #{A => integer()}) -> Line.
 replace_index(Val, Term, CurrentLine, VariableIndices) ->

--- a/src/espresso_bin.erl
+++ b/src/espresso_bin.erl
@@ -1,0 +1,23 @@
+-module(espresso_bin).
+-export([get_path/0]).
+-on_load(ensure_cached/0).
+
+%% @doc Returns the path to the espresso binary in the user cache directory.
+%% On module load, copies the binary from _build/espresso if not already cached.
+
+-spec get_path() -> string().
+get_path() ->
+    filename:join(filename:basedir(user_cache, "etylizer"), "espresso").
+
+%% Called via -on_load. OTP delays all calls to this module until
+%% ensure_cached returns ok, so there is no race with get_path/0 callers.
+-spec ensure_cached() -> ok.
+ensure_cached() ->
+    Path = get_path(),
+    case filelib:is_regular(Path) of
+        true -> ok;
+        false ->
+            filelib:ensure_dir(Path),
+            {ok, _} = file:copy("_build/espresso", Path),
+            ok = file:change_mode(Path, 8#755)
+    end.

--- a/src/etylizer_main.erl
+++ b/src/etylizer_main.erl
@@ -1,6 +1,5 @@
 -module(etylizer_main).
 -export([
-    get_espresso_binary/0,
     main/1
 ]).
 
@@ -159,14 +158,7 @@ fix_load_path(Opts) ->
 
 -spec doWork(#opts{}) -> [file:filename()].
 doWork(Opts) ->
-    % erlang_types needs to know the path of espresso
-    % save that in persistent_term
-    persistent_term:put(espresso_root, Opts#opts.espresso_root),
-
     global_state:with_new_state(fun() ->
-      ?LOG_TRACE("Check if espresso executable is available"),
-      {ok, _} = file:read_file_info(get_espresso_binary()),
-
       ?LOG_TRACE("Initializing ETS tables"),
       parse_cache:init(Opts),
       stdtypes:init(),
@@ -207,23 +199,6 @@ doWork(Opts) ->
           stdtypes:cleanup()
       end
                                 end).
-
-% different path for testing environment
--ifdef(TEST).
-get_espresso_binary() ->
-    Path = "_build/espresso",
-    {ok, _} = file:read_file_info(Path),
-    Path.
--else.
-get_espresso_binary() ->
-    Path = case (catch persistent_term:get(espresso_root)) of
-        {_, _} -> filename:join([filename:dirname(escript:script_name()), "espresso"]); % default
-        empty -> filename:join([filename:dirname(escript:script_name()), "espresso"]); % default
-        Root -> filename:join([Root, "espresso"])
-    end,
-    {ok, _} = file:read_file_info(Path),
-    Path.
--endif.
 
 -spec main([string()]) -> ok.
 main(Args) ->

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -152,6 +152,19 @@ empty() -> #tab { funs = #{}, ops = #{}, types = #{}, records = #{}, modules = #
 
 -spec std_symtab(paths:search_path(), t()) -> t().
 std_symtab(SearchPath, OverlaySymtab) ->
+    CacheKey = erlang:phash2(OverlaySymtab),
+    case persistent_term:get(std_symtab_cache, undefined) of
+        {CacheKey, CachedTab} ->
+            ?LOG_DEBUG("Using cached standard symtab"),
+            CachedTab;
+        _ ->
+            Tab = build_std_symtab(SearchPath, OverlaySymtab),
+            persistent_term:put(std_symtab_cache, {CacheKey, Tab}),
+            Tab
+    end.
+
+-spec build_std_symtab(paths:search_path(), t()) -> t().
+build_std_symtab(SearchPath, OverlaySymtab) ->
     ?LOG_DEBUG("Building symtab for standard library ..."),
     Funs =
         lists:foldl(fun({Name, Arity, T}, Map) ->

--- a/src/tmp.erl
+++ b/src/tmp.erl
@@ -15,10 +15,11 @@
 -spec int_to_hex(integer()) -> string().
 int_to_hex(I) -> integer_to_list(I, 16).
 
+% OTP has no function to get an OS-independent temporary directory
 -spec tmp_dir() -> string().
 tmp_dir() ->
     F =
-        fun F([]) -> ".";
+        fun F([]) -> "/tmp";
             F([V | Vs]) ->
                 case os:getenv(V) of
                     false -> F(Vs);

--- a/test/erlang_types/tally/tally_basic_tests.erl
+++ b/test/erlang_types/tally/tally_basic_tests.erl
@@ -188,7 +188,6 @@ tally_10_test() ->
     V0 = v(v1),
     V7 = v(v2),
     B = b(foo),
-    T = b(tag),
     test_tally(
       [
        {

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -97,8 +97,7 @@ check_decls_in_file(F, What, NoInfer) ->
         Ty = symtab:lookup_fun({ref, Name, Arity}, Loc, Tab),
         ShouldFail = utils:string_ends_with(NameStr, "_fail"),
         RunTest =
-          % FIXME #54 reduce timeout after issue has been fixed
-          {timeout, 45, {FullNameStr, fun() ->
+          {timeout, 10, {FullNameStr ++ " (typecheck)", fun() ->
                 ?LOG_NOTE("Type checking ~s from ~s", NameStr, F),
                 global_state:with_new_state(fun() ->
                   case ShouldFail of
@@ -110,7 +109,7 @@ check_decls_in_file(F, What, NoInfer) ->
               end}
             },
         InferTest =
-          {timeout, 45, {FullNameStr ++ " (infer)", fun() ->
+          {timeout, 10, {FullNameStr ++ " (infer)", fun() ->
                 ?LOG_NOTE("Infering type for ~s from ~s", NameStr, F),
                 global_state:with_new_state(fun() ->
                   check_infer_ok_fun(F, Tab, OverlayTab, Decl, Ty)
@@ -167,6 +166,10 @@ simple_test_() ->
 
   NoInfer = [
     % TODO slow, timeouts
+    "dyn_union_case_02",
+    "op_04",
+    "op_15",
+    "list_as_tuple_05",
     "refine_tagged_tuple",
     % TODO timeout, with flipped variable ordering it infers instantly
     "match_13",

--- a/test_files/etylizer-mini/check.sh
+++ b/test_files/etylizer-mini/check.sh
@@ -2,15 +2,17 @@
 
 cd $(dirname $0)
 OVERLAY=overlay.erl
-LOGLEVEL=info
+LOGLEVEL=error
 
 if [ ! -z "$ETYLIZER_CASE_STUDY_LOGLEVEL" ]; then
     LOGLEVEL="$ETYLIZER_CASE_STUDY_LOGLEVEL"
 fi
 
 function run_ety() {
-    ../../ety --build --type-overlay $OVERLAY --force -l $LOGLEVEL -P . -I src $QF --no-deps "$@" || exit 1
+    ../../ety --type-overlay $OVERLAY --force -l $LOGLEVEL -P . -I src $QF --no-deps "$@" || exit 1
 }
+
+../../ety --build -h
 
 # to) timeout
 # 1) impl: try & catch
@@ -28,6 +30,8 @@ QF=""
 run_ety src/ast_erl.erl
 
 QF=""
+QF=$QF" -i mk_intersection/1" # to)
+QF=$QF" -i mk_union/1" # to)
 run_ety src/ast_lib.erl
 
 QF=""
@@ -55,7 +59,7 @@ QF="" run_ety src/records.erl
 QF=""
 QF=$QF" -i expand_predef_alias/1" # to)
 QF=$QF" -i builtin_ops/0" # to)
-# QF=$QF" -i mk_builtin_funs/1" # 5) 
+QF=$QF" -i mk_builtin_funs/1" # to)
 QF=$QF" -i builtin_funs/0" # 4)
 run_ety src/stdtypes.erl
 
@@ -66,7 +70,9 @@ run_ety src/tmp.erl
 
 QF="" run_ety src/varenv.erl
 
-QF="" run_ety src/varenv_local.erl
+QF="" 
+QF=$QF" -i merge_envs/1" # to
+run_ety src/varenv_local.erl
 
 QF="" run_ety src/ast_erl.erl
 
@@ -83,6 +89,8 @@ QF=$QF" -i fl/1" # not part of case study (overlay with additional -type)
 run_ety src/utils.erl
 
 QF="" 
+QF=$QF" -i thread_through_env/3" # 130s
+QF=$QF" -i trans_exp_bin_elem/3" # 130s
 QF=$QF" -i resolve_ety_ty/3" # 80s
 QF=$QF" -i eval_const_ty/2" # 1)
 QF=$QF" -i shallow_remove_match/1" # to)
@@ -95,6 +103,11 @@ QF=$QF" -i trans_pat/4" # 4)
 QF=$QF" -i trans_exp/3" # to)
 QF=$QF" -i trans/4" # to) tally v1 is faster check why
 QF=$QF" -i trans_catch_clause/3" # 3)
-# QF=$QF" -i build_funenv/2" # 5) implemented assert fun
+QF=$QF" -i trans_case_clause/3" # 120s
+QF=$QF" -i trans_map_assoc/3" # 200s
+QF=$QF" -i build_funenv/2" # to)
+QF=$QF" -i trans_pat_bin_elem/4" # to)
+QF=$QF" -i trans_case_clauses/3" # to)
+QF=$QF" -i trans_fun_clause/3" # to)
 # QF=$QF" -i mk_builtin_funs/2" # 5) implemented assert fun
 run_ety src/ast_transform.erl


### PR DESCRIPTION
Better and faster testing framework.

* Moved espresso to its own port invocation, so that we can execute etylizer in parallel invocations
* A test runner to filter `tycheck_simple_tests` for debugging purposes
* Limited simple test timeouts to 10s for  both check and infer
* Removed some functions in the case study that take `>10s` to check (we will type check etylizer fully later anyway with improved speed)

Pipeline time down from `16m` to `4m`