### PR TITLE
[Spec] Spec only changes to prepare for type checking etylizer

### DIFF
--- a/overlays/etylizer_overlay.erl
+++ b/overlays/etylizer_overlay.erl
@@ -13,6 +13,10 @@
 'lists:foldl'(_, _, _) -> error(badarg).
 -spec 'lists:foldr'(fun((T, Acc) -> Acc), Acc, [T]) -> Acc.
 'lists:foldr'(_, _, _) -> error(badarg).
+-spec 'lists:map'
+  (fun((A) -> B), nonempty_list(A)) -> nonempty_list(B);
+  (fun((A) -> B), list(A)) -> list(B).
+'lists:map'(_, _) -> error(badarg).
 
 % more precise filtermap spec needed for ty_map:split_into_associations
 % basically a replacement for list comprehensions with filters
@@ -33,6 +37,9 @@
 
 -spec 'lists:keysort'(1, [{K, V}]) -> [{K, V}].
 'lists:keysort'(1, _) -> error(overlay).
+
+-spec 'lists:keyfind'(Key, pos_integer(), [{Key, Value}]) -> {Key, Value} | false.
+'lists:keyfind'(_, _, _) -> error(overlay).
 
 -spec 'lists:reverse'
   (nonempty_list(T)) -> nonempty_list(T);
@@ -63,10 +70,15 @@
 'string:split'(_, _, _) -> error(badarg).
 -spec 'string:slice'(string(), non_neg_integer(), non_neg_integer()) -> string().
 'string:slice'(_, _, _) -> error(badarg).
+-spec 'string:trim'(string(), leading | trailing | both) -> string().
+'string:trim'(_, _) -> error(badarg).
 -spec 'os:cmd'(string()) -> string().
 'os:cmd'(_) -> error(badarg).
 -spec 'file:write_file'(string(), string()) -> _.
 'file:write_file'(_, _) -> error(badarg).
+
+-spec 'io:get_line'(pid(), string()) -> string() | eof.
+'io:get_line'(_, _) -> error(overlay).
 
 -spec 'maps:get'(Key, #{Key => Value}) -> Value.
 'maps:get'(_, _) -> error(badarg).
@@ -74,7 +86,61 @@
 'maps:put'(_, _, _) -> error(badarg).
 -spec 'maps:is_key'(Key, #{Key => _Value}) -> boolean().
 'maps:is_key'(_, _) -> error(badarg).
+-spec 'maps:remove'(Key, #{Key => Value}) -> #{Key => Value}.
+'maps:remove'(_, _) -> error(badarg).
 -spec 'maps:from_list'([{Key, Value}]) -> #{Key => Value}.
 'maps:from_list'(_) -> error(badarg).
 -spec 'maps:to_list'(#{Key => Value}) -> list({Key, Value}).
 'maps:to_list'(_) -> error(badarg).
+-spec 'maps:fold'(fun((Key, Value, Acc) -> Acc), Acc, #{Key => Value}) -> Acc.
+'maps:fold'(_, _, _) -> error(badarg).
+-spec 'maps:merge'(#{Key => Value}, #{Key => Value}) -> #{Key => Value}.
+'maps:merge'(_, _) -> error(badarg).
+-spec 'maps:map'(fun((Key, Value1) -> Value2), #{Key => Value1}) -> #{Key => Value2}.
+'maps:map'(_, _) -> error(overlay).
+-spec 'maps:find'(Key, #{Key => Value}) -> {ok, Value} | error.
+'maps:find'(_, _) -> error(overlay).
+
+% filename overlays
+-spec 'filename:join'(string(), string()) -> string().
+'filename:join'(_, _) -> error(overlay).
+-spec 'filename:join'([string()]) -> string().
+'filename:join'(_) -> error(overlay).
+-spec 'filename:basename'(string(), string()) -> string().
+'filename:basename'(_, _) -> error(overlay).
+-spec 'filename:basename'(string()) -> string().
+'filename:basename'(_) -> error(overlay).
+-spec 'filename:dirname'(string()) -> string().
+'filename:dirname'(_) -> error(overlay).
+-spec 'filename:basedir'(atom(), string()) -> string().
+'filename:basedir'(_, _) -> error(overlay).
+-spec 'filename:nativename'(string()) -> string().
+'filename:nativename'(_) -> error(overlay).
+-spec 'filename:rootname'(string()) -> string().
+'filename:rootname'(_) -> error(overlay).
+-spec 'filename:extension'(string()) -> string().
+'filename:extension'(_) -> error(overlay).
+
+% filelib overlays
+-spec 'filelib:ensure_dir'(string()) -> ok | {error, term()}.
+'filelib:ensure_dir'(_) -> error(overlay).
+-spec 'filelib:is_regular'(string()) -> boolean().
+'filelib:is_regular'(_) -> error(overlay).
+-spec 'filelib:is_dir'(string()) -> boolean().
+'filelib:is_dir'(_) -> error(overlay).
+-spec 'filelib:is_file'(string()) -> boolean().
+'filelib:is_file'(_) -> error(overlay).
+
+% file overlays
+-spec 'file:read_file'(string()) -> {ok, binary()} | {error, term()}.
+'file:read_file'(_) -> error(overlay).
+-spec 'file:list_dir'(string()) -> {ok, [string()]} | {error, term()}.
+'file:list_dir'(_) -> error(overlay).
+-spec 'file:open'(string(), [atom()]) -> {ok, pid()} | {error, term()}.
+'file:open'(_, _) -> error(overlay).
+-spec 'file:copy'(string(), string()) -> {ok, non_neg_integer()} | {error, term()}.
+'file:copy'(_, _) -> error(overlay).
+-spec 'file:change_mode'(string(), non_neg_integer()) -> ok | {error, term()}.
+'file:change_mode'(_, _) -> error(overlay).
+-spec 'file:consult'(string()) -> {ok, [term()]} | {error, term()}.
+'file:consult'(_) -> error(overlay).

--- a/src/ast.erl
+++ b/src/ast.erl
@@ -256,8 +256,9 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 
 % Attribute "-file(File,Line)" ignored.
 % Wild attributes ignored.
+-type etylizer_form() :: {attribute, loc(), etylizer, term()}.
 -type form() :: export_form() | export_type_form() | import_form() | mod_form() | compile_form()
-    | fun_decl() | fun_spec() | record_decl() | type_decl().
+    | fun_decl() | fun_spec() | record_decl() | type_decl() | etylizer_form().
 -type forms() :: [form()].
 
 % 8.2  Atomic Literals

--- a/src/ast_erl.erl
+++ b/src/ast_erl.erl
@@ -182,7 +182,7 @@
 
 
 % 8.1  Module Declarations and Forms
--type anno() :: any(). % Should be erl_anno:anno() but ast_check.erl cannot handle this.
+-type anno() :: erl_anno:anno().
 -type fun_with_arity() :: {atom(), integer()}.
 -type ty_with_arity() :: {atom(), integer()}.
 -type export_form() :: {attribute, anno(), export, [fun_with_arity()]}.

--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -8,12 +8,14 @@
 ]).
 
 
+-spec unfold_intersection([ast:ty()], [ast:ty()]) -> [ast:ty()].
 unfold_intersection([], All) -> All;
 unfold_intersection([{intersection, Components} | Rest], All) ->
     unfold_intersection(Components ++ Rest, All);
 unfold_intersection([X | Rest], All) ->
     unfold_intersection(Rest, All ++ [X]) .
 
+-spec unfold_union([ast:ty()], [ast:ty()]) -> [ast:ty()].
 unfold_union([], All) -> All;
 unfold_union([{union, Components} | Rest], All) ->
     unfold_union(Components ++ Rest, All);

--- a/src/attr.erl
+++ b/src/attr.erl
@@ -6,8 +6,10 @@
     parse_ety_attr/2,
     ety_attrs_from_file/1
    ]).
-    
+
 -type ety_attr() :: {etylizer, ast:loc(), term()}.
+
+-include("etylizer.hrl").
 
 -spec ety_attrs_from_file(file:filename()) -> t:opt([ety_attr()], string()).
 ety_attrs_from_file(Path) ->
@@ -43,9 +45,10 @@ parse_ety_attr(Loc, S) ->
        "%-etylizer" ++ Rest ->
            case string:trim(Rest) of
                TermStr = ("(" ++ _) ->
-                   case erl_scan:string(TermStr, N) of
+                   case erl_scan:string(TermStr, ?assert_type(N, erl_anno:location())) of
                        {ok, Toks, _} ->
-                           case erl_parse:parse_term(Toks) of
+                           ParseResult = ?assert_type(erl_parse:parse_term(?assert_type(Toks, dynamic())), dynamic()),
+                           case ParseResult of
                                {ok, Term} -> {ok, {etylizer, Loc, Term}};
                                {error, E} -> throw({bad_attr, E})
                             end;

--- a/src/cm_depgraph.erl
+++ b/src/cm_depgraph.erl
@@ -29,10 +29,10 @@
 -type dep_graph() :: {
     sets:set(file:filename()),
     % Maps a file F to all files that F directly or indirectly depends on.
-    #{file:filename() => {sets:set(file:filename())}},
+    #{file:filename() => sets:set(file:filename())},
     % Separate mapping module name -> module names, always in sync with the mapping
     % filename -> filenames.
-    #{atom() => {sets:set(atom())}}
+    #{atom() => sets:set(atom())}
 }.
 
 -spec new() -> dep_graph().

--- a/src/constr_solve.erl
+++ b/src/constr_solve.erl
@@ -178,14 +178,14 @@ search_failing_prefix(L, F, Pred, Left, Right) ->
     end.
 
 -spec locate_tyerror(symtab:t(), sets:set(ast:ty_varname()), constr_error_locs:constr_blocks())
-    -> ok | {error, error() | none}.
+    -> {error, error() | none}.
 locate_tyerror(Tab, FreeSet, Blocks) ->
     Extract = fun({_Kind, _Span, _What, Ds}) -> Ds end,
     Pred = fun(Ds) -> is_satisfiable(Tab, Ds, FreeSet, "error location") end,
     {Kind, Span, _What, _Ds} = search_failing_prefix(Blocks, Extract, Pred),
     {error, {Kind, Span, ""}}.
 
--spec format_tally_error([string()]) -> string().
+-spec format_tally_error([{error, string()}]) -> string().
 format_tally_error([]) -> "(no specific error messages)";
 format_tally_error(ErrList) ->
     {ErrListShort, N} = utils:shorten(ErrList, 20),
@@ -210,7 +210,7 @@ is_satisfiable(Tab, Constrs, Fixed, What) ->
             true
     end.
 
--spec solve_simp_constrs(symtab:t(), constr:subty_constrs(), string()) -> error | nonempty_list(subst:t()).
+-spec solve_simp_constrs(symtab:t(), constr:simp_constrs(), string()) -> error | nonempty_list(subst:t()).
 solve_simp_constrs(Tab, Ds, What) ->
     SubtyConstrs = constr_collect:collect_constrs_no_matching_cond(Ds),
     {Res, Delta} = utils:timing(fun() -> tally:tally(Tab, SubtyConstrs) end),

--- a/src/erlang_types/dnf/bdd.hrl
+++ b/src/erlang_types/dnf/bdd.hrl
@@ -23,6 +23,8 @@
     has_negative_only_line/1
 ]).
 
+-etylizer({functions_exhaustive, off, [convert_back_to_repr/5]}).
+
 -include("erlang_types.hrl").
 
 -export_type([type/0]).
@@ -325,25 +327,25 @@ minimize_node_dnf(Dnf) ->
         lists:foldl(fun(Term, Env2) -> Env2#{Term => []} end, Env, Pos ++ Neg)
     end, #{}, Dnf).
 
--spec '_minimize_outputs_from_dnf'(dnf()) -> {#{?LEAF:type() => integer()}, #{integer() => ?LEAF:type()}}.
+-spec '_minimize_outputs_from_dnf'(dnf()) -> {#{?LEAF:type() => pos_integer()}, #{pos_integer() => ?LEAF:type()}}.
 '_minimize_outputs_from_dnf'(Dnf) ->
     {All, Reverse, _} = lists:foldl(fun({_, _, T}, {Env, RevEnv, Index}) ->
         case Env of
             #{T := _} -> {Env, RevEnv, Index};
-            _ -> {Env#{T => Index}, RevEnv#{Index => T}, Index + 1}
+            _ -> {Env#{T => Index}, RevEnv#{Index => T}, ?assert_type(Index + 1, pos_integer())}
         end
     end, {#{}, #{}, 1}, Dnf),
     {All, Reverse}.
 
--spec '_minimize_indices_from_variables'(#{?ATOM:type() => []}) -> {#{?ATOM:type() => integer()}, #{integer() => ?ATOM:type()}}.
+-spec '_minimize_indices_from_variables'(#{?ATOM:type() => []}) -> {#{?ATOM:type() => pos_integer()}, #{pos_integer() => ?ATOM:type()}}.
 '_minimize_indices_from_variables'(AllVariables) ->
     {_, VarInd, RevVarInd} = maps:fold(
         fun(K, _V, {Index, Vars, RevVars}) ->
-            {Index+1, Vars#{K => Index}, RevVars#{Index => K}}
+            {?assert_type(Index+1, pos_integer()), Vars#{K => Index}, RevVars#{Index => K}}
         end, {1, #{}, #{}}, AllVariables),
     {VarInd, RevVarInd}.
 
--spec '_minimize_all_lines_from_dnf'(dnf(), #{?ATOM:type() => integer()}, #{?LEAF:type() => integer()}, non_neg_integer(), non_neg_integer()) -> [string()].
+-spec '_minimize_all_lines_from_dnf'(dnf(), #{?ATOM:type() => pos_integer()}, #{?LEAF:type() => pos_integer()}, non_neg_integer(), non_neg_integer()) -> [string()].
 '_minimize_all_lines_from_dnf'(Dnf, VariableIndices, AllOutputs, I, O) ->
     lists:foldl(fun({Pos, Neg, T}, All) ->
         % variables
@@ -355,8 +357,8 @@ minimize_node_dnf(Dnf) ->
         MinTermOutputs = list_to_tuple(lists:duplicate(O, "0")),
         MinTermOutputsFin = erlang:setelement(maps:get(T, AllOutputs), MinTermOutputs, "1"),
 
-        NewTWithoutOutputs = tuple_to_list(NewMinTerm1),
-        Outputs = tuple_to_list(MinTermOutputsFin),
+        NewTWithoutOutputs = ?assert_type(tuple_to_list(NewMinTerm1), [string()]),
+        Outputs = ?assert_type(tuple_to_list(MinTermOutputsFin), [string()]),
         [utils:flatten(NewTWithoutOutputs ++ " " ++ Outputs)] ++ All % TODO lists:flatten overlay
     end, [], Dnf).
 
@@ -368,7 +370,7 @@ espresso_split_line_into_elements_and_result(LineStr) ->
         _ -> error(badarg) % TODO mark non-exhaustive
     end.
 
--spec '_minimize_get_result'(string(), non_neg_integer(), non_neg_integer(), #{integer() => ?ATOM:type()}, #{integer() => ?LEAF:type()}) -> dnf().
+-spec '_minimize_get_result'(string(), non_neg_integer(), non_neg_integer(), #{pos_integer() => ?ATOM:type()}, #{pos_integer() => ?LEAF:type()}) -> dnf().
 '_minimize_get_result'(Result, I, O, RevVariableIndices, ReverseAllOutputs) ->
     OnlyResultLines = extract_integer_lines(Result, I + 1 + O),
 
@@ -388,7 +390,7 @@ espresso_split_line_into_elements_and_result(LineStr) ->
     port_command(Port, ?assert_type([StrInput, "\n.e\n"], iodata())),
     '_collect_port_output'(Port, []).
 
--spec '_collect_port_output'(port(), iolist()) -> string().
+-spec '_collect_port_output'(port(), string()) -> string().
 '_collect_port_output'(Port, Acc) ->
     receive
         {Port, {data, Data}} ->
@@ -399,7 +401,7 @@ espresso_split_line_into_elements_and_result(LineStr) ->
             error({espresso_exit, Status})
     end.
 
--spec replace_index(string(), [A], Line, #{A => integer()}) -> Line.
+-spec replace_index(string(), A, tuple(), #{A => pos_integer()}) -> tuple().
 replace_index(Val, Term, CurrentLine, VariableIndices) ->
     erlang:setelement(maps:get(Term, VariableIndices), CurrentLine, Val).
 
@@ -438,9 +440,7 @@ convert_back_to_repr({[$- | Rest], Outputs}, IndexToTerms, IndexToOutput, Curren
 convert_back_to_repr({[$1 | Rest], Outputs}, IndexToTerms, IndexToOutput, CurrentIndex, {Pos, Neg, to_replace}) ->
     convert_back_to_repr({Rest, Outputs}, IndexToTerms, IndexToOutput, CurrentIndex + 1, {Pos ++ [maps:get(CurrentIndex, IndexToTerms)], Neg, to_replace});
 convert_back_to_repr({[$0 | Rest], Outputs}, IndexToTerms, IndexToOutput, CurrentIndex, {Pos, Neg, to_replace}) ->
-    convert_back_to_repr({Rest, Outputs}, IndexToTerms, IndexToOutput, CurrentIndex + 1, {Pos, Neg ++ [maps:get(CurrentIndex, IndexToTerms)], to_replace});
-convert_back_to_repr(_, _, _, _, _) ->
-    error(badarg).
+    convert_back_to_repr({Rest, Outputs}, IndexToTerms, IndexToOutput, CurrentIndex + 1, {Pos, Neg ++ [maps:get(CurrentIndex, IndexToTerms)], to_replace}).
 
 -spec has_negative_only_line(type()) -> boolean().
 has_negative_only_line(T) ->

--- a/src/erlang_types/etally.erl
+++ b/src/erlang_types/etally.erl
@@ -3,7 +3,7 @@
 -define(TY, ty_node).
 
 
--export_type([monomorphic_variables/0]).
+-export_type([monomorphic_variables/0, tally_solutions/0, tally_solutions_nonempty/0]).
 
 -export([
   tally/1,
@@ -24,6 +24,7 @@
 -type input_constraint() :: {ty:type(), ty:type()}.
 -type input_constraints() :: [input_constraint()].
 -type tally_solutions() :: [#{variable() => ty:type()}].
+-type tally_solutions_nonempty() :: [#{variable() => ty:type()}, ...].
 
 % early return if constraints are found to be satisfiable
 % does not solve the equations

--- a/src/erlang_types/ty_node.erl
+++ b/src/erlang_types/ty_node.erl
@@ -57,7 +57,7 @@
 -include("etylizer.hrl").
 
 -type type() :: {node, integer()}.
--type temporary_type() :: {local_ref, term()}. % used in ty_parser
+-type temporary_type() :: {local_ref, integer()}. % used in ty_parser
 -type set_of_constraint_sets() :: constraint_set:set_of_constraint_sets().
 
 

--- a/src/erlang_types/ty_parser.erl
+++ b/src/erlang_types/ty_parser.erl
@@ -60,10 +60,13 @@
 -type ty_rec() :: ?TY:type().
 -type ast_ty() :: ast:ty(). 
 -type ety_ty_scheme() :: ast:ty_scheme().
--type ety_ref() :: ast:ty_ref(). %TODO etylizer reference
--type ety_args() :: term(). %TODO [ast:ty()]
--type database() :: {#{temporary_ref() => ty_rec()}, #{ty_rec() => temporary_ref()}}. 
--type local_cache() :: #{{Ref :: ety_ref(), Args :: ety_args()} => temporary_ref()}. % the local cache should only consist of temporary references
+-type ety_ref() :: ast:ty_ref() | mu_var. % also used as mu_var key in local_cache
+-type ety_args() :: [ast:ty()].
+-type database() :: {#{temporary_ref() => ty_rec()}, #{ty_rec() => [temporary_ref()]}}.
+% the local cache should only consist of temporary references
+% it is used both for recursive variable recursion
+% and named type recursion at the same time
+-type local_cache() :: #{ast:ty_mu_var() | {Ref :: ety_ref(), Args :: ety_args()} => temporary_ref()}.
 -type queue() :: queue:queue({temporary_ref(), ast_ty()}).
 
 % global state

--- a/src/espresso_bin.erl
+++ b/src/espresso_bin.erl
@@ -2,6 +2,8 @@
 -export([get_path/0]).
 -on_load(ensure_cached/0).
 
+-include("etylizer.hrl").
+
 %% @doc Returns the path to the espresso binary in the user cache directory.
 %% On module load, copies the binary from _build/espresso if not already cached.
 
@@ -18,6 +20,6 @@ ensure_cached() ->
         true -> ok;
         false ->
             filelib:ensure_dir(Path),
-            {ok, _} = file:copy("_build/espresso", Path),
-            ok = file:change_mode(Path, 8#755)
+            ?assert_pattern({ok, _}, file:copy("_build/espresso", Path)),
+            ?assert_pattern(ok, file:change_mode(Path, 8#755))
     end.

--- a/src/gradual_utils.erl
+++ b/src/gradual_utils.erl
@@ -86,8 +86,8 @@ replace_dynamic(Ty, Ctx) ->
   end, Ty).
 
 % This postprocess step refers to the work of Petrucciani in his PhD thesis (chapter 10.4.2)
--spec postprocess(subst:t(), constr:subty_constrs(), constr:subty_constrs(), symtab:t()) ->
-    subst:t().
+-spec postprocess(subst:tally_subst(), constr:subty_constrs(), constr:mater_constrs(), symtab:t()) ->
+    subst:tally_subst().
 postprocess({tally_subst, S, Fixed}, Constrs, Maters, SymTab) ->
     ?LOG_DEBUG("Postprocessing tally substitution:~nSubstitution:~n~s~nConstraints:~n~s~nMaterialization constraints:~n~s",
         pretty:render_subst(S),
@@ -188,7 +188,7 @@ collect_pos_neg_tyvars(Ty, SymTab) ->
       sets:new(),
       VarPositions).
 
--spec compose(subst:t(), subst:base_subst()) -> subst:t().
+-spec compose(subst:tally_subst(), subst:base_subst()) -> subst:tally_subst().
 compose({tally_subst, S, Fixed}, Sigma2) ->
         S1 = apply_subst(S, Sigma2),
         {tally_subst, S1, sets:union(Fixed, sets:from_list([N || {var, N} <- maps:values(Sigma2)]))}.

--- a/src/graph.erl
+++ b/src/graph.erl
@@ -5,6 +5,8 @@
 
 -export_type([graph/1]).
 
+-include("etylizer.hrl").
+
 -type digraph(_V) :: digraph:graph().
 -type table(_V) :: ets:table().
 % A graph consists of a diagraph and a table mapping extern vertices of
@@ -25,7 +27,7 @@ with_graph(F) ->
 -spec add_vertex(graph(V), V) -> ok.
 add_vertex({G, Tab}, ExternV) ->
     InternV = digraph:add_vertex(G),
-    InternV = digraph:add_vertex(G, InternV, ExternV),
+    _ = digraph:add_vertex(G, InternV, ExternV),
     ets:insert(Tab, {ExternV, InternV}),
     ok.
 
@@ -41,7 +43,7 @@ get_intern(Tab, V) ->
 get_extern(G, InternV) ->
     case digraph:vertex(G, InternV) of
         false -> errors:bug("no such vertex: ~w", InternV);
-        {_, ExternV} -> ExternV
+        {_, ExternV} -> ?assert_type(ExternV, dynamic())
     end.
 
 % add_edge(G, V1, V2) adds an edge from V1 to V2 to graph G. Does nothing if

--- a/src/log.erl
+++ b/src/log.erl
@@ -6,6 +6,8 @@
 -export([init/1, init/2, allow/1, macro_log/5, parse_level/1]).
 -export_type([log_level/0]).
 
+-include("etylizer.hrl").
+
 -type log_level() :: trace2 | trace | debug | info | note | warn | error | abort.
 
 -spec num_level(log_level()) -> integer().
@@ -62,12 +64,13 @@ get_logger_pid() ->
     Table = ets:whereis(log_config),
     case ets:lookup(Table, logger_pid) of
         [] -> none;
-        [{_, Pid}] -> Pid
+        [{_, Pid}] -> ?assert_type(Pid, pid());
+        _ -> none
     end.
 
 -spec file_logger(string()) -> ok.
 file_logger(LogFile) ->
-    {ok, F} = file:open(LogFile, [write]),
+    {ok, F} = ?assert_pattern({ok, _}, file:open(LogFile, [write])),
     Loop =
         fun Loop() ->
                 receive
@@ -90,8 +93,8 @@ allow(L) ->
         case Table of
             undefined -> lazy_init();
             T ->
-                [{_, X}] = ets:lookup(T, level),
-                X
+                [{_, X}] = ?assert_pattern([{_, _}], ets:lookup(T, level)),
+                ?assert_type(X, log_level())
         end,
     num_level(L) =< num_level(MaxL).
 

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -14,6 +14,7 @@
 
 -include("log.hrl").
 -include("etylizer_main.hrl").
+-include("etylizer.hrl").
 
 % An entry in the search path is a kind (local, dep, or otp), a source directory and a list
 % of include directories.
@@ -131,7 +132,7 @@ find_include_dirs(RootDir, SubDirs) ->
 -spec find_otp_paths() -> {search_path(), [file:filename()]}.
 find_otp_paths() ->
     RootDir = code:lib_dir(),
-    {ok, Dirs} = file:list_dir(RootDir),
+    {ok, Dirs} = ?assert_pattern({ok, _}, file:list_dir(RootDir)),
     IncDirs = find_include_dirs(RootDir, Dirs),
     Sp = lists:flatmap(fun(Path) -> standard_path_entries(otp, RootDir, Path, IncDirs) end, Dirs),
     {Sp, IncDirs}.
@@ -144,7 +145,7 @@ find_dependency_roots(ProjectDir, OtpIncDirs) ->
         RebarConfig = filename:join([ProjectDir, "rebar.config"]),
         case filelib:is_dir(ProjectBuildDir) of
             true ->
-                {ok, PathList} = file:list_dir(ProjectLibDir),
+                {ok, PathList} = ?assert_pattern({ok, _}, file:list_dir(ProjectLibDir)),
                 IncDirs = find_include_dirs(ProjectLibDir, PathList) ++ OtpIncDirs,
                 Sp = lists:flatmap(fun(Path) -> standard_path_entries(dep, ProjectLibDir, Path, IncDirs) end, PathList),
                 {Sp, IncDirs};
@@ -228,7 +229,7 @@ find_module_path(SearchPath, Module) ->
     end,
     Key = {SearchPath, Module},
     case ets:lookup(?TABLE, Key) of
-        [{_, Result}] -> Result;
+        [{_, Result}] -> ?assert_type(Result, search_path_entry());
         [] ->
             X = really_find_module_path(SearchPath, Module),
             true = ets:insert(?TABLE, {Key, X}),

--- a/src/subst.erl
+++ b/src/subst.erl
@@ -6,7 +6,8 @@
 
 -export_type([
     t/0,
-    base_subst/0
+    base_subst/0,
+    tally_subst/0
 ]).
 
 -export([
@@ -48,6 +49,7 @@ clean(T, Fixed, SymTab) ->
     true = ty_node:leq(X, ty_parser:parse(T)),
     Res.
 
+-spec clean_cons([{ast:ty(), ast:ty()}], sets:set(ast:ty_varname()), symtab:t()) -> [{ast:ty(), ast:ty()}].
 clean_cons(CList, Fixed, SymTab) ->
     Unfold = fun(Ty) -> ast_utils:unfold_ty(SymTab, Ty) end,
     UnfoldedCList = [{Unfold(C1), Unfold(C2)} || {C1, C2} <- CList],
@@ -139,7 +141,7 @@ from_list(L) -> maps:from_list(L).
 -spec empty() -> t().
 empty() -> #{}.
 
--spec mk_tally_subst(sets:set(ast:ty_varname()), base_subst()) -> t().
+-spec mk_tally_subst(sets:set(ast:ty_varname()), base_subst()) -> tally_subst().
 mk_tally_subst(Fixed, Base) -> {tally_subst, Base, Fixed}.
 
 clean_type(Ty, Fix, SymTab) ->
@@ -181,6 +183,8 @@ collect_vars_clist(L, CPos, Pos, Fix) when is_list(L) ->
         maps:merge_with(fun combine_vars/3, M1, M2)
                 end, Pos, L).
 
+-spec collect_vars(ast:ty() | {ty_hole}, 0 | 1, #{ast:ty_varname() => [0 | 1]}, sets:set(ast:ty_varname())) ->
+    #{ast:ty_varname() => [0 | 1]}.
 collect_vars(M = {map, _}, CPos, Pos, Fix) ->
     collect_vars(ty_parser:rewrite_map_to_representation(M), CPos, Pos, Fix);
 collect_vars({K, Components}, CPos, Pos, Fix) when K == union; K == intersection; K == tuple ->

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -35,6 +35,8 @@
 ]).
 -endif.
 
+-include("etylizer.hrl").
+
 -type fun_env() :: #{ ast:global_ref() => ast:ty_scheme() }.
 -type ty_key() :: {ty_key, Module::atom(), Name::atom(), Arity::arity()}.
 -type ty_env() :: #{ ty_key() => ast:ty_scheme() }.
@@ -51,6 +53,7 @@
 
 -type t() :: #tab{}.
 
+-spec get_types(t()) -> ty_env().
 get_types(#tab{types = Types}) -> Types.
 
 -spec dump_symtab(string(), t()) -> ok.
@@ -289,7 +292,7 @@ maybe_add_qref(ref, Module, Name, Arity, Type, Forms, Tab) ->
         false -> NewTab 
     end.
 
--spec create_ref_tuple(ref(), atom(), arity()) -> tuple().
+-spec create_ref_tuple(ref(), atom(), arity()) -> ast:global_ref().
 create_ref_tuple(ref, Name, Arity) ->
     {ref, Name, Arity};
 create_ref_tuple({qref, Module}, Name, Arity) ->

--- a/src/typing_common.erl
+++ b/src/typing_common.erl
@@ -11,6 +11,7 @@
 
 -include("log.hrl").
 -include("typing.hrl").
+-include("etylizer.hrl").
 
 -spec format_src_loc(ast:loc()) -> string().
 format_src_loc({loc, File, LineNo, ColumnNo}) ->
@@ -21,8 +22,8 @@ format_src_loc({loc, File, LineNo, ColumnNo}) ->
             N = length(Lines),
             if
                 LineNo >= 1 andalso LineNo =< N ->
-                    Line = string:trim(lists:nth(LineNo, Lines), trailing),
-                    ColumnSpace = lists:duplicate(ColumnNo - 1, $\s),
+                    Line = string:trim(lists:nth(LineNo, ?assert_type(Lines, nonempty_list(string()))), trailing),
+                    ColumnSpace = lists:duplicate(?assert_type(ColumnNo - 1, non_neg_integer()), $\s),
                     utils:sformat("%~5.B| ~s~n%     | ~s^", LineNo, Line, ColumnSpace);
                 true ->
                     ErrMsg
@@ -80,7 +81,7 @@ order_bounds(BoundedTyvars) ->
                     end,
                     BoundedTyvars),
                 L = graph:topsort(G),
-                ?LOG_TRACE("Graph: ~200p, L: ~200p", graph:to_list(G, fun atom_to_list/1), L),
+                ?LOG_TRACE("Graph: ~200p, L: ~200p", graph:to_list(G, fun erlang:atom_to_list/1), L),
                 L
             end),
     case VarOrder of

--- a/src/tyutils.erl
+++ b/src/tyutils.erl
@@ -17,13 +17,13 @@ free_in_ty(T) ->
                          end, T),
     sets:from_list(L, [{version, 2}]).
 
--spec free_in_subty_constr(constr:simp_constr()) -> sets:set(ast:ty_varname()).
+-spec free_in_subty_constr(constr:simp_constr_subty()) -> sets:set(ast:ty_varname()).
 free_in_subty_constr(C) ->
     case C of
         {scsubty, _Locs, T1, T2} -> sets:union(free_in_ty(T1), free_in_ty(T2))
     end.
 
--spec free_in_subty_constrs(constr:simp_constrs()) -> sets:set(ast:ty_varname()).
+-spec free_in_subty_constrs(constr:subty_constrs()) -> sets:set(ast:ty_varname()).
 free_in_subty_constrs(Cs) ->
     sets:fold(
         fun (C, Acc) -> sets:union(Acc, free_in_subty_constr(C)) end,

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -5,6 +5,8 @@
 -include_lib("kernel/include/file.hrl").
 -include("log.hrl").
 
+-etylizer({functions_exhaustive, off, [compare/3]}). % assumes equal length lists
+
 -export([
     quit/3, quit/2,
     everywhere/2, everything/2,
@@ -35,6 +37,7 @@
     parse_fun_ids/1
 ]).
 
+-include("etylizer.hrl").
 % quit exits the erlang program with the given exit code. No stack trace is produced,
 % so don't use this function for aborting because of a bug.
 -spec quit(non_neg_integer(), string(), [_]) -> no_return().
@@ -103,7 +106,9 @@ is_char(X) -> is_string([X]).
 % - If the function given returns {rec, X}, then the term is replaced
 %   by X, and recursive traversal is done.
 % - If the funtion returns error, then everywhere traverses the term recursively.
--spec everywhere(fun((term()) -> t:opt(term())), T) -> T.
+% -spec everywhere(fun((term()) -> t:opt(term())), T) -> T.
+% we can't assert the result type T without scoped variables
+-spec everywhere(fun((any()) -> {rec, any()} | t:opt(any())), any()) -> dynamic().
 everywhere(F, T) ->
     TransList = fun(L) -> lists:map(fun(X) -> everywhere(F, X) end, L) end,
     case F(T) of
@@ -145,7 +150,7 @@ if_true(B, Action) ->
     end,
     ok.
 
--spec file_get_lines(file:filename()) -> {ok, [string()]} | {error, _Why}.
+-spec file_get_lines(file:filename()) -> {ok, [string()]} | {error, term()}.
 file_get_lines(Path) ->
     case file:open(Path, [read]) of
         {error, X} -> {error, X};
@@ -180,7 +185,7 @@ replicate(N, X) -> [X | replicate(N - 1, X)].
 string_ends_with(S, Suffix) ->
     string:find(S, Suffix, trailing) =:= Suffix.
 
--spec shorten(list(), integer()) -> {list(), integer()}.
+-spec shorten(list(T), integer()) -> {list(T), integer()}.
 shorten(L, N) when N < 0 -> {[], length(L)};
 shorten([], _) -> {[], 0};
 shorten([X | Xs], N) ->
@@ -207,7 +212,7 @@ with_index(Start, L) ->
 
 -spec mkdirs(file:filename()) -> ok | {error, string()}.
 mkdirs(D) ->
-    ok = filelib:ensure_dir(filename:join(D, "XXX")). % only creates the parent!
+    ?assert_pattern(ok, filelib:ensure_dir(filename:join(D, "XXX"))). % only creates the parent!
 
 -spec hash_sha1(iodata()) -> string().
 hash_sha1(Data) ->
@@ -344,7 +349,8 @@ compare(Cmp, [T1 | Ts1], [T2 | Ts2]) ->
 replace(Term, Mapping) ->
     replace_term(Term, Mapping).
 
--spec replace_term(A, #{term() => term()}) -> A.
+-spec replace_term(dynamic(), #{term() => term()}) -> dynamic().
+%-spec replace_term(A, #{term() => term()}) -> A. % rank-2 types needed
 replace_term({node, _} = Ref, Mapping) ->
     case maps:find(Ref, Mapping) of
         {ok, NewTerm} -> NewTerm;
@@ -365,7 +371,7 @@ replace_term(Term, _Mapping) ->
     Term.
 
 
--spec update_ets_from_map(term(), #{term() => term()}) -> _.
+-spec update_ets_from_map(atom(), #{term() => term()}) -> _.
 update_ets_from_map(EtsTable, LocalMap) ->
   % Filter LocalMap to only new/changed entries
   ChangedEntries = maps:fold(


### PR DESCRIPTION
Improved type specifications for etylizer. Added etylizer attribute forms to `ast.erl`. Not yet enforced, we will likely need another PR after this one to fix remaining issues.