### PR TITLE
Refinement Heuristics

### DIFF
--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -1193,6 +1193,35 @@ guard_lower_envs(Tests) ->
 guard_seq_lower_envs([]) -> [{#{}, safe}];
 guard_seq_lower_envs(Guards) -> lists:flatmap(fun guard_lower_envs/1, Guards).
 
+% Flips a comparison operator: N op X becomes X flip(op) N.
+-spec flip_comparison_op(atom()) -> atom().
+flip_comparison_op('>') -> '<';
+flip_comparison_op('<') -> '>';
+flip_comparison_op('>=') -> '=<';
+flip_comparison_op('=<') -> '>='.
+
+% Refinement heuristic for < > <= >= operators and constant types.
+% For integer constants, returns an integer range (e.g. X > 2 gives 3..*).
+-spec comparison_refine_env(atom(), ast:local_varname(), ast:exp()) -> {constr:constr_env(), safe | unsafe}.
+comparison_refine_env(Op, X, ConstExp) ->
+    % operators work for any term
+    % we can refine only on the integer part
+    TyOther = fun(Ty) -> stdtypes:tunion(
+                         Ty,
+                         ty_without({predef, any}, {predef, integer})
+                         ) end,
+    case ty_of_const_exp(ConstExp) of
+        {ok, {singleton, N}} when is_integer(N) ->
+            Ty = case Op of
+                '>'  -> TyOther(stdtypes:trange(N + 1, '*'));
+                '>=' -> TyOther(stdtypes:trange(N, '*'));
+                '<'  -> TyOther(stdtypes:trange('*', N - 1));
+                '=<' -> TyOther(stdtypes:trange('*', N))
+            end,
+            {#{{local_ref, X} => Ty}, safe};
+        _ -> {#{}, unsafe}
+    end.
+
 % env(g)
 -spec guard_seq_env([ast:guard()]) -> {constr:constr_env(), safe | unsafe}.
 guard_seq_env(Guards) ->
@@ -1244,6 +1273,14 @@ guard_test_env(G) ->
                     {EnvLeft, StatusLeft} = guard_test_env(Left),
                     {EnvRight, StatusRight} = guard_test_env(Right),
                     {union_envs(EnvLeft, EnvRight), merge_status(StatusLeft, StatusRight)};
+                (Op =:= '==') orelse (Op =:= '=:=') ->
+                    refine_eq_env(Op, Left, Right);
+                (Op =:= '>') orelse (Op =:= '<') orelse (Op =:= '>=') orelse (Op =:= '=<') ->
+                    case {Left, Right} of
+                        {{var, _, {local_ref, X}}, E} -> comparison_refine_env(Op, X, E);
+                        {E, {var, _, {local_ref, X}}} -> comparison_refine_env(flip_comparison_op(Op), X, E);
+                        _ -> Default
+                    end;
                 true -> Default
             end;
         {op, _L, 'not', Exp} ->
@@ -1252,6 +1289,74 @@ guard_test_env(G) ->
         {'atom', _Loc, true} ->
             {#{}, safe};
         _ -> Default
+    end.
+
+% Best-effort recursive refine variable types from an equality guard Left == Right or Left =:= Right.
+% Variables in Left are refined to a possibly constant type of the corresponding part of Right, and vice versa.
+% For == with numeric constants, we return unsafe because == has loose numeric comparison (1 == 1.0 is true).
+-spec refine_eq_env(atom(), ast:exp(), ast:exp()) -> {constr:constr_env(), safe | unsafe}.
+refine_eq_env(Op, Left, Right) ->
+    case {Left, Right} of
+        {{var, _, {local_ref, X}}, _} ->
+            case ty_of_const_exp(Right) of
+                {ok, Ty} ->
+                    case eq_status(Op, Ty) of
+                        safe -> {#{{local_ref, X} => Ty}, safe};
+                        unsafe -> {#{}, unsafe}
+                    end;
+                error -> {#{}, unsafe}
+            end;
+        {_, {var, _, {local_ref, X}}} ->
+            case ty_of_const_exp(Left) of
+                {ok, Ty} ->
+                    case eq_status(Op, Ty) of
+                        safe -> {#{{local_ref, X} => Ty}, safe};
+                        unsafe -> {#{}, unsafe}
+                    end;
+                error -> {#{}, unsafe}
+            end;
+        {{tuple, _, LeftElems}, {tuple, _, RightElems}}
+                when length(LeftElems) =:= length(RightElems) ->
+            lists:foldl(
+                fun({L, R}, {EnvAcc, StatusAcc}) ->
+                    {Env, Status} = refine_eq_env(Op, L, R),
+                    {intersect_envs(Env, EnvAcc), merge_status(Status, StatusAcc)}
+                end,
+                {#{}, safe},
+                lists:zip(LeftElems, RightElems));
+        _ ->
+            % safe if both constant structurally equal
+            case {ty_of_const_exp(Left), ty_of_const_exp(Right)} of
+                {{ok, T}, {ok, T}} -> {#{}, safe};
+                _ -> {#{}, unsafe}
+            end
+    end.
+
+% For =:= (strict equality), refinement is always safe.
+% For == (loose equality), refinement is unsafe when the constant is numeric,
+% because == treats integers and floats as equal (e.g. 1 == 1.0).
+-spec eq_status(atom(), ast:ty()) -> safe | unsafe.
+eq_status('=:=', _) -> safe;
+eq_status('==', {singleton, N}) when is_integer(N); is_float(N) -> unsafe;
+eq_status('==', _) -> safe.
+
+% Returns the type of a constant (variable-free) expression, or error if not constant.
+-spec ty_of_const_exp(ast:exp()) -> t:opt(ast:ty()).
+ty_of_const_exp(E) ->
+    case E of
+        {'atom', _, A} -> {ok, {singleton, A}};
+        {'integer', _, I} -> {ok, {singleton, I}};
+        {'char', _, C} -> {ok, {singleton, C}};
+        {'string', _, ""} -> {ok, {empty_list}};
+        {'string', _, _} -> {ok, {predef_alias, nonempty_string}};
+        {nil, _} -> {ok, {empty_list}};
+        {tuple, _, Elems} ->
+            TysOpt = lists:map(fun ty_of_const_exp/1, Elems),
+            case lists:all(fun(R) -> R =/= error end, TysOpt) of
+                true -> {ok, {tuple, lists:map(fun({ok, T}) -> T end, TysOpt)}};
+                false -> error
+            end;
+        _ -> error
     end.
 
 merge_status(safe, safe) -> safe;

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -164,7 +164,10 @@ simple_test_() ->
     %      bounds for scoped variables
     "if_06",
     "if_17",
-    "if_18"
+    "if_18",
+    "case_26",
+    "refinement_01c",
+    "refinement_01b"
   ],
 
   NoInfer = [
@@ -191,7 +194,9 @@ simple_test_() ->
     "op_08",
     % TODO slow maybe inference
     "maybe_08",
-    "maybe_09"
+    "maybe_09",
+    % TODO slow list inference (nonempty_string)
+    "refinement_string"
   ],
 
   %What = ["atom_03_fail"],

--- a/test_files/tycheck_simple/case_of.erl
+++ b/test_files/tycheck_simple/case_of.erl
@@ -159,6 +159,33 @@ case_20_fail(X) ->
     end,
     S.
 
+% S has type foo | bar
+% the case expression is exhaustive
+-spec case_21_fail(foo | bar) -> foo.
+case_21_fail(X) ->
+    case X of
+        S when S == foo -> S;
+        S when S == bar -> foo
+    end,
+    S.
+
+% S has type foo | bar
+% the case expression is exhaustive
+-spec case_22(foo | bar) -> foo | bar.
+case_22(X) ->
+    case X of
+        S when S == foo -> S;
+        S when S == bar -> foo
+    end,
+    S.
+
+-spec case_23(foo | bar) -> ok.
+case_23(X) ->
+    case X of
+        S when S == foo -> ok;
+        S when S == bar -> ok
+    end.
+
 -spec case_24(integer()) -> integer().
 case_24(X) ->
     case X of
@@ -169,6 +196,45 @@ case_24(X) ->
 -spec case_25() -> ok.
 case_25() ->
     begin case foo of _ -> S = ok end end,
+    S.
+
+% exhaustiveness with variables from outer scope
+-spec case_26(integer()) -> ok.
+case_26(X) ->
+    case {} of _ when is_integer(X) -> ok end.
+
+% Tests that guard {S, complex} == {foo, complex} correctly refines S to foo
+-spec case_27(foo | bar) -> foo | bar.
+case_27(X) ->
+    case X of
+        S when {S, complex} == {foo, complex} -> S;
+        S -> S
+    end,
+    S.
+
+-spec case_28_fail(foo | bar) -> bar.
+case_28_fail(X) ->
+    case X of
+        S when {S, complex} == {foo, complex} -> S;
+        S -> S
+    end,
+    S.
+
+% symmetry
+-spec case_29(foo | bar) -> foo | bar.
+case_29(X) ->
+    case X of
+        S when {foo, complex} == {S, complex} -> S;
+        S -> S
+    end,
+    S.
+
+-spec case_30_fail(foo | bar) -> bar.
+case_30_fail(X) ->
+    case X of
+        S when {foo, complex} == {S, complex} -> S;
+        S -> S
+    end,
     S.
 
 % #295 variable bound in case scrutinee should be visible in clause bodies

--- a/test_files/tycheck_simple/guards.erl
+++ b/test_files/tycheck_simple/guards.erl
@@ -54,9 +54,9 @@ guard_variable_name_01({_, _}) -> ok.
 guard_variable_name_02({ZZ1, ZZ2}) when is_atom(ZZ1), is_atom(ZZ2) -> ZZ1;
 guard_variable_name_02({_, _}) -> ok.
 
-% Guard narrowing with 'or': when the or-guard fails, 
-% the negation 
-%   not(is_atom(X) or is_atom(Y)) 
+% Guard narrowing with 'or': when the or-guard fails,
+% the negation
+%   not(is_atom(X) or is_atom(Y))
 % which is equal to
 %   not is_atom(X) and not is_atom(Y)
 % should narrow both X and Y to integer() in clause 2.
@@ -97,3 +97,61 @@ guard_outer_refine_01(X, Y) ->
 -spec guard_not_or_precise_01({atom(), atom()}) -> atom(); ({integer(), integer()}) -> integer().
 guard_not_or_precise_01({X, Y}) when not (is_atom(X) orelse is_atom(Y)) -> X + Y;
 guard_not_or_precise_01({X, _}) -> X.
+
+-spec refinement_01(integer()) -> 1.
+refinement_01(X) ->
+    case X of
+        _ when X < 1 -> 1;
+        _ when X > 1 -> 1;
+        _ -> X
+    end.
+
+-spec refinement_01b(integer()) -> 1.
+refinement_01b(X) ->
+    if X < 1 -> 1;
+       X > 1 -> 1;
+       true -> X
+    end.
+
+-spec refinement_01c(integer()) -> 1.
+refinement_01c(X) ->
+    case {} of
+        _ when X < 1 -> 1;
+        _ when X > 1 -> 1;
+        _ -> X
+    end.
+
+-spec refinement_02(do) -> integer().
+refinement_02(Do) when Do =:= do -> 0.
+
+-spec refinement_03(integer()) -> non_neg_integer().
+refinement_03(X) when X > 0 -> X;
+refinement_03(_) -> 0.
+
+-spec refinement_04_fail(integer()) -> non_neg_integer().
+refinement_04_fail(X) when X > 0 -> X.
+
+-spec refinement_05(integer()) -> non_neg_integer().
+refinement_05(X) when X > 0 -> X;
+refinement_05(X) when not(X > 0) -> 0.
+
+% we dont (cant) refine floats
+-spec refinement_06(float()) -> float().
+refinement_06(X) when not(X > 0.5) -> X;
+refinement_06(X) -> 5.0.
+
+% X is float(). X == 0 is true when X is 0.0 (loose equality).
+-spec refinement_loose_eq(float()) -> float().
+refinement_loose_eq(X) when X == 0 -> X;
+refinement_loose_eq(X) -> X.
+
+% Refine with string constant: nonempty_string is not a singleton,
+% so the second branch still has type string() | foo.
+-spec refinement_string(string() | foo) -> string() | foo.
+refinement_string(X) when X =:= "hello" -> foo;
+refinement_string(X) -> X.
+
+% Refine with nil constant: [] is precise, so the second branch narrows to foo.
+-spec refinement_nil([] | foo) -> foo.
+refinement_nil(X) when X =:= [] -> foo;
+refinement_nil(X) -> X.


### PR DESCRIPTION
Added basic refinement heuristics for operators `==, =:=, <, >, <=, >=,` in guards. That should be enough to cover most uses that we encountered during the case study. This can be extended in the future.

The refinements for operators like `<` are quite interesting, I think: Since they are allowed to be applied on all terms, they only refine the integer part of the type, when applied to a constant integer type. The test case in the issue #279 is actually wrongly classified. That was not immediately obvious to me.

The refinement for `==` with numeric types is very coarse, because `1 == 1.0` is true in Erlang

Also, refinement on operators is not enough for `if` constructs. #5 for example, is still not possible. The issue is not the refinement, but #168. Still, fixes #5 as refinement is implemented in principle. Fixes #122.