### PR TITLE
Semantically equivalent refactorings

### DIFF
--- a/overlays/etylizer_overlay.erl
+++ b/overlays/etylizer_overlay.erl
@@ -58,7 +58,8 @@
 -spec 'erlang:hd'(nonempty_list(A)) -> A.
 'erlang:hd'(_List) -> error(overlay).
 
--spec 'lists:flatten'(DeepList) -> [A] when DeepList :: [A | DeepList].
+-type deepList(A) :: [A | deepList(A)].
+-spec 'lists:flatten'(deepList(A)) -> [A].
 'lists:flatten'(_) -> error(overlay).
 
 % TODO bdd.hrl:espresso_split_line_into_elements_and_result/1: why is string() not compatible with [chardata()]?

--- a/src/ast.erl
+++ b/src/ast.erl
@@ -368,7 +368,11 @@ get_fun_name({function, _Loc, Name, Arity, _}) -> utils:sformat("~w/~w", Name, A
 -type exps() :: [exp()].
 
 -spec loc_exp(exp()) -> loc().
-loc_exp(X) -> element(2, X).
+loc_exp({_, L}) -> L;
+loc_exp({_, L, _}) -> L;
+loc_exp({_, L, _, _}) -> L;
+loc_exp({_, L, _, _, _}) -> L;
+loc_exp({_, L, _, _, _, _}) -> L.
 
 -type qual_zip_gen() ::  {zip, loc(), [generators()]}. 
 -type qual_list_strict_gen() ::  {generate_strict, loc(), pat(), exp()}.

--- a/src/ast_lib.erl
+++ b/src/ast_lib.erl
@@ -42,7 +42,6 @@ mk_intersection(Tys) ->
                 lists:filter(
                     fun(T) ->
                         case T of
-                            [] -> false;
                             {predef, any} -> false;
                             {negation, {predef, none}} -> false;
                             _ -> true
@@ -80,7 +79,6 @@ mk_union(Tys) ->
                     fun(T) ->
                         case T of
                             {predef, none} -> false;
-                            [] -> errors:bug(utils:sformat("~w", Tys));
                             _ -> true
                         end
                     end,

--- a/src/ast_utils.erl
+++ b/src/ast_utils.erl
@@ -9,58 +9,58 @@
     unfold_ty/2
 ]).
 
+-include("etylizer.hrl").
+
 -spec modname_from_path(file:filename()) -> ast:mod_name().
 modname_from_path(Path) -> list_to_atom(filename:basename(Path, ".erl")).
 
--spec remove_locs(T) -> T.
+-spec loc_replacer(term()) -> {ok, {loc, string(), 0, 0}} | error.
+loc_replacer({loc, File, Line, Col}) ->
+    case utils:is_string(File) andalso is_integer(Line) andalso is_integer(Col) of
+        true -> {ok, {loc, "", 0, 0}};
+        false -> error
+    end;
+loc_replacer(_) -> error.
+
+-spec remove_locs(dynamic()) -> dynamic().
 remove_locs(X) ->
-    LocToError = fun(Z) ->
-        case Z of
-            {loc,File,Line,Col} ->
-                case utils:is_string(File) andalso is_integer(Line) andalso is_integer(Col) of
-                    true -> {ok, {loc, "", 0, 0}};
-                    false -> error
-                end;
-            _ -> error
-        end
-    end,
-    utils:everywhere(LocToError, X).
+    utils:everywhere(fun loc_replacer/1, X).
 
 -spec referenced_modules_via_types(ast:forms()) -> [ast:mod_name()].
 referenced_modules_via_types(Forms) ->
     Modules = utils:everything(
                 fun(T) ->
                         case T of
-                            {attribute, _, import, {ModuleName, _}} -> {ok, ModuleName};
-                            {ty_qref, ModuleName, _, _} -> {ok, ModuleName};
+                            {attribute, _, import, {ModuleName, _}} when is_atom(ModuleName) -> {ok, ModuleName};
+                            {ty_qref, ModuleName, _, _} when is_atom(ModuleName) -> {ok, ModuleName};
                             _ -> error
                         end
                 end, Forms),
-    lists:uniq(Modules).
+    ?assert_type(lists:uniq(Modules), [ast:mod_name()]).
 
 -spec referenced_modules(ast:forms()) -> [ast:mod_name()].
 referenced_modules(Forms) ->
     Modules = utils:everything(
                 fun(T) ->
                         case T of
-                            {attribute, _, import, {ModuleName, _}} -> {ok, ModuleName};
-                            {qref, ModuleName, _, _} -> {ok, ModuleName};
-                            {ty_qref, ModuleName, _, _} -> {ok, ModuleName};
+                            {attribute, _, import, {ModuleName, _}} when is_atom(ModuleName) -> {ok, ModuleName};
+                            {qref, ModuleName, _, _} when is_atom(ModuleName) -> {ok, ModuleName};
+                            {ty_qref, ModuleName, _, _} when is_atom(ModuleName) -> {ok, ModuleName};
                             _ -> error
                         end
                 end, Forms),
-    lists:uniq(Modules).
+    ?assert_type(lists:uniq(Modules), [ast:mod_name()]).
 
 -spec referenced_recursive_variables(ast:ty()) -> [ast:ty_mu_var()].
 referenced_recursive_variables(Forms) ->
     Modules = utils:everything(
                 fun(T) ->
                         case T of
-                            {mu_var, Name} -> {ok, {mu_var, Name}};
+                            {mu_var, Name} when is_atom(Name) -> {ok, {mu_var, Name}};
                             _ -> error
                         end
                 end, Forms),
-    lists:uniq(Modules).
+    ?assert_type(lists:uniq(Modules), [ast:ty_mu_var()]).
 
 % @doc Unfold a type by resolving all named type references via the symtab.
 % Recursive back-references are replaced with {ty_hole}.
@@ -69,6 +69,12 @@ unfold_ty(Tab, Ty) -> unfold_ty(Tab, Ty, #{}).
 
 -spec unfold_ty(symtab:t(), ast:ty(), map()) -> ast:ty() | {ty_hole}.
 unfold_ty(Tab, {named, Loc, Ref, Args}, Memo) ->
+    unfold_ty_named(Tab, Loc, Ref, Args, Memo);
+unfold_ty(Tab, Ty, Memo) ->
+    unfold_ty_compound_2(Tab, Ty, Memo).
+
+-spec unfold_ty_named(symtab:t(), ast:loc(), ast:ty_ref(), [ast:ty()], map()) -> ast:ty() | {ty_hole}.
+unfold_ty_named(Tab, Loc, Ref, Args, Memo) ->
     case Memo of
         #{{Ref, Args} := _} -> {ty_hole};
         _ ->
@@ -76,31 +82,49 @@ unfold_ty(Tab, {named, Loc, Ref, Args}, Memo) ->
             Map = subst:from_list(lists:zip([V || {V, _Bound} <- Vars], Args)),
             Expanded = subst:apply(Map, Body, no_clean),
             unfold_ty(Tab, Expanded, Memo#{{Ref, Args} => []})
-    end;
-unfold_ty(Tab, {union, Args}, Memo) ->
-    {union, [unfold_ty(Tab, T, Memo) || T <- Args]};
-unfold_ty(Tab, {intersection, Args}, Memo) ->
-    {intersection, [unfold_ty(Tab, T, Memo) || T <- Args]};
-unfold_ty(Tab, {tuple, Args}, Memo) ->
-    {tuple, [unfold_ty(Tab, T, Memo) || T <- Args]};
-unfold_ty(Tab, {fun_full, Args, Ret}, Memo) ->
-    {fun_full, [unfold_ty(Tab, T, Memo) || T <- Args], unfold_ty(Tab, Ret, Memo)};
-unfold_ty(Tab, {fun_any_arg, Ret}, Memo) ->
-    {fun_any_arg, unfold_ty(Tab, Ret, Memo)};
-unfold_ty(Tab, {negation, T}, Memo) ->
-    {negation, unfold_ty(Tab, T, Memo)};
-unfold_ty(Tab, {list, T}, Memo) ->
-    {list, unfold_ty(Tab, T, Memo)};
-unfold_ty(Tab, {nonempty_list, T}, Memo) ->
-    {nonempty_list, unfold_ty(Tab, T, Memo)};
-unfold_ty(Tab, {cons, A, B}, Memo) ->
-    {cons, unfold_ty(Tab, A, Memo), unfold_ty(Tab, B, Memo)};
-unfold_ty(Tab, {improper_list, A, B}, Memo) ->
-    {improper_list, unfold_ty(Tab, A, Memo), unfold_ty(Tab, B, Memo)};
-unfold_ty(Tab, {nonempty_improper_list, A, B}, Memo) ->
-    {nonempty_improper_list, unfold_ty(Tab, A, Memo), unfold_ty(Tab, B, Memo)};
-unfold_ty(Tab, {map, Assocs}, Memo) ->
-    {map, [{Kind, unfold_ty(Tab, K, Memo), unfold_ty(Tab, V, Memo)} || {Kind, K, V} <- Assocs]};
-unfold_ty(Tab, {mu, Var, T}, Memo) ->
-    {mu, Var, unfold_ty(Tab, T, Memo)};
-unfold_ty(_Tab, T, _Memo) -> T.
+    end.
+
+-spec unfold_ty_compound_2(symtab:t(), ast:ty(), map()) -> ast:ty() | {ty_hole}.
+unfold_ty_compound_2(Tab, {fun_full, Args, Ret}, Memo) ->
+    {fun_full, unfold_ty_list(Tab, Args, Memo), unfold_ty_single(Tab, Ret, Memo)};
+unfold_ty_compound_2(Tab, {fun_any_arg, Ret}, Memo) ->
+    {fun_any_arg, unfold_ty_single(Tab, Ret, Memo)};
+unfold_ty_compound_2(Tab, {negation, T}, Memo) ->
+    {negation, unfold_ty_single(Tab, T, Memo)};
+unfold_ty_compound_2(Tab, Ty, Memo) ->
+    unfold_ty_compound_3(Tab, Ty, Memo).
+
+-spec unfold_ty_compound_3(symtab:t(), ast:ty(), map()) -> ast:ty() | {ty_hole}.
+unfold_ty_compound_3(Tab, {cons, A, B}, Memo) ->
+    {cons, unfold_ty_single(Tab, A, Memo), unfold_ty_single(Tab, B, Memo)};
+unfold_ty_compound_3(Tab, {improper_list, A, B}, Memo) ->
+    {improper_list, unfold_ty_single(Tab, A, Memo), unfold_ty_single(Tab, B, Memo)};
+unfold_ty_compound_3(Tab, {nonempty_improper_list, A, B}, Memo) ->
+    {nonempty_improper_list, unfold_ty_single(Tab, A, Memo), unfold_ty_single(Tab, B, Memo)};
+unfold_ty_compound_3(Tab, Ty, Memo) ->
+    unfold_ty_list_or_leaf(Tab, Ty, Memo).
+
+-spec unfold_ty_list_or_leaf(symtab:t(), ast:ty(), map()) -> ast:ty() | {ty_hole}.
+unfold_ty_list_or_leaf(Tab, {union, Args}, Memo) ->
+    {union, unfold_ty_list(Tab, Args, Memo)};
+unfold_ty_list_or_leaf(Tab, {intersection, Args}, Memo) ->
+    {intersection, unfold_ty_list(Tab, Args, Memo)};
+unfold_ty_list_or_leaf(Tab, {tuple, Args}, Memo) ->
+    {tuple, unfold_ty_list(Tab, Args, Memo)};
+unfold_ty_list_or_leaf(Tab, {list, T}, Memo) ->
+    {list, unfold_ty_single(Tab, T, Memo)};
+unfold_ty_list_or_leaf(Tab, {nonempty_list, T}, Memo) ->
+    {nonempty_list, unfold_ty_single(Tab, T, Memo)};
+unfold_ty_list_or_leaf(Tab, {map, Assocs}, Memo) ->
+    {map, [{Kind, unfold_ty_single(Tab, K, Memo), unfold_ty_single(Tab, V, Memo)} || {Kind, K, V} <- Assocs]};
+unfold_ty_list_or_leaf(Tab, {mu, Var, T}, Memo) ->
+    {mu, Var, unfold_ty_single(Tab, T, Memo)};
+unfold_ty_list_or_leaf(_Tab, T, _Memo) -> T.
+
+-spec unfold_ty_list(symtab:t(), [ast:ty()], map()) -> [ast:ty() | {ty_hole}].
+unfold_ty_list(Tab, Types, Memo) ->
+    [unfold_ty(Tab, T, Memo) || T <- Types].
+
+-spec unfold_ty_single(symtab:t(), ast:ty(), map()) -> ast:ty() | {ty_hole}.
+unfold_ty_single(Tab, T, Memo) ->
+    unfold_ty(Tab, T, Memo).

--- a/src/attr.erl
+++ b/src/attr.erl
@@ -21,22 +21,24 @@ ety_attrs_from_file(Path) ->
 -spec ety_attrs_from_lines(string(), [string()]) -> t:opt([ety_attr()], string()).
 ety_attrs_from_lines(Path, Lines) -> ety_attrs_from_lines(Path, 1, Lines).
 
+-spec collect_ety_attrs(string(), t:lineno(), [string()]) -> [ety_attr()].
+collect_ety_attrs(_Path, _N, []) -> [];
+collect_ety_attrs(Path, N, [Line | RestLines]) ->
+    Rest = collect_ety_attrs(Path, N + 1, RestLines),
+    case parse_ety_attr({loc, Path, N, 1}, Line) of
+        no_attr -> Rest;
+        {ok, R} -> [R | Rest]
+    end.
+
 -spec ety_attrs_from_lines(string(), t:lineno(), [string()]) -> t:opt([ety_attr()], string()).
 ety_attrs_from_lines(Path, Lineno, Lines) ->
-    Loop =
-        fun Loop(N, List) ->
-            case List of
-                [] -> [];
-                [Line | RestLines] ->
-                    Rest = Loop(N + 1, RestLines),
-                    case parse_ety_attr({loc, Path, N, 1}, Line) of
-                        no_attr -> Rest;
-                        {ok, R} -> [R | Rest]
-                    end
-            end
-        end,
-    try {ok, Loop(Lineno, Lines)}
-    catch {bad_attr, Msg} -> {error, utils:sformat("~1000p", Msg)} end.
+    try {ok, collect_ety_attrs(Path, Lineno, Lines)}
+    catch throw:BadAttr:ST ->
+        case BadAttr of
+            {bad_attr, Msg} -> {error, utils:sformat("~1000p", Msg)};
+            _ -> erlang:raise(throw, BadAttr, ST)
+        end
+    end.
 
 -spec parse_ety_attr(ast:loc(), string()) -> no_attr | {ok, ety_attr()}.
 parse_ety_attr(Loc, S) ->

--- a/src/cm_check.erl
+++ b/src/cm_check.erl
@@ -84,13 +84,25 @@ traverse_and_check([], _, _, _, _, Index) ->
     Index;
 
 traverse_and_check([CurrentFile | RemainingFiles], Symtab, OverlaySymtab, SearchPath, Opts, Index) ->
+    {Forms, _ExpandedSymtab} = check_single_file(CurrentFile, Symtab, OverlaySymtab, SearchPath, Opts, Index),
+    NewIndex = cm_index:insert(CurrentFile, Forms, Index),
+    traverse_and_check(RemainingFiles, Symtab, OverlaySymtab, SearchPath, Opts, NewIndex).
+
+-spec check_single_file(
+    file:filename(), symtab:t(), symtab:t(), paths:search_path(), cmd_opts(), cm_index:index())
+    -> {ast:forms(), symtab:t()}.
+check_single_file(CurrentFile, Symtab, OverlaySymtab, SearchPath, Opts, _Index) ->
     ?LOG_DEBUG("Checking ~s", CurrentFile),
     Forms = parse_cache:parse(intern, CurrentFile),
     ModName = ast_utils:modname_from_path(CurrentFile),
     Referenced = lists:filter(fun (M) -> M =/= ModName end, ast_utils:referenced_modules(Forms)),
     ?LOG_DEBUG("Referenced from ~s: ~200p", CurrentFile, Referenced),
     ExpandedSymtab = symtab:extend_symtab_with_module_list(Symtab, SearchPath, Referenced, OverlaySymtab),
+    do_type_check(CurrentFile, Forms, ExpandedSymtab, OverlaySymtab, Opts),
+    {Forms, ExpandedSymtab}.
 
+-spec do_type_check(file:filename(), ast:forms(), symtab:t(), symtab:t(), cmd_opts()) -> ok.
+do_type_check(CurrentFile, Forms, ExpandedSymtab, OverlaySymtab, Opts) ->
     Only = sets:from_list(Opts#opts.type_check_only, [{version, 2}]),
     Ignore = sets:from_list(Opts#opts.type_check_ignore,[{version, 2}]),
     Sanity = perform_sanity_check(CurrentFile, Forms, Opts#opts.sanity),
@@ -107,8 +119,7 @@ traverse_and_check([CurrentFile | RemainingFiles], Symtab, OverlaySymtab, Search
         false ->
             typing:check_forms(Ctx, CurrentFile, Forms, Only, Ignore, Opts#opts.check_exports, {CliNoExhaustiveness, CliNoRedundancy})
     end,
-    NewIndex = cm_index:insert(CurrentFile, Forms, Index),
-    traverse_and_check(RemainingFiles, Symtab, OverlaySymtab, SearchPath, Opts, NewIndex).
+    ok.
 
 -spec perform_sanity_check(file:filename(), ast:forms(), boolean()) -> {ok, ast_check:ty_map()} | error.
 perform_sanity_check(CurrentFile, Forms, DoCheck) ->

--- a/src/constr_error_locs.erl
+++ b/src/constr_error_locs.erl
@@ -10,6 +10,8 @@
     constr_block/0
 ]).
 
+-include("etylizer.hrl").
+
 -type constr_error_kind() :: tyerror | redundant_branch | non_exhaustive_case.
 
 -type constr_blocks() :: list(constr_block()).
@@ -39,36 +41,41 @@ simp_constrs_to_blocks(Ds) ->
             ListOfBlocks),
     lists:append(SortedListOfBlocks).
 
+-spec simp_constr_branch_to_blocks(constr:simp_constr_case_branch()) -> constr_blocks().
+simp_constr_branch_to_blocks({sccase_branch, {LocGuard, Guards}, _Cond,
+        {LocBody, Body}, {LocResult, Result}}) ->
+    BodyBlocks =
+        case sets:size(Body) of
+            1 -> simp_constr_to_blocks(lists:nth(1, ?assert_type(sets:to_list(Body), nonempty_list(constr:simp_constr()))));
+            _ -> [{tyerror, LocBody, "branch body",
+                    constr_collect:collect_constrs_no_matching_cond(Body)}]
+        end,
+    GuardBlocks =
+        case sets:is_empty(Guards) of
+            true -> [];
+            false ->
+                [{tyerror, LocGuard, "branch guard",
+                     constr_collect:collect_constrs_no_matching_cond(Guards)}]
+        end,
+    ResultBlocks =
+        [{tyerror, LocResult, "branch result",
+            constr_collect:collect_constrs_no_matching_cond(Result)}],
+    GuardBlocks ++ ResultBlocks ++ BodyBlocks.
+
+-spec simp_constr_to_blocks_sccase(constr:simp_constrs(), ast:loc(), constr:simp_constrs(),
+    [constr:simp_constr_case_branch()]) -> constr_blocks().
+simp_constr_to_blocks_sccase(DsScrut, LocExhaus, DsExhaust, Branches) ->
+    BranchBlocks = utils:concat_map(Branches, fun simp_constr_branch_to_blocks/1),
+    simp_constrs_to_blocks(DsScrut) ++
+        [{non_exhaustive_case, LocExhaus, "case exhaust",
+            constr_collect:collect_constrs_no_matching_cond(DsExhaust)}] ++
+        BranchBlocks.
+
 -spec simp_constr_to_blocks(constr:simp_constr()) -> constr_blocks().
 simp_constr_to_blocks(D) ->
     case D of
         {scsubty, L, _, _} -> [{tyerror, L, "subty", utils:single(D)}];
         {scmater, L, _T, _Alpha} -> [{tyerror, L, "subty", utils:single(D)}];
         {sccase, {_LocScrut, DsScrut}, {LocExhaus, DsExhaust}, Branches} ->
-            BranchBlocks =
-                utils:concat_map(Branches,
-                    fun ({sccase_branch, {LocGuard, Guards}, _Cond,
-                            {LocBody, Body}, {LocResult, Result}}) ->
-                        BodyBlocks =
-                            case sets:size(Body) of
-                                1 -> simp_constr_to_blocks(lists:nth(1, sets:to_list(Body)));
-                                _ -> [{tyerror, LocBody, "branch body",
-                                        constr_collect:collect_constrs_no_matching_cond(Body)}]
-                            end,
-                        GuardBlocks =
-                            case sets:is_empty(Guards) of
-                                true -> [];
-                                false ->
-                                    [{tyerror, LocGuard, "branch guard",
-                                         constr_collect:collect_constrs_no_matching_cond(Guards)}]
-                            end,
-                        ResultBlocks =
-                            [{tyerror, LocResult, "branch result",
-                                constr_collect:collect_constrs_no_matching_cond(Result)}],
-                        GuardBlocks ++ ResultBlocks ++ BodyBlocks
-                    end),
-            simp_constrs_to_blocks(DsScrut) ++
-                [{non_exhaustive_case, LocExhaus, "case exhaust",
-                    constr_collect:collect_constrs_no_matching_cond(DsExhaust)}] ++
-                BranchBlocks
+            simp_constr_to_blocks_sccase(DsScrut, LocExhaus, DsExhaust, Branches)
     end.

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -1648,7 +1648,9 @@ var_test_env(FunExp, X, RestArgs) ->
                                     _ -> ?LOG_INFO("Unsupported type test ~w", Name)
                                 end,
                                 Default
-                        end
+                        end;
+                    {_Name, _Arity} ->
+                        Default
                 end;
             _ ->
                 Default

--- a/src/constr_simp.erl
+++ b/src/constr_simp.erl
@@ -32,25 +32,55 @@ new_ctx(Tab, Env, Sanity) ->
 simp_constrs(Ctx, Cs) ->
     sets:union(lists:map(fun (C) -> simp_constr(Ctx, C) end, sets:to_list(Cs))).
 
+-spec lookup_var_ty(ctx(), ast:any_ref(), constr:locs(), string()) -> ast:ty_scheme().
+lookup_var_ty(Ctx, X, Locs, Context) ->
+    case maps:find(X, Ctx#ctx.env) of
+        {ok, U} -> U;
+        error ->
+            case X of
+                {local_ref, Y} ->
+                    errors:bug("Unbound variable in " ++ Context ++ " ~w: ~p",
+                         [Y, Ctx#ctx.env]);
+                GlobalX ->
+                    symtab:lookup_fun(GlobalX, loc(Locs), Ctx#ctx.symtab)
+            end
+    end.
+
+-spec simp_cvar(ctx(), constr:locs(), ast:any_ref(), ast:ty()) -> constr:simp_constrs().
+simp_cvar(Ctx, Locs, X, T) ->
+    PolyTy = lookup_var_ty(Ctx, X, Locs, "constraint simplification"),
+    utils:single({scsubty, loc(Locs), fresh_ty_scheme(Ctx, PolyTy), T}).
+
+-spec simp_cop(ctx(), constr:locs(), atom(), arity(), ast:ty()) -> constr:simp_constrs().
+simp_cop(Ctx, Locs, OpName, OpArity, T) ->
+    PolyTy = symtab:lookup_op(OpName, OpArity, loc(Locs), Ctx#ctx.symtab),
+    utils:single({scsubty, loc(Locs), fresh_ty_scheme(Ctx, PolyTy), T}).
+
+-spec simp_cdef(ctx(), constr:constr_env(), constr:constrs()) -> constr:simp_constrs().
+simp_cdef(Ctx, Env, Cs) ->
+    NewCtx = extend_env(Ctx, Env),
+    simp_constrs(NewCtx, Cs).
+
+-spec simp_ccase(ctx(), constr:locs(), constr:constrs(), constr:constrs(), [constr:constr_case_branch()]) -> constr:simp_constrs().
+simp_ccase(Ctx, Locs, CsScrut, CsExhaust, Bodies) ->
+    case Ctx#ctx.sanity of
+        {ok, TyMap0} -> constr_gen:sanity_check(CsScrut, TyMap0);
+        error -> ok
+    end,
+    DsScrut = simp_constrs(Ctx, CsScrut),
+    LocsScrut = loc(CsScrut),
+    DsExhaust = simp_constrs(Ctx, CsExhaust),
+    L = lists:map(fun (Body) -> simp_case_branch(Ctx, Body) end, Bodies),
+    utils:single({sccase, {LocsScrut, DsScrut}, {loc(Locs), DsExhaust}, L}).
+
 -spec simp_constr(ctx(), constr:constr()) -> constr:simp_constrs().
 simp_constr(Ctx, C) ->
     ?LOG_TRACE("simp_constr, C=~w", C),
     case C of
-        {csubty, Locs, T1, T2} -> utils:single({scsubty, loc(Locs), T1, T2});
+        {csubty, Locs, T1, T2} ->
+            utils:single({scsubty, loc(Locs), T1, T2});
         {cvar, Locs, X, T} ->
-            PolyTy =
-                case maps:find(X, Ctx#ctx.env) of
-                    {ok, U} -> U;
-                    error ->
-                        case X of
-                            {local_ref, Y} ->
-                                errors:bug("Unbound variable in constraint simplification ~w: ~p",
-                                     [Y, Ctx#ctx.env]);
-                            GlobalX ->
-                                symtab:lookup_fun(GlobalX, loc(Locs), Ctx#ctx.symtab)
-                        end
-                end,
-            utils:single({scsubty, loc(Locs), fresh_ty_scheme(Ctx, PolyTy), T});
+            simp_cvar(Ctx, Locs, X, T);
         {cvarmater, Locs, X, Alpha} ->
             PolyTy =
                 case maps:find(X, Ctx#ctx.env) of
@@ -71,23 +101,11 @@ simp_constr(Ctx, C) ->
                 {scmater, Loc, fresh_ty_scheme(Ctx, PolyTy), Alpha}
             ]);
         {cop, Locs, OpName, OpArity, T} ->
-            PolyTy = symtab:lookup_op(OpName, OpArity, loc(Locs), Ctx#ctx.symtab),
-            utils:single({scsubty, loc(Locs), fresh_ty_scheme(Ctx, PolyTy), T});
+            simp_cop(Ctx, Locs, OpName, OpArity, T);
         {cdef, _Locs, Env, Cs} ->
-            NewCtx = extend_env(Ctx, Env),
-            simp_constrs(NewCtx, Cs);
+            simp_cdef(Ctx, Env, Cs);
         {ccase, Locs, CsScrut, CsExhaust, Bodies} ->
-            case Ctx#ctx.sanity of
-                {ok, TyMap0} ->
-                    constr_gen:sanity_check(CsScrut, TyMap0);
-                error -> ok
-            end,
-            DsScrut = simp_constrs(Ctx, CsScrut),
-            LocsScrut = loc(CsScrut),
-            DsExhaust = simp_constrs(Ctx, CsExhaust),
-            L = lists:map(fun (Body) -> simp_case_branch(Ctx, Body) end, Bodies),
-            utils:single({sccase, {LocsScrut, DsScrut}, {loc(Locs), DsExhaust}, L});
-        X -> errors:uncovered_case(?FILE, ?LINE, X)
+            simp_ccase(Ctx, Locs, CsScrut, CsExhaust, Bodies)
     end.
 
 -spec simp_case_branch(ctx(), constr:constr_case_branch()) -> constr:simp_constr_case_branch().
@@ -184,20 +202,17 @@ extend_env(Ctx, Env) ->
         pretty:render_poly_env(NewEnv)),
     Ctx#ctx { env = NewEnv }.
 
--spec sanity_check(any(), ast_check:ty_map()) -> ok.
-sanity_check(Ds, Spec) ->
-    case sets:is_set(Ds) of
-        false ->
-            ?ABORT("Expected set of simple constraints, got ~w", Ds);
+-spec sanity_check_one(constr:simp_constr(), ast_check:ty_map()) -> ok.
+sanity_check_one(D, Spec) ->
+    case ast_check:check_against_type(Spec, constr, simp_constr, D) of
         true ->
-            lists:foreach(
-            fun(D) ->
-                    case ast_check:check_against_type(Spec, constr, simp_constr, D) of
-                        true ->
-                            ?LOG_DEBUG("Sanity check OK");
-                        false ->
-                            ?ABORT("Invalid simple constraint generated: ~w", D)
-                    end
-            end,
-            sets:to_list(Ds))
+            ?LOG_DEBUG("Sanity check OK");
+        false ->
+            ?ABORT("Invalid simple constraint generated: ~w", D)
     end.
+
+-spec sanity_check(constr:simp_constrs(), ast_check:ty_map()) -> ok.
+sanity_check(Ds, Spec) ->
+    lists:foreach(
+        fun(D) -> sanity_check_one(D, Spec) end,
+        sets:to_list(Ds)).

--- a/src/constr_solve.erl
+++ b/src/constr_solve.erl
@@ -77,6 +77,41 @@ has_dynamic_constr(Tab, Constrs) ->
         end,
         sets:to_list(Constrs)).
 
+-spec check_redundant_branch(symtab:t(), sets:set(ast:ty_varname()), constr:subty_constrs(),
+    {ast:loc(), constr:subty_constrs()}, ok | {error, error()}) -> ok | {error, error()}.
+check_redundant_branch(_Tab, _FixedTyvars, _SubtyConstrs, _LocAndConstrs, Acc = {error, _}) -> Acc;
+check_redundant_branch(Tab, FixedTyvars, SubtyConstrs, {Loc, UnmatchedConstrs}, ok) ->
+    All = sets:union(UnmatchedConstrs, SubtyConstrs),
+    case is_satisfiable(Tab, All, FixedTyvars, "redundancy check") of
+        true ->
+            ?LOG_DEBUG("Branch at ~s is redundant. Constraints that were added to the constraint above: ~s~nFixed: ~200p",
+                ast:format_loc(Loc),
+                pretty:render_constr(UnmatchedConstrs),
+                sets:to_list(FixedTyvars)),
+            {error, {redundant_branch, Loc, ""}};
+        false ->
+            ?LOG_DEBUG("Branch at ~s is not redundant. Constraints that were added to the constraint above: ~s~nFixed: ~200p",
+                ast:format_loc(Loc),
+                pretty:render_constr(UnmatchedConstrs),
+                sets:to_list(FixedTyvars)),
+            ok
+    end.
+
+-spec locate_unsat_error(symtab:t(), sets:set(ast:ty_varname()), constr:simp_constrs()) ->
+    {error, error() | none}.
+locate_unsat_error(Tab, FixedTyvars, Ds) ->
+    Blocks = constr_error_locs:simp_constrs_to_blocks(Ds),
+    ?LOG_DEBUG("Constraints are not satisfiable, now locating source of errors. Blocks:~n~s",
+        pretty:render_list(fun pretty:constr_block/1, Blocks)),
+    Timeout = 4000,
+    TimeoutRes = utils:timeout(Timeout, fun () -> locate_tyerror(Tab, FixedTyvars, Blocks) end),
+    case TimeoutRes of
+        {ok, Res} -> Res;
+        timeout ->
+            ?LOG_INFO("Locating type error timed out after ~wms", Timeout),
+            {error, none}
+    end.
+
 % Treats unmatched branches as errors.
 -spec check_simp_constrs(symtab:t(), sets:set(ast:ty_varname()), constr:simp_constrs(), string()) ->
     ok | {error, error() | none}.
@@ -96,44 +131,14 @@ check_simp_constrs(Tab, FixedTyvars, Ds, What) ->
                     ok;
                 false ->
                     lists:foldl(
-                        fun ({Loc, UnmatchedConstrs}, Acc) ->
-                            case Acc of
-                                ok ->
-                                    All = sets:union(UnmatchedConstrs, SubtyConstrs),
-                                    case is_satisfiable(Tab, All, FixedTyvars, "redundancy check") of
-                                        true ->
-                                            ?LOG_DEBUG("Branch at ~s is redundant. Constraints that were added to the constraint above: ~s~nFixed: ~200p",
-                                                ast:format_loc(Loc),
-                                                pretty:render_constr(UnmatchedConstrs),
-                                                sets:to_list(FixedTyvars)),
-                                            {error, {redundant_branch, Loc, ""}};
-                                        false ->
-                                            ?LOG_DEBUG("Branch at ~s is not redundant. Constraints that were added to the constraint above: ~s~nFixed: ~200p",
-                                                ast:format_loc(Loc),
-                                                pretty:render_constr(UnmatchedConstrs),
-                                                sets:to_list(FixedTyvars)),
-                                            ok
-                                    end;
-                                _ -> Acc
-                            end
+                        fun (LocAndConstrs, Acc) ->
+                            check_redundant_branch(Tab, FixedTyvars, SubtyConstrs, LocAndConstrs, Acc)
                         end,
                         ok,
                         ReduDs)
             end;
         false ->
-            Blocks = constr_error_locs:simp_constrs_to_blocks(Ds),
-            ?LOG_DEBUG("Constraints are not satisfiable, now locating source of errors. Blocks:~n~s",
-                pretty:render_list(fun pretty:constr_block/1, Blocks)),
-            Timeout = 4000,
-            TimeoutRes = utils:timeout(
-                Timeout,
-                fun () -> locate_tyerror(Tab, FixedTyvars, Blocks) end),
-            case TimeoutRes of
-                {ok, Res} -> Res;
-                timeout ->
-                    ?LOG_INFO("Locating type error timed out after ~wms", Timeout),
-                    {error, none}
-            end
+            locate_unsat_error(Tab, FixedTyvars, Ds)
     end.
 
 % search_failing_prefix(L, F, Pred, Acc).
@@ -218,7 +223,7 @@ solve_simp_constrs(Tab, Ds, What) ->
         {error, ErrList} ->
             ?LOG_DEBUG("Tally time (~s): ~pms, tally finished with errors.", What, Delta),
             ?LOG_TRACE("Tally errors: ~s", format_tally_error(ErrList)),
-            false;
+            error;
         Substs ->
             ?LOG_DEBUG("Tally time (~s): ~pms, tally successful.", What, Delta),
             ?LOG_TRACE("Substitutions:~n~s", [pretty:render_substs(Substs)]),

--- a/src/erlang_types/dnf/bdd.hrl
+++ b/src/erlang_types/dnf/bdd.hrl
@@ -76,21 +76,27 @@ reorder({node, Atom, Pos, Neg}) ->
 
 -spec reorder_if_needed(?ATOM:type() | undefined, ?ATOM:type() | undefined, ?ATOM:type(), type(), type()) -> type().
 reorder_if_needed(PosAtom, NegAtom, Atom, OrderedPos, OrderedNeg) ->
-    % Determine if we need to push this node down
-    Z = case {PosAtom, NegAtom} of
-        {undefined, undefined} -> {node, Atom, OrderedPos, OrderedNeg};
-        _ ->
-            case PosAtom /= undefined andalso ?ATOM:compare(Atom, PosAtom) /= lt of
+    Z = case PosAtom of
+        undefined -> reorder_check_neg(NegAtom, Atom, OrderedPos, OrderedNeg);
+        PA ->
+            case ?ATOM:compare(Atom, PA) /= lt of
                 true -> push_down(Atom, OrderedPos, OrderedNeg);
-                _ ->
-                    case NegAtom /= undefined andalso ?ATOM:compare(Atom, NegAtom) /= lt of
-                        true -> push_down(Atom, OrderedPos, OrderedNeg);
-                        _ -> {node, Atom, OrderedPos, OrderedNeg}
-                    end
+                false -> reorder_check_neg(NegAtom, Atom, OrderedPos, OrderedNeg)
             end
     end,
     assert_valid(Z),
     Z.
+
+-spec reorder_check_neg(?ATOM:type() | undefined, ?ATOM:type(), type(), type()) -> type().
+reorder_check_neg(NegAtom, Atom, OrderedPos, OrderedNeg) ->
+    case NegAtom of
+        undefined -> {node, Atom, OrderedPos, OrderedNeg};
+        NA ->
+            case ?ATOM:compare(Atom, NA) /= lt of
+                true -> push_down(Atom, OrderedPos, OrderedNeg);
+                false -> {node, Atom, OrderedPos, OrderedNeg}
+            end
+    end.
 
 -spec push_down(?ATOM:type(), bdd(), bdd()) -> bdd().
 push_down(TopAtom, Pos, Neg) ->
@@ -317,7 +323,7 @@ minimize_node_dnf(Dnf) ->
 
     % convert all lines using the variable indices
     AllLines = '_minimize_all_lines_from_dnf'(Dnf, VariableIndices, AllOutputs, I, O),
-    StrInput = ".i " ++ integer_to_list(I) ++ "\n.o " ++ integer_to_list(O) ++ "\n" ++ utils:flatten(lists:join("\n", AllLines)),
+    StrInput = ".i " ++ integer_to_list(I) ++ "\n.o " ++ integer_to_list(O) ++ "\n" ++ lists:flatten(lists:join("\n", AllLines)),
     Result = '_minimize_espresso'(StrInput),
     '_minimize_get_result'(Result, I, O, RevVariableIndices, ReverseAllOutputs).
 
@@ -359,7 +365,7 @@ minimize_node_dnf(Dnf) ->
 
         NewTWithoutOutputs = ?assert_type(tuple_to_list(NewMinTerm1), [string()]),
         Outputs = ?assert_type(tuple_to_list(MinTermOutputsFin), [string()]),
-        [utils:flatten(NewTWithoutOutputs ++ " " ++ Outputs)] ++ All % TODO lists:flatten overlay
+        [lists:flatten(NewTWithoutOutputs ++ " " ++ Outputs)] ++ All
     end, [], Dnf).
 
 % "01-1001 1" -> {"01-1001", "1"}
@@ -394,9 +400,9 @@ espresso_split_line_into_elements_and_result(LineStr) ->
 '_collect_port_output'(Port, Acc) ->
     receive
         {Port, {data, Data}} ->
-            '_collect_port_output'(Port, [Acc, Data]);
+            '_collect_port_output'(Port, Acc ++ Data);
         {Port, {exit_status, 0}} ->
-            lists:flatten(Acc);
+            Acc;
         {Port, {exit_status, Status}} ->
             error({espresso_exit, Status})
     end.

--- a/src/erlang_types/dnf_ty_bitstring.erl
+++ b/src/erlang_types/dnf_ty_bitstring.erl
@@ -28,7 +28,9 @@
 -spec reorder(X) -> X when X :: type().
 reorder(X) -> X.
 -spec compare(T, T) -> eq | lt | gt when T :: type().
-compare(0, 0) -> eq; compare(1, 1) -> eq; compare(1, 0) -> gt; compare(0, 1) -> lt.
+compare(X, Y) when X < Y -> lt;
+compare(X, Y) when X > Y -> gt;
+compare(_, _) -> eq.
 -spec empty() -> type().
 empty() -> 0.
 -spec any() -> type().
@@ -38,7 +40,7 @@ union(X, Y) -> erlang:max(X, Y).
 -spec intersect(T, T) -> T when T :: type().
 intersect(X, Y) -> erlang:min(X, Y).
 -spec difference(T, T) -> T when T :: type().
-difference(_, 1) -> 0; difference(X, _) -> X.
+difference(_, 1) -> 0; difference(X, _Y) -> X.
 -spec negate(T) -> T when T :: type().
 negate(1) -> 0; negate(0) -> 1.
 -spec is_any(type()) -> boolean().

--- a/src/erlang_types/dnf_ty_tuple.erl
+++ b/src/erlang_types/dnf_ty_tuple.erl
@@ -10,7 +10,9 @@
   normalize_line/3,
   all_variables_line/4,
   phi/3,
+  phi_solve/4,
   phi_norm/4,
+  phi_norm_solve/5,
   unparse_any/1,
   unparse_any/0
 ]).
@@ -42,29 +44,26 @@ phi(BigS, [], ST) ->
     {false, ST}, 
   BigS);
 phi(BigS, [Ty | N], ST) ->
-  Solve = fun
-    (_, {false, ST2}) -> {false, ST2};
-    ({Index, {_PComponent, NComponent}}, {true, ST2}) ->
-      begin
-      % remove pi_Index(NegativeComponents) from pi_Index(PComponents) and continue searching
-        DoDiff = fun({IIndex, PComp}) ->
-          case IIndex of
-            Index -> ?NODE:difference(PComp, NComponent);
-            _ -> PComp
-          end
-                 end,
-        NewBigS = lists:map(DoDiff, lists:zip(lists:seq(1, length(BigS)), BigS)),
-        phi(NewBigS, N, ST2)
-      end
-          end,
-
   maybe
     {false, ST1} ?= lists:foldl(fun(_S, {true, ST0}) -> {true, ST0}; (S, {false, ST0}) -> ?NODE:is_empty(S, ST0) end, {false, ST}, BigS),
     lists:foldl(
-      Solve, 
-      {true, ST1}, 
+      fun(E, Acc) -> phi_solve(E, Acc, N, BigS) end,
+      {true, ST1},
       lists:zip(lists:seq(1, length(ty_tuple:components(Ty))), lists:zip(BigS, ty_tuple:components(Ty))))
   end.
+
+-spec phi_solve({integer(), {ty:type(), ty:type()}}, {boolean(), S}, [?ATOM:type()], [ty:type()]) -> {boolean(), S} when S :: is_empty_cache().
+phi_solve(_, {false, ST2}, _, _) -> {false, ST2};
+phi_solve({Index, {_PComponent, NComponent}}, {true, ST2}, N, BigS) ->
+    % remove pi_Index(NegativeComponents) from pi_Index(PComponents) and continue searching
+    DoDiff = fun({IIndex, PComp}) ->
+      case IIndex of
+        Index -> ?NODE:difference(PComp, NComponent);
+        _ -> PComp
+      end
+             end,
+    NewBigS = lists:map(DoDiff, lists:zip(lists:seq(1, length(BigS)), BigS)),
+    phi(NewBigS, N, ST2).
 
 
 -spec normalize_line({[T], [T], ?LEAF:type()}, monomorphic_variables(), S) -> 
@@ -90,37 +89,36 @@ phi_norm(BigS, [], Fixed, ST) ->
     {[], ST}, 
     BigS);
 phi_norm(BigS, [Ty | N], Fixed, ST) ->
-  Solve = fun({Index, {_PComponent, NComponent}}, {Result, ST00}) -> % FIXME shortcut
-    % TODO can be implemented easier with new Erlang list zipper &&
-    % remove pi_Index(NegativeComponents) from pi_Index(PComponents) and continue searching
-    DoDiff = 
-      fun({IIndex, PComp}) -> 
-        case IIndex of 
-          Index -> ty_node:difference(PComp, NComponent); 
-          _ -> PComp 
-        end
-      end,
-    % elp:ignore W0033
-    NewBigS = lists:map(DoDiff, lists:zip(lists:seq(1, length(BigS)), BigS)),
-    {Res01, ST01} = phi_norm(NewBigS, N, Fixed, ST00),
-    {constraint_set:meet(Result, Res01, Fixed), ST01}
-          end,
-
   {R1, ST0} = lists:foldl(
-    fun(S, {R2, ST2}) -> 
+    fun(S, {R2, ST2}) ->
       {R3, ST3} = ty_node:normalize(S, Fixed, ST2),
       {constraint_set:join(R2, R3, Fixed), ST3}
-    end, 
-    {[], ST}, 
+    end,
+    {[], ST},
     BigS),
 
   {R4, ST4} = lists:foldl(
-    Solve, 
-    {[[]], ST0}, 
+    fun(E, Acc) -> phi_norm_solve(E, Acc, N, BigS, Fixed) end,
+    {[[]], ST0},
     lists:zip(lists:seq(1, length(ty_tuple:components(Ty))), lists:zip(BigS, ty_tuple:components(Ty)))
   ),
 
   {constraint_set:join(R1, R4, Fixed), ST4}.
+
+-spec phi_norm_solve({integer(), {ty_node:type(), ty_node:type()}}, {set_of_constraint_sets(), S}, [?ATOM:type()], [ty_node:type()], monomorphic_variables()) ->
+    {set_of_constraint_sets(), S} when S :: normalize_cache().
+phi_norm_solve({Index, {_PComponent, NComponent}}, {Result, ST00}, N, BigS, Fixed) ->
+    % remove pi_Index(NegativeComponents) from pi_Index(PComponents) and continue searching
+    DoDiff =
+      fun({IIndex, PComp}) ->
+        case IIndex of
+          Index -> ty_node:difference(PComp, NComponent);
+          _ -> PComp
+        end
+      end,
+    NewBigS = lists:map(DoDiff, lists:zip(lists:seq(1, length(BigS)), BigS)),
+    {Res01, ST01} = phi_norm(NewBigS, N, Fixed, ST00),
+    {constraint_set:meet(Result, Res01, Fixed), ST01}.
 
 -spec all_variables_line([T], [T], ?LEAF:type(), all_variables_cache()) -> 
     sets:set(variable()) when T :: ?ATOM:type().

--- a/src/erlang_types/ty_map.erl
+++ b/src/erlang_types/ty_map.erl
@@ -94,7 +94,7 @@ unparse_tuple_part_dnf(TyTupPart, ST) ->
     TDnf = dnf_ty_tuple:minimize_dnf(dnf_ty_tuple:dnf(TuplesDnf)),
 
     % negative part should be empty always, and only a single positive tuple remaining
-    ToUnparse = lists:map(fun({[PosTup], [], 1}) -> PosTup;(_) -> error(badarg) end, TDnf), %[PosTup || {[PosTup], [], 1} <- TDnf], 
+    ToUnparse = [PosTup || {[PosTup], [], 1} <- TDnf],
     unparse_tuple_part_dnf_unparse(ToUnparse, ST).
 
 -spec unparse_tuple_part_dnf_unparse([ty_tuple:type()], S) -> {{union, [ast:ty_tuple()]}, S} when S :: unparse_cache().

--- a/src/erlang_types/ty_parser.erl
+++ b/src/erlang_types/ty_parser.erl
@@ -69,6 +69,54 @@
 -type local_cache() :: #{ast:ty_mu_var() | {Ref :: ety_ref(), Args :: ety_args()} => temporary_ref()}.
 -type queue() :: queue:queue({temporary_ref(), ast_ty()}).
 
+% Subset types for split do_convert helpers.
+-type ast_ty_predef() :: ast:ty_singleton() | ast:ty_bitstring() | ast:ty_some_list()
+    | ast:ty_fun() | ast:ty_integer_range() | ast:ty_map_any() | ast:ty_map()
+    | ast:ty_predef() | ast:ty_predef_alias()
+    | ast:ty_tuple_any() | ast:ty_tuple() | ast:ty_var()
+    | ast:ty_union() | ast:ty_intersection() | ast:ty_negation().
+-type ast_ty_compound() :: ast:ty_cons() | ast:ty_list() | ast:ty_nonempty_list()
+    | ast:ty_improper_list() | ast:ty_nonempty_improper_list()
+    | ast:ty_full_fun() | ast:ty_map() | ast:ty_tuple()
+    | ast:ty_var() | ast:ty_union() | ast:ty_intersection() | ast:ty_negation().
+-type ast_ty_rewrite() :: ast:ty_cons() | ast:ty_list() | ast:ty_nonempty_list()
+    | ast:ty_improper_list() | ast:ty_nonempty_improper_list()
+    | ast:ty_full_fun() | ast:ty_map() | ast:ty_tuple()
+    | ast:ty_var().
+-type ast_ty_rewrite_list() :: ast:ty_cons() | ast:ty_list() | ast:ty_nonempty_list()
+    | ast:ty_improper_list() | ast:ty_nonempty_improper_list()
+    | ast:ty_full_fun() | ast:ty_map() | ast:ty_tuple().
+-type ast_ty_rewrite_map() :: ast:ty_cons() | ast:ty_improper_list()
+    | ast:ty_full_fun() | ast:ty_map() | ast:ty_tuple().
+-type ast_ty_data() :: ast:ty_cons() | ast:ty_improper_list()
+    | ast:ty_full_fun() | ast:ty_tuple().
+% Subset types for debruijn helpers
+-type ast_ty_db1() :: ast:ty_singleton() | ast:ty_bitstring() | ast:ty_some_list()
+    | ast:ty_fun() | ast:ty_integer_range() | ast:ty_map_any() | ast:ty_map()
+    | ast:ty_predef() | ast:ty_predef_alias() | ast:ty_named()
+    | ast:ty_tuple_any() | ast:ty_tuple() | ast:ty_var()
+    | ast:ty_union() | ast:ty_intersection() | ast:ty_negation().
+-type ast_ty_db2() :: ast:ty_nonempty_list() | ast:ty_improper_list() | ast:ty_nonempty_improper_list()
+    | ast:ty_fun() | ast:ty_integer_range() | ast:ty_map_any() | ast:ty_map()
+    | ast:ty_predef() | ast:ty_predef_alias() | ast:ty_named()
+    | ast:ty_tuple_any() | ast:ty_tuple() | ast:ty_var()
+    | ast:ty_union() | ast:ty_intersection() | ast:ty_negation().
+-type ast_ty_db3() :: ast:ty_integer_range() | ast:ty_map_any() | ast:ty_map()
+    | ast:ty_predef() | ast:ty_predef_alias() | ast:ty_named()
+    | ast:ty_tuple_any() | ast:ty_tuple() | ast:ty_var()
+    | ast:ty_union() | ast:ty_intersection() | ast:ty_negation().
+-type ast_ty_db4() :: ast:ty_tuple_any() | ast:ty_tuple() | ast:ty_var()
+    | ast:ty_union() | ast:ty_intersection() | ast:ty_negation().
+% Subset types for convert_back helpers
+-type ast_ty_cb_other() :: ast:ty_singleton() | ast:ty_bitstring() | ast:ty_some_list()
+    | ast:ty_fun() | ast:ty_integer_range() | ast:ty_map_any() | ast:ty_map()
+    | ast:ty_predef() | ast:ty_predef_alias() | ast:ty_named()
+    | ast:ty_tuple_any() | ast:ty_negation().
+-type ast_ty_cb_rest() :: ast:ty_singleton() | ast:ty_bitstring() | ast:ty_empty_list()
+    | ast:ty_fun() | ast:ty_integer_range() | ast:ty_map_any() | ast:ty_map()
+    | ast:ty_predef() | ast:ty_predef_alias() | ast:ty_named()
+    | ast:ty_tuple_any() | ast:ty_negation().
+
 % global state
 -spec init() -> _.
 init() ->
@@ -89,7 +137,8 @@ clean() ->
 -spec set_symtab(symtab:t()) -> _.
 set_symtab(SymTab) ->
   Types = symtab:get_types(SymTab),
-  maps:foreach(fun(K, V) -> ty_parser:extend_symtab(K, V) end, Types).
+  % elp:ignore W0034
+  [ty_parser:extend_symtab(K, V) || {K, V} <- maps:to_list(Types)].
 
 -spec lookup_ref(temporary_ref()) -> type(). 
 lookup_ref(Ref) ->
@@ -121,169 +170,180 @@ parse(RawTy) ->
     [{LocalRef, Node}] ->
       Node;
     _ ->
-      % 1. Convert to temporary local representation
-      %    Create a temporary type equation with a first entrypoint LocalRef = ...
-      %    and parse the type layer by layer
-      %    use local type references stored in a local map
-      ({{NewR, NewTUnsorted}, _NewCache}) = convert(queue:from_list([{LocalRef, Ty}]), {_RefToTy = #{}, _TyToRef = #{}}, #{}),
-      % can have duplicates, e.g. TODO explain
-      NewT = #{K => lists:usort(V) || K := V <- NewTUnsorted},
-      % io:format(user,"Result of Converting:~n~p~n~p~n", [NewR, NewT]),
-
-      % 2. (Locally) unify the results
-      %    There can be many duplicate type references;
-      %    these will be substituted with their representative
-      %    e.g. any U any    any          type to parse
-      %         ref1         ref2         local temporary references
-      %         internal1    internal1    internal type representations
-      %    replace all ref2 by ref1, so that no unecessary nodes are created
-      {UnifiedRef, UnifiedResult} = unify(LocalRef, {NewR, NewT}),
-      % io:format(user,"Unified:~n~p~n", [{UnifiedRef, UnifiedResult}]),
-
-      % 3. create new type references and replace temporary ones
-      %    return result reference
-      ReplaceRefs = maps:from_list([{Ref, lookup_ref(Ref)} || Ref <- lists:sort(maps:keys(UnifiedResult))]),
-      assert_replaced_refs_have_good_order(ReplaceRefs),
-      {ReplacedRef, ReplacedResultsRaw} = utils:replace({UnifiedRef, UnifiedResult}, ReplaceRefs),
-      % trigger a reorder
-      % might contain duplicate nodes (hash consed) and not reordered properly
-      % e.g. {node, {ty_tuple,1,[{local_ref,-1}]}, {leaf,1}, {node, {ty_tuple,1,[{local_ref,-1}]}, {leaf,1}, {leaf,0}}}}}
-      % where the second -1 ref was a -2 ref before, mapping to a same type
-      ReplacedResults = maps:map(fun(_, V) -> dnf_ty_variable:reorder(V) end, ReplacedResultsRaw),
-      % io:format(user,"Replaced:~n~p~n", [ReplacedResults]),
-
-      % 4. define types
-      % 4.1 create a graph, a reverse graph, a condensed graph, then topological sort, then define and replace if already consed
-      Graph = #{K => lists:usort(V) || K := V <- #{Ref => collect_refs(Ref, ReplacedResults) || Ref := _ <- ReplacedResults}},
-      RevGraph = tarjan:reverse_graph(Graph),
-
-      {Scc, Condensed} = tarjan:condense(Graph),
-
-      Components = lists:foldl(fun({Node, Root}, Acc) ->
-        maps:update_with(Root, fun(Nodes) -> [Node | Nodes] end, [Node], Acc)
-      end, #{}, lists:sort(maps:to_list(Scc))),
-
-      Sort = tarjan:dfs(Condensed),
-      Define = [maps:get(T, Components) || T <- Sort],
-
-
-      DefineAndReplace = fun({{ReplacedRef1, RefMapping, ResultMapping, LocalDefinitions}, Def, Rest}) -> 
-        {NewReplacedRef, NewRef, NewRes, NewLocalDefinitions, NewRest} = lists:foldl(fun(DefineOrReplace, Acc = {ReplacedRef0, Refmapping, ResultMapping0, LocalDefinitions0, Rest0}) ->
-          case ?NODE:is_defined(DefineOrReplace) of
-            true -> % from previous parsing runs
-              Acc;
-            false ->
-              ToDefineTy = maps:get(DefineOrReplace, ResultMapping0),
-              case is_consed(ToDefineTy, LocalDefinitions0) of
-                {true, N} ->
-                  ToDefine = DefineOrReplace,
-
-                  NodeContainedIn = maps:get(ToDefine, RevGraph, []),
-
-                  NewRefmapping = #{K => case V of ToDefine -> N; _ -> V end || K := V <- Refmapping},
-
-                  % remove ToDefine from result mapping, its already consed
-                  SmallerResultMapping = maps:remove(ToDefine, ResultMapping0),
-
-                  FinalResultMapping = lists:foldl(fun(E, Acc0) ->
-                    case maps:find(E, Acc0) of
-                      error ->
-                        % E was already consed/removed in a prior step within this SCC
-                        Acc0;
-                      {ok, Val} ->
-                        dnf_ty_variable:assert_valid(Val),
-
-                        % just a syntactical replacement is not valid here
-                        % e.g. replacing {node, 80} by {node, 1}
-                        % might need to trigger a reorder of the BDD
-                        % also, remove duplicate nodes after local unification
-                        Fin = utils:replace(Val, #{ToDefine => N}),
-                        dnf_ty_variable:assert_valid(FinalReordered = dnf_ty_variable:reorder(Fin)),
-                        Acc0#{E => FinalReordered}
-                    end
-                  end, SmallerResultMapping, NodeContainedIn),
-
-                  NewReplacedRef = case ReplacedRef0 of ToDefine -> N; _ -> ReplacedRef0 end,
-
-                  {NewReplacedRef, NewRefmapping, FinalResultMapping, LocalDefinitions0, Rest0};
-                false ->
-                  % so this can happen with recursive types:
-                  % the ty_rec is already consed,
-                  % but the reference has been used already in a previous definition.
-                  % Ideally, we don't want to define this reference.
-                  % But we need to, since this reference is used in another definition already (in this local parse)
-                  % We don't want to touch anything that has been defined already (globally),
-                  % so we need to prevent this case from happening in the first place.
-                  % The problem is that local unification is not smart enough to merge these two type references in one pass:
-                  % 
-                  % {local_ref,-576460752303423167} => ... {ty_function, [{local_ref,-576460752303423071}], {local_ref,-576460752303423231}} ...
-                  % {local_ref,-576460752303423135} => ... {ty_function, [{local_ref,-576460752303423071}], {local_ref,-576460752303423231}} ...
-                  % 
-                  % Which (before and) after replacement point to the same records
-                  % 
-                  % {node,3} => ... {ty_function,[{node,6}],{node,1}} ...
-                  % {node,4} => ... {ty_function,[{node,6}],{node,1}} ...
-                  % 
-                  % Therefore, we don't define the types globally, but locally first
-                  % and remove the duplicates once a consed match is detected
-                  {ReplacedRef0, Refmapping, ResultMapping0, LocalDefinitions0#{ToDefineTy => DefineOrReplace}, Rest0}
-              end
-            end
-          end, {ReplacedRef1, RefMapping, ResultMapping, LocalDefinitions, Rest}, Def),
-
-      {{NewReplacedRef, NewRef, NewRes, NewLocalDefinitions}, NewRest}
-    end,
-
-    % Modifying the context is not needed
-    % TODO refactor
-    {FinalReplacedRef, FinalReplaceRefs, FinalReplacedResults, _FinalLocalDefinitions} = utils:fold_with_context(DefineAndReplace, {ReplacedRef, ReplaceRefs, ReplacedResults, _LocalDefinitions = #{}}, Define),
-    % io:format(user,"Final: ~p~n", [FinalReplacedResults]),
-
-    % define the final results globally
-    [?NODE:define(NodeRef, Record) || NodeRef := Record <- FinalReplacedResults, is_not_defined(NodeRef, Record)],
-
-    % 5. update global cache, there are now old entries to overwrite
-    %    this invariant has to be kept up inside do_convert
-    %    whenever a new reference is created with new_local_ref(...),
-    %    we need to check the global cache if that reference does not already point
-    %    to a real node inside the global system
-    %    the true = ... check is a sanity check
-    %    if somethings has been inserted before, it had to be Node already
-    [case ets:insert_new(?CACHE, {LLocalRef, Node}) of
-       true -> ok;
-       false -> [{LLocalRef, Node}] = ets:lookup(?CACHE, LLocalRef), ok
-     end
-     || LLocalRef := Node <- FinalReplaceRefs],
-
-    % sanity check: all references should be defined
-    % [ty_node:dump(Node) || _LLocalRef := Node <- FinalReplaceRefs],
-      
-    FinalReplacedRef
+      parse_convert(LocalRef, Ty)
   end,
-  
+
   % generate the reverse named mapping at the end
-  InQueue = ets:tab2list(?UNPARSE_NAMED_QUEUE),
-  lists:foreach(
-    fun({N, _}) -> 
-      case ets:lookup(?UNPARSE_NAMED_FINISHED, N) of 
-        [] -> 
-          ets:insert(?UNPARSE_NAMED_FINISHED, {N, []}),
-          ets:delete(?UNPARSE_NAMED_QUEUE, N),
-          Mapping = parse(N),
-          case ets:insert_new(?UNPARSE_NAMED_MAPPING, {Mapping, N}) of
-            true -> 
-              % io:format(user, "Created reverse mapping for ~w :: ~w~n", [Mapping, N]),
-              ok;
-            _ -> 
-              % [{Mapping, OldNode}] = ets:lookup(?UNPARSE_NAMED_MAPPING, Mapping), 
-              % io:format(user, "Warning: ~p maps to a node that already has a reverse mapping:~n~p~n", [N, OldNode]),
-              ok
-          end;
-        _ -> ok 
-      end 
-    end, InQueue),
+  parse_named_mapping(),
 
   FinalResult.
+
+-spec parse_convert(temporary_ref(), ast_ty()) -> type().
+parse_convert(LocalRef, Ty) ->
+  % 1. Convert to temporary local representation
+  %    Create a temporary type equation with a first entrypoint LocalRef = ...
+  %    and parse the type layer by layer
+  %    use local type references stored in a local map
+  ({{NewR, NewTUnsorted}, _NewCache}) = convert(queue:from_list([{LocalRef, Ty}]), {_RefToTy = #{}, _TyToRef = #{}}, #{}),
+  % can have duplicates, e.g. TODO explain
+  NewT = #{K => lists:usort(V) || K := V <- NewTUnsorted},
+  % io:format(user,"Result of Converting:~n~p~n~p~n", [NewR, NewT]),
+
+  % 2. (Locally) unify the results
+  %    There can be many duplicate type references;
+  %    these will be substituted with their representative
+  %    e.g. any U any    any          type to parse
+  %         ref1         ref2         local temporary references
+  %         internal1    internal1    internal type representations
+  %    replace all ref2 by ref1, so that no unecessary nodes are created
+  {UnifiedRef, UnifiedResult} = unify(LocalRef, {NewR, NewT}),
+  % io:format(user,"Unified:~n~p~n", [{UnifiedRef, UnifiedResult}]),
+
+  % 3. create new type references and replace temporary ones
+  %    return result reference
+  ReplaceRefs = maps:from_list([{Ref, lookup_ref(Ref)} || Ref <- lists:sort(maps:keys(UnifiedResult))]),
+  assert_replaced_refs_have_good_order(ReplaceRefs),
+  {ReplacedRef, ReplacedResultsRaw} = utils:replace({UnifiedRef, UnifiedResult}, ReplaceRefs),
+  % trigger a reorder
+  % might contain duplicate nodes (hash consed) and not reordered properly
+  % e.g. {node, {ty_tuple,1,[{local_ref,-1}]}, {leaf,1}, {node, {ty_tuple,1,[{local_ref,-1}]}, {leaf,1}, {leaf,0}}}}}
+  % where the second -1 ref was a -2 ref before, mapping to a same type
+  ReplacedResults = maps:map(fun(_, V) -> dnf_ty_variable:reorder(V) end, ReplacedResultsRaw),
+  % io:format(user,"Replaced:~n~p~n", [ReplacedResults]),
+
+  % 4. define types
+  % 4.1 create a graph, a reverse graph, a condensed graph, then topological sort, then define and replace if already consed
+  Graph = #{K => lists:usort(V) || K := V <- #{Ref => collect_refs(Ref, ReplacedResults) || Ref := _ <- ReplacedResults}},
+  RevGraph = tarjan:reverse_graph(Graph),
+
+  {Scc, Condensed} = tarjan:condense(Graph),
+
+  Components = lists:foldl(fun({Node, Root}, Acc) ->
+    maps:update_with(Root, fun(Nodes) -> [Node | Nodes] end, [Node], Acc)
+  end, #{}, lists:sort(maps:to_list(Scc))),
+
+  Sort = tarjan:dfs(Condensed),
+  Define = [maps:get(T, Components) || T <- Sort],
+
+
+  DefineAndReplace = fun({{ReplacedRef1, RefMapping, ResultMapping, LocalDefinitions}, Def, Rest}) ->
+    {NewReplacedRef, NewRef, NewRes, NewLocalDefinitions, NewRest} = lists:foldl(fun(DefineOrReplace, Acc = {ReplacedRef0, Refmapping, ResultMapping0, LocalDefinitions0, Rest0}) ->
+      case ?NODE:is_defined(DefineOrReplace) of
+        true -> % from previous parsing runs
+          Acc;
+        false ->
+          ToDefineTy = maps:get(DefineOrReplace, ResultMapping0),
+          case is_consed(ToDefineTy, LocalDefinitions0) of
+            {true, N} ->
+              ToDefine = DefineOrReplace,
+
+              NodeContainedIn = maps:get(ToDefine, RevGraph, []),
+
+              NewRefmapping = #{K => case V of ToDefine -> N; _ -> V end || K := V <- Refmapping},
+
+              % remove ToDefine from result mapping, its already consed
+              SmallerResultMapping = maps:remove(ToDefine, ResultMapping0),
+
+              FinalResultMapping = lists:foldl(fun(E, Acc0) ->
+                case maps:find(E, Acc0) of
+                  error ->
+                    % E was already consed/removed in a prior step within this SCC
+                    Acc0;
+                  {ok, Val} ->
+                    dnf_ty_variable:assert_valid(Val),
+
+                    % just a syntactical replacement is not valid here
+                    % e.g. replacing {node, 80} by {node, 1}
+                    % might need to trigger a reorder of the BDD
+                    % also, remove duplicate nodes after local unification
+                    Fin = utils:replace(Val, #{ToDefine => N}),
+                    dnf_ty_variable:assert_valid(FinalReordered = dnf_ty_variable:reorder(Fin)),
+                    Acc0#{E => FinalReordered}
+                end
+              end, SmallerResultMapping, NodeContainedIn),
+
+              NewReplacedRef = case ReplacedRef0 of ToDefine -> N; _ -> ReplacedRef0 end,
+
+              {NewReplacedRef, NewRefmapping, FinalResultMapping, LocalDefinitions0, Rest0};
+            false ->
+              % so this can happen with recursive types:
+              % the ty_rec is already consed,
+              % but the reference has been used already in a previous definition.
+              % Ideally, we don't want to define this reference.
+              % But we need to, since this reference is used in another definition already (in this local parse)
+              % We don't want to touch anything that has been defined already (globally),
+              % so we need to prevent this case from happening in the first place.
+              % The problem is that local unification is not smart enough to merge these two type references in one pass:
+              %
+              % {local_ref,-576460752303423167} => ... {ty_function, [{local_ref,-576460752303423071}], {local_ref,-576460752303423231}} ...
+              % {local_ref,-576460752303423135} => ... {ty_function, [{local_ref,-576460752303423071}], {local_ref,-576460752303423231}} ...
+              %
+              % Which (before and) after replacement point to the same records
+              %
+              % {node,3} => ... {ty_function,[{node,6}],{node,1}} ...
+              % {node,4} => ... {ty_function,[{node,6}],{node,1}} ...
+              %
+              % Therefore, we don't define the types globally, but locally first
+              % and remove the duplicates once a consed match is detected
+              {ReplacedRef0, Refmapping, ResultMapping0, LocalDefinitions0#{ToDefineTy => DefineOrReplace}, Rest0}
+          end
+      end
+    end, {ReplacedRef1, RefMapping, ResultMapping, LocalDefinitions, Rest}, Def),
+
+  {{NewReplacedRef, NewRef, NewRes, NewLocalDefinitions}, NewRest}
+  end,
+
+  % Modifying the context is not needed
+  % TODO refactor
+  {FinalReplacedRef, FinalReplaceRefs, FinalReplacedResults, _FinalLocalDefinitions} = utils:fold_with_context(DefineAndReplace, {ReplacedRef, ReplaceRefs, ReplacedResults, _LocalDefinitions = #{}}, Define),
+  % io:format(user,"Final: ~p~n", [FinalReplacedResults]),
+
+  % define the final results globally
+  % elp:ignore W0034
+  [?NODE:define(NodeRef, Record) || NodeRef := Record <- FinalReplacedResults, is_not_defined(NodeRef, Record)],
+
+  % 5. update global cache, there are now old entries to overwrite
+  %    this invariant has to be kept up inside do_convert
+  %    whenever a new reference is created with new_local_ref(...),
+  %    we need to check the global cache if that reference does not already point
+  %    to a real node inside the global system
+  %    the true = ... check is a sanity check
+  %    if somethings has been inserted before, it had to be Node already
+  % elp:ignore W0034
+  [case ets:insert_new(?CACHE, {LLocalRef, Node}) of
+     true -> ok;
+     false -> [{LLocalRef, Node}] = ets:lookup(?CACHE, LLocalRef), ok
+   end
+   || LLocalRef := Node <- FinalReplaceRefs],
+
+  % sanity check: all references should be defined
+  % [ty_node:dump(Node) || _LLocalRef := Node <- FinalReplaceRefs],
+
+  FinalReplacedRef.
+
+-spec parse_named_mapping() -> ok.
+parse_named_mapping() ->
+  InQueue = ets:tab2list(?UNPARSE_NAMED_QUEUE),
+  lists:foreach(fun({N, _}) -> parse_named_mapping_entry(N) end, InQueue).
+
+-spec parse_named_mapping_entry(ast_ty()) -> ok.
+parse_named_mapping_entry(N) ->
+  case ets:lookup(?UNPARSE_NAMED_FINISHED, N) of
+    [] ->
+      ets:insert(?UNPARSE_NAMED_FINISHED, {N, []}),
+      ets:delete(?UNPARSE_NAMED_QUEUE, N),
+      Mapping = parse(N),
+      case ets:insert_new(?UNPARSE_NAMED_MAPPING, {Mapping, N}) of
+        true ->
+          % io:format(user, "Created reverse mapping for ~w :: ~w~n", [Mapping, N]),
+          ok;
+        _ ->
+          % [{Mapping, OldNode}] = ets:lookup(?UNPARSE_NAMED_MAPPING, Mapping),
+          % io:format(user, "Warning: ~p maps to a node that already has a reverse mapping:~n~p~n", [N, OldNode]),
+          ok
+      end;
+    _ -> ok
+  end.
 
 -spec is_not_defined(_, _) -> _.
 is_not_defined(Node, Rec) ->
@@ -392,7 +452,7 @@ new_local_ref(RawTerm) ->
 
   Final.
 
--spec extend_symtab(ety_ref(), ety_ty_scheme()) -> _. 
+-spec extend_symtab(ast:ty_ref(), ety_ty_scheme()) -> _.
 extend_symtab({_, Namespace, Type, ArgsCount}, RawTyScheme) ->
   Ref = {Namespace, Type, ArgsCount},
   % replace all locs 
@@ -400,7 +460,7 @@ extend_symtab({_, Namespace, Type, ArgsCount}, RawTyScheme) ->
   % io:format(user,"Extending symtab by ~p~n With scheme: ~p~n", [Ref, TyScheme]),
   ets:insert_new(?SYMTAB, {Ref, TyScheme}).
 
--spec lookup_ty(ety_ref()) -> ety_ty_scheme().
+-spec lookup_ty(ast:ty_qref() | ast:ty_ref()) -> ety_ty_scheme().
 lookup_ty({ty_qref, A, B, C}) ->
   Ref = {A, B, C},
   [{_, Scheme}] = ?assert_pattern([{_, _}], ets:lookup(?SYMTAB, Ref)),
@@ -417,7 +477,21 @@ group(M, Key, Value) ->
 
 % entrypoint for recursion: named type
 -spec do_convert({ast_ty(), database()}, queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
-do_convert({X = {named, _, Ref, Args}, R = {IdTy, _}}, Q, Cache) ->
+do_convert({X = {named, _, _Ref, _Args}, R}, Q, Cache) ->
+  do_convert_named(X, R, Q, Cache);
+% entrypoint for recursion: local equation
+do_convert({AstTy = {mu, _RecVar = {mu_var, _Name}, _Ty}, R}, Q, Cache) ->
+  do_convert_recursive(AstTy, R, Q, Cache);
+% exit for recursion: local equation variable
+do_convert({AstTy = {mu_var, _Name}, R}, Q, Cache) ->
+  do_convert_mu_var(AstTy, R, Q, Cache);
+% all other (non-named, non-mu) types
+do_convert({Ty, R}, Q, Cache) ->
+  do_convert_predef(?assert_type(Ty, ast_ty_predef()), R, Q, Cache).
+
+% --- named type ---
+-spec do_convert_named(ast:ty_named(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_named(X = {named, _, Ref, Args}, R = {IdTy, _}, Q, Cache) ->
   % add to create a reverse mapping between the internal result node and the named type
   case ets:lookup(?UNPARSE_NAMED_FINISHED, X) of
     [] -> ets:insert(?UNPARSE_NAMED_QUEUE, {X, []});
@@ -429,36 +503,44 @@ do_convert({X = {named, _, Ref, Args}, R = {IdTy, _}}, Q, Cache) ->
       #{NewRef := Ty} = IdTy,
       {Ty, Q, R, Cache};
     _ ->
-      % find ty in global table
-      % io:format(user,"Lookup ~p~n", [Ref]),
-      ({ty_scheme, Vars, Ty}) = lookup_ty(Ref),
+      do_convert_named_new(X, Ref, Args, R, Q, Cache)
+  end.
 
-      Map = subst:from_list(lists:zip([V || {V, _Bound} <- Vars], Args)),
-      % we can do this since recursive variables should not descend "into" a named type
-      NewTy = convert_back(debruijn(subst:apply(Map, Ty, no_clean))),
-      
-      % sanity
-      ?assert_pattern(false, maps:is_key({Ref, Args}, Cache)),
+-spec do_convert_named_new(ast:ty_named(), ety_ref(), ety_args(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_named_new(X, Ref, Args, R, Q, Cache) ->
+  % find ty in global table
+  % io:format(user,"Lookup ~p~n", [Ref]),
+  ({ty_scheme, Vars, Ty}) = lookup_ty(Ref),
 
-      NewRef = new_local_ref(X),
-      case ets:lookup(?CACHE, NewRef) of 
-        [] -> 
-          % create a new reference (ref args pair), memoize, and add continue converting
-          {InternalTy, NewQ, {R0, R1}, C0} = do_convert({NewTy, R}, Q, Cache#{{Ref, Args} => NewRef}),
-          {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}, C0};
-        [{NewRef, CachedNode}] -> 
-          % reuse type representation of the global cache
-          InternalTy = ?NODE:load(CachedNode),
-          {InternalTy, Q, R, Cache}
-      end
-  end;
+  Map = subst:from_list(lists:zip([V || {V, _Bound} <- Vars], Args)),
+  % we can do this since recursive variables should not descend "into" a named type
+  NewTy = convert_back(debruijn(subst:apply(Map, Ty, no_clean))),
 
-% entrypoint for recursion: local equation
-do_convert({AstTy = {mu, RecVar = {mu_var, Name}, Ty}, R}, Q, Cache) ->
+  % sanity
+  ?assert_pattern(false, maps:is_key({Ref, Args}, Cache)),
+
+  NewRef = new_local_ref(X),
+  case ets:lookup(?CACHE, NewRef) of
+    [] ->
+      % create a new reference (ref args pair), memoize, and add continue converting
+      {InternalTy, NewQ, {R0, R1}, C0} = do_convert({NewTy, R}, Q, Cache#{{Ref, Args} => NewRef}),
+      {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}, C0};
+    [{NewRef, CachedNode}] ->
+      % reuse type representation of the global cache
+      InternalTy = ?NODE:load(CachedNode),
+      {InternalTy, Q, R, Cache}
+  end.
+
+% --- recursive (mu) types ---
+-spec do_convert_recursive(ast:ty_mu(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_recursive(AstTy = {mu, RecVar = {mu_var, Name}, Ty}, R, Q, Cache) ->
   ?assert_pattern(true, is_atom(Name)),
+  do_convert_mu(AstTy, RecVar, Ty, R, Q, Cache).
 
+-spec do_convert_mu(ast:ty_mu(), ast:ty_mu_var(), ast_ty(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_mu(AstTy, RecVar, Ty, R, Q, Cache) ->
   NewRef = new_local_ref(AstTy),
-  % all binders should be unique, 
+  % all binders should be unique,
   % only binders with the same body are allowed to share the name
   case maps:is_key(RecVar, Cache) of
     false -> ok;
@@ -467,143 +549,171 @@ do_convert({AstTy = {mu, RecVar = {mu_var, Name}, Ty}, R}, Q, Cache) ->
   NewCache = Cache#{RecVar => NewRef},
   {InternalTy, NewQ, {R0, R1}, C0} = do_convert({Ty, R}, Q, NewCache),
   % return record
-  {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}, C0};
+  {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}, C0}.
 
-% exit for recursion: local equation variable
-do_convert({AstTy = {mu_var, Name}, R = {IdTy, _}}, Q, Cache) ->
+% --- mu_var ---
+-spec do_convert_mu_var(ast:ty_mu_var(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_mu_var(AstTy = {mu_var, Name}, R = {IdTy, _}, Q, Cache) ->
   ?assert_pattern(true, is_atom(Name)),
 
   #{AstTy := Ref} = Cache,
   % We are allowed to load the memoized ref
   % because the second occurrence of the mu variable
-  % is below a type constructor, 
+  % is below a type constructor,
   % i.e. the memoized reference is fully defined
   #{Ref := Ty} = IdTy,
-  {Ty, Q, R, Cache};
- 
-% built-ins
-do_convert({{predef, dynamic}, R}, Q, Cache) -> {?TY:singleton(ty_variable:new_as_frame()), Q, R, Cache};
-do_convert({{predef, any}, R}, Q, Cache) -> {?TY:any(), Q, R, Cache};
-do_convert({{predef, none}, R}, Q, Cache) -> {?TY:empty(), Q, R, Cache};
-do_convert({{predef, atom}, R}, Q, Cache) -> {?TY:atom(dnf_ty_atom:any()), Q, R, Cache};
-do_convert({{predef, integer}, R}, Q, Cache) -> {?TY:interval(dnf_ty_interval:any()), Q, R, Cache};
-do_convert({{predef_alias, Alias}, R}, Q, Cache) -> do_convert({stdtypes:expand_predef_alias(Alias), R}, Q, Cache);
+  {Ty, Q, R, Cache}.
 
-% predefined
-do_convert({{fun_simple}, R}, Q, Cache) -> {?TY:functions(ty_functions:any()), Q, R, Cache};
-do_convert({{tuple_any}, R}, Q, Cache) -> {?TY:tuples(ty_tuples:any()), Q, R, Cache};
-do_convert({{empty_list}, R}, Q, Cache) -> {?TY:predefined(dnf_ty_predefined:predefined('[]')), Q, R, Cache};
-do_convert({{predef, T}, R}, Q, Cache) when T == pid; T == port; T == reference; T == float ->
-  {?TY:predefined(dnf_ty_predefined:predefined(T)), Q, R, Cache};
-do_convert({{map_any}, R}, Q, Cache) ->
-  {?TY:map(dnf_ty_map:any()), Q, R, Cache};
+% --- predef types (built-ins, literals, boolean ops, variables, rewrites, data) ---
+-spec do_convert_predef(ast_ty_predef(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_predef({predef, dynamic}, R, Q, Cache) -> {?TY:singleton(ty_variable:new_as_frame()), Q, R, Cache};
+do_convert_predef({predef, any}, R, Q, Cache) -> {?TY:any(), Q, R, Cache};
+do_convert_predef({predef, none}, R, Q, Cache) -> {?TY:empty(), Q, R, Cache};
+do_convert_predef({predef, atom}, R, Q, Cache) -> {?TY:atom(dnf_ty_atom:any()), Q, R, Cache};
+do_convert_predef({predef, integer}, R, Q, Cache) -> {?TY:interval(dnf_ty_interval:any()), Q, R, Cache};
+do_convert_predef({predef_alias, Alias}, R, Q, Cache) -> do_convert({stdtypes:expand_predef_alias(Alias), R}, Q, Cache);
+do_convert_predef({predef, T}, R, Q, Cache) when T == pid; T == port; T == reference; T == float ->
+  do_convert_predef_atom(T, R, Q, Cache);
+do_convert_predef(Ty, R, Q, Cache) ->
+  do_convert_builtin(?assert_type(Ty, ast_ty_compound()), R, Q, Cache).
 
-% bitstrings
-do_convert({{bitstring}, R}, Q, Cache) ->
-  {?TY:bitstring(dnf_ty_bitstring:any()), Q, R, Cache};
+-spec do_convert_predef_atom(atom(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_predef_atom(T, R, Q, Cache) ->
+  {?TY:predefined(dnf_ty_predefined:predefined(T)), Q, R, Cache}.
 
-% atoms
-do_convert({{singleton, Atom}, R}, Q, Cache) when is_atom(Atom) ->
+% --- builtin types ---
+-spec do_convert_builtin(ast_ty_compound(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_builtin({fun_simple}, R, Q, Cache) -> {?TY:functions(ty_functions:any()), Q, R, Cache};
+do_convert_builtin({tuple_any}, R, Q, Cache) -> {?TY:tuples(ty_tuples:any()), Q, R, Cache};
+do_convert_builtin({empty_list}, R, Q, Cache) -> {?TY:predefined(dnf_ty_predefined:predefined('[]')), Q, R, Cache};
+do_convert_builtin({map_any}, R, Q, Cache) -> {?TY:map(dnf_ty_map:any()), Q, R, Cache};
+do_convert_builtin({bitstring}, R, Q, Cache) -> {?TY:bitstring(dnf_ty_bitstring:any()), Q, R, Cache};
+do_convert_builtin(Ty, R, Q, Cache) ->
+  do_convert_literal(Ty, R, Q, Cache).
+
+% --- literal types (atoms, integers, ranges) ---
+-spec do_convert_literal(ast_ty_compound(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_literal({singleton, Atom}, R, Q, Cache) when is_atom(Atom) ->
   TAtom = dnf_ty_atom:finite([Atom]),
   {?TY:atom(TAtom), Q, R, Cache};
-
-% intervals
-do_convert({{singleton, I}, R}, Q, Cache) when is_integer(I) ->
+do_convert_literal({singleton, I}, R, Q, Cache) when is_integer(I) ->
   Int = dnf_ty_interval:interval(I, I),
   {?TY:interval(Int), Q, R, Cache};
-do_convert({{range, From, To}, R}, Q, Cache) ->
+do_convert_literal({range, From, To}, R, Q, Cache) ->
   Int = dnf_ty_interval:interval(From, To),
   {?TY:interval(Int), Q, R, Cache};
+do_convert_literal(Ty, R, Q, Cache) ->
+  do_convert_compound(Ty, R, Q, Cache).
 
-% boolean operators
-do_convert({{union, []}, R}, Q, Cache) -> {?TY:empty(), Q, R, Cache};
-do_convert({{union, [A]}, R}, Q, Cache) -> do_convert({A, R}, Q, Cache);
-do_convert({{union, [A|T]}, R}, Q, Cache) -> 
-  {R1, Q1, RR1, C1} = do_convert({A, R}, Q, Cache),
-  {R2, Q2, RR2, C2} = do_convert({{union, T}, RR1}, Q1, C1),
-  {?TY:union(R1, R2), Q2, RR2, C2};
-
-do_convert({{intersection, []}, R}, Q, Cache) -> {?TY:any(), Q, R, Cache};
-do_convert({{intersection, [A]}, R}, Q, Cache) -> do_convert({A, R}, Q, Cache);
-do_convert({{intersection, [A|T]}, R}, Q, Cache) -> 
-  {R1, Q1, RR0, C0} = do_convert({A, R}, Q, Cache),
-  {R2, Q2, RR1, C1} = do_convert({{intersection, T}, RR0}, Q1, C0),
-  {?TY:intersect(R1, R2), Q2, RR1, C1};
-
-do_convert({{negation, Ty}, R}, Q, Cache) -> 
+% --- compound types (boolean ops, variables, rewrites, data) ---
+-spec do_convert_compound(ast_ty_compound(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_compound({union, Args}, R, Q, Cache) ->
+  do_convert_union(Args, R, Q, Cache);
+do_convert_compound({intersection, Args}, R, Q, Cache) ->
+  do_convert_intersect(Args, R, Q, Cache);
+do_convert_compound({negation, Ty}, R, Q, Cache) ->
   {NewR, Q0, RR0, C0} = do_convert({Ty, R}, Q, Cache),
   {?TY:negate(NewR), Q0, RR0, C0};
-
-% variables
-do_convert({{var, A}, R}, Q, Cache) ->
+do_convert_compound({var, A}, R, Q, Cache) ->
   % if this is a special $ety_integer()_name() variable, convert to that representation
-  case string:prefix(atom_to_list(A), "$ety_") of 
-    nomatch -> 
+  case string:prefix(atom_to_list(A), "$ety_") of
+    nomatch ->
       {?TY:singleton(ty_variable:new_with_name(A)), Q, R, Cache};
-    IdName -> 
+    IdName ->
       % TODO test case for this branch
       % assumption: erlang types generates variables only in this pattern: $ety_integer()_name()
       [Id, Name] = string:split(IdName, "_"),
       {?TY:singleton(ty_variable:with_name_and_id(list_to_integer(Id), list_to_atom(Name))), Q, R, Cache}
   end;
+do_convert_compound(Ty, R, Q, Cache) ->
+  do_convert_rewrite(?assert_type(Ty, ast_ty_rewrite()), R, Q, Cache).
+
+-spec do_convert_union([ast_ty()], database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_union([], R, Q, Cache) -> {?TY:empty(), Q, R, Cache};
+do_convert_union([A], R, Q, Cache) -> do_convert({A, R}, Q, Cache);
+do_convert_union([A|T], R, Q, Cache) ->
+  {R1, Q1, RR1, C1} = do_convert({A, R}, Q, Cache),
+  {R2, Q2, RR2, C2} = do_convert_union(T, RR1, Q1, C1),
+  {?TY:union(R1, R2), Q2, RR2, C2}.
+
+-spec do_convert_intersect([ast_ty()], database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_intersect([], R, Q, Cache) -> {?TY:any(), Q, R, Cache};
+do_convert_intersect([A], R, Q, Cache) -> do_convert({A, R}, Q, Cache);
+do_convert_intersect([A|T], R, Q, Cache) ->
+  {R1, Q1, RR0, C0} = do_convert({A, R}, Q, Cache),
+  {R2, Q2, RR1, C1} = do_convert_intersect(T, RR0, Q1, C0),
+  {?TY:intersect(R1, R2), Q2, RR1, C1}.
 
 % === term rewrites
-do_convert({{nonempty_list, Ty}, R}, Q, Cache) ->
-  do_convert({{cons, Ty, {list, Ty}} , R}, Q, Cache);
-do_convert({{nonempty_improper_list, Ty, Term}, R}, Q, Cache) ->
-  do_convert({{cons, Ty, {improper_list, Ty, Term}} , R}, Q, Cache);
-do_convert({{list, Ty}, R}, Q, Cache) ->
-  do_convert({{improper_list, Ty, {empty_list}}, R}, Q, Cache);
+-spec do_convert_rewrite(ast_ty_rewrite(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_rewrite({nonempty_list, Ty}, R, Q, Cache) ->
+  do_convert_rewrite_list({cons, Ty, {list, Ty}}, R, Q, Cache);
+do_convert_rewrite({nonempty_improper_list, Ty, Term}, R, Q, Cache) ->
+  do_convert_rewrite_list({cons, Ty, {improper_list, Ty, Term}}, R, Q, Cache);
+do_convert_rewrite({list, Ty}, R, Q, Cache) ->
+  do_convert_rewrite_list({improper_list, Ty, {empty_list}}, R, Q, Cache);
+do_convert_rewrite(Ty, R, Q, Cache) ->
+  do_convert_rewrite_list(?assert_type(Ty, ast_ty_rewrite_list()), R, Q, Cache).
+
+-spec do_convert_rewrite_list(ast_ty_rewrite_list(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_rewrite_list(M = {map, _}, R, Q, Cache) ->
+  do_convert_rewrite_map(M, R, Q, Cache);
+do_convert_rewrite_list(Ty, R, Q, Cache) ->
+  do_convert_rewrite_map(?assert_type(Ty, ast_ty_rewrite_map()), R, Q, Cache).
 
 % rewrite maps into {Tuple, Function} tuples
-do_convert({M = {map, _}, R}, Q, Cache) ->
+-spec do_convert_rewrite_map(ast_ty_rewrite_map(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
+do_convert_rewrite_map(M = {map, _}, R, Q, Cache) ->
   MapTuple = rewrite_map_to_representation(M),
   {Recc, Q0, R0, C0} = do_convert({MapTuple, R}, Q, Cache),
   {?TY:tuple_to_map(Recc), Q0, R0, C0};
+do_convert_rewrite_map(Ty, R, Q, Cache) ->
+  do_convert_data(?assert_type(Ty, ast_ty_data()), R, Q, Cache).
 
-% === nested data structures 
+% === nested data structures
 % === these can potentially create temporary references and can extend the queue
- 
+-spec do_convert_data(ast_ty_data(), database(), queue(), local_cache()) -> {ty_rec(), queue(), database(), local_cache()}.
 % functions
-do_convert({{fun_full, Domains, CoDomain}, R}, Q, Cache) ->
-  {ParsedDomains, Q0} = lists:foldl(
-    fun(Element, {Components, OldQ}) ->
-      {IdOrNode, QQ} = queue_if_new(Element, OldQ),
-      {Components ++ [IdOrNode], QQ}
-   end, {[], Q}, Domains),
+do_convert_data({fun_full, Domains, CoDomain}, R, Q, Cache) ->
+  {ParsedDomains, Q0} = queue_all(Domains, Q),
 
   {ParsedCoDomain, Q1} = queue_if_new(CoDomain, Q0),
-    
+
   T = ty_functions:singleton(length(Domains), dnf_ty_function:singleton(ty_function:function(ParsedDomains, ParsedCoDomain))),
   {?TY:functions(T), Q1, R, Cache};
 
 % tuples
-do_convert({{tuple, Comps}, R}, Q, Cache) ->
-  {ParsedComponents, Q0} = lists:foldl(
-    fun(Element, {Components, OldQ}) ->
-      {IdOrNode, QQ} = queue_if_new(Element, OldQ),
-      {Components ++ [IdOrNode], QQ}
-    end, {[], Q}, Comps),
-    
+do_convert_data({tuple, Comps}, R, Q, Cache) ->
+  {ParsedComponents, Q0} = queue_all(Comps, Q),
+
   T = ty_tuples:singleton(length(Comps), dnf_ty_tuple:singleton(ty_tuple:tuple(ParsedComponents))),
   {?TY:tuples(T), Q0, R, Cache};
 
 % lists
-do_convert({{improper_list, A, B}, R}, Q, Cache) ->
+do_convert_data({improper_list, A, B}, R, Q, Cache) ->
   RVar = {mu_var, list_to_atom(integer_to_list(erlang:unique_integer()))},
   NewTerm = {mu, RVar, {union, [B, {cons, A, RVar}]}},
   do_convert({NewTerm, R}, Q, Cache);
-do_convert({{cons, A, B}, R}, Q, Cache) ->
+do_convert_data({cons, A, B}, R, Q, Cache) ->
   {T1, Q0} = queue_if_new(A, Q),
   {T2, Q1} = queue_if_new(B, Q0),
-    
+
   {?TY:list(dnf_ty_list:singleton(ty_list:list([T1, T2]))), Q1, R, Cache};
 
-% maps 
+do_convert_data(T, _R, _Q, _Cache) ->
+  convert_error(T).
 
-do_convert(T, _Q, _) ->
-  % io:format(user,"~p~n", [T]),
+-spec convert_error(_) -> no_return().
+convert_error(T) ->
   erlang:error({"Transformation from ast:ty() to ty_rec:ty() not implemented or malformed type", T}).
+
+-spec queue_all([ast_ty()], queue()) -> {[type() | temporary_ref()], queue()}.
+queue_all(Elements, Q) ->
+  lists:foldl(
+    fun(Element, {Components, OldQ}) ->
+      {IdOrNode, QQ} = queue_if_new(Element, OldQ),
+      {Components ++ [IdOrNode], QQ}
+    end, {[], Q}, Elements).
 
 -spec queue_if_new(ast_ty(), queue()) -> {type() | temporary_ref(), queue()}.
 queue_if_new(Element, Queue) ->
@@ -682,31 +792,43 @@ debruijn({bitstring}, _Env) -> {bitstring};
 debruijn({empty_list}, _Env) -> {empty_list};
 debruijn({cons, U, L}, Env) -> {cons, debruijn(U, Env), debruijn(L, Env)};
 debruijn({list, U}, Env) -> {list, debruijn(U, Env)};
-debruijn({nonempty_list, U}, Env) -> {nonempty_list, debruijn(U, Env)};
-debruijn({improper_list, U, V}, Env) -> 
+debruijn(Ty, Env) -> debruijn_1(?assert_type(Ty, ast_ty_db1()), Env).
+
+-spec debruijn_1(ast_ty_db1(), var_env()) -> ast_ty().
+debruijn_1({nonempty_list, U}, Env) -> {nonempty_list, debruijn(U, Env)};
+debruijn_1({improper_list, U, V}, Env) ->
   {improper_list, debruijn(U, Env), debruijn(V, Env)};
-debruijn({nonempty_improper_list, U, V}, Env) -> 
+debruijn_1({nonempty_improper_list, U, V}, Env) ->
   {nonempty_improper_list, debruijn(U, Env), debruijn(V, Env)};
-debruijn({fun_simple}, _Env) -> {fun_simple};
-debruijn({fun_any_arg, U}, Env) -> {fun_any_arg, debruijn(U, Env)};
-debruijn({fun_full, Args, U}, Env) -> 
+debruijn_1(Ty, Env) -> debruijn_2(?assert_type(Ty, ast_ty_db2()), Env).
+
+-spec debruijn_2(ast_ty_db2(), var_env()) -> ast_ty().
+debruijn_2({fun_simple}, _Env) -> {fun_simple};
+debruijn_2({fun_any_arg, U}, Env) -> {fun_any_arg, debruijn(U, Env)};
+debruijn_2({fun_full, Args, U}, Env) ->
   {fun_full, debruijn_list(Args, Env), debruijn(U, Env)};
-debruijn({range, Min, Max}, _Env) -> {range, Min, Max};
-debruijn({map_any}, _Env) -> {map_any};
-debruijn({map, Assocs}, Env) ->
-  {map, lists:map(fun({Kind, U, V}) -> 
-    {Kind, debruijn(U, Env), debruijn(V, Env)} 
+debruijn_2({range, Min, Max}, _Env) -> {range, Min, Max};
+debruijn_2({map_any}, _Env) -> {map_any};
+debruijn_2({map, Assocs}, Env) ->
+  {map, lists:map(fun({Kind, U, V}) ->
+    {Kind, debruijn(U, Env), debruijn(V, Env)}
   end, Assocs)};
-debruijn({predef, Name}, _Env) -> {predef, Name};
-debruijn({predef_alias, Name}, _Env) -> {predef_alias, Name};
-debruijn({named, Loc, Ref, Args}, Env) ->
+debruijn_2(Ty, Env) -> debruijn_3(?assert_type(Ty, ast_ty_db3()), Env).
+
+-spec debruijn_3(ast_ty_db3(), var_env()) -> ast_ty().
+debruijn_3({predef, Name}, _Env) -> {predef, Name};
+debruijn_3({predef_alias, Name}, _Env) -> {predef_alias, Name};
+debruijn_3({named, Loc, Ref, Args}, Env) ->
   {named, Loc, Ref, debruijn_list(Args, Env)};
-debruijn({tuple_any}, _Env) -> {tuple_any};
-debruijn({tuple, Args}, Env) -> {tuple, debruijn_list(Args, Env)};
-debruijn({var, Alpha}, _Env) -> {var, Alpha};
-debruijn({union, Args}, Env) -> {union, debruijn_list(Args, Env)};
-debruijn({intersection, Args}, Env) -> {intersection, debruijn_list(Args, Env)};
-debruijn({negation, U}, Env) -> {negation, debruijn(U, Env)}.
+debruijn_3(Ty, Env) -> debruijn_4(?assert_type(Ty, ast_ty_db4()), Env).
+
+-spec debruijn_4(ast_ty_db4(), var_env()) -> ast_ty().
+debruijn_4({tuple_any}, _Env) -> {tuple_any};
+debruijn_4({tuple, Args}, Env) -> {tuple, debruijn_list(Args, Env)};
+debruijn_4({var, Alpha}, _Env) -> {var, Alpha};
+debruijn_4({union, Args}, Env) -> {union, debruijn_list(Args, Env)};
+debruijn_4({intersection, Args}, Env) -> {intersection, debruijn_list(Args, Env)};
+debruijn_4({negation, U}, Env) -> {negation, debruijn(U, Env)}.
 
 %% Helper to debruijn lists of types
 
@@ -753,42 +875,51 @@ convert_back({intersection, Args}, Env, Counter) ->
   {{intersection, ConvertedArgs}, NewCounter};
 %% Handle all other type constructors similarly
 convert_back(Type, Env, Counter) when is_tuple(Type) ->
-  case element(1, Type) of
-    Constructor when Constructor =:= list; 
-                     Constructor =:= nonempty_list ->
-      [Constructor, Arg] = tuple_to_list(Type),
-      {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
-      {list_to_tuple([Constructor, ConvertedArg]), NewCounter};
-    Constructor when Constructor =:= cons;
-                     Constructor =:= improper_list;
-                     Constructor =:= nonempty_improper_list ->
-      [Constructor, Arg, Arg2] = tuple_to_list(Type),
-      {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
-      {ConvertedArg2, NewCounter2} = convert_back(Arg2, Env, NewCounter),
-      {list_to_tuple([Constructor, ConvertedArg, ConvertedArg2]), NewCounter2};
-    Constructor when Constructor =:= fun_any_arg;
-                     Constructor =:= negation ->
-      [Constructor, Arg] = tuple_to_list(Type),
-      {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
-      {list_to_tuple([Constructor, ConvertedArg]), NewCounter};
-    fun_full ->
-      [fun_full, Args, Ret] = tuple_to_list(Type),
-      {ConvertedArgs, Counter1} = convert_back_list(Args, Env, Counter),
-      {ConvertedRet, NewCounter} = convert_back(Ret, Env, Counter1),
-      {{fun_full, ConvertedArgs, ConvertedRet}, NewCounter};
-    map ->
-      [map, Assocs] = tuple_to_list(Type),
-      {ConvertedAssocs, NewCounter} = convert_back_assocs(Assocs, Env, Counter),
-      {{map, ConvertedAssocs}, NewCounter};
-    named ->
-      [named, Loc, Ref, Args] = tuple_to_list(Type),
-      {ConvertedArgs, NewCounter} = convert_back_list(Args, Env, Counter),
-      {{named, Loc, Ref, ConvertedArgs}, NewCounter};
-    _ ->
-      {Type, Counter} % For atomic types
-  end;
+  convert_back_other(?assert_type(Type, ast_ty_cb_other()), Env, Counter);
 convert_back(Type, _Env, Counter) ->
   {Type, Counter}. % For non-tuple types
+
+-spec convert_back_other(ast_ty_cb_other(), var_env(), non_neg_integer()) -> {ast_ty(), non_neg_integer()}.
+convert_back_other({list, Arg}, Env, Counter) ->
+  {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
+  {{list, ConvertedArg}, NewCounter};
+convert_back_other({nonempty_list, Arg}, Env, Counter) ->
+  {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
+  {{nonempty_list, ConvertedArg}, NewCounter};
+convert_back_other({cons, Arg, Arg2}, Env, Counter) ->
+  {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
+  {ConvertedArg2, NewCounter2} = convert_back(Arg2, Env, NewCounter),
+  {{cons, ConvertedArg, ConvertedArg2}, NewCounter2};
+convert_back_other({improper_list, Arg, Arg2}, Env, Counter) ->
+  {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
+  {ConvertedArg2, NewCounter2} = convert_back(Arg2, Env, NewCounter),
+  {{improper_list, ConvertedArg, ConvertedArg2}, NewCounter2};
+convert_back_other({nonempty_improper_list, Arg, Arg2}, Env, Counter) ->
+  {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
+  {ConvertedArg2, NewCounter2} = convert_back(Arg2, Env, NewCounter),
+  {{nonempty_improper_list, ConvertedArg, ConvertedArg2}, NewCounter2};
+convert_back_other({fun_any_arg, Arg}, Env, Counter) ->
+  {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
+  {{fun_any_arg, ConvertedArg}, NewCounter};
+convert_back_other({negation, Arg}, Env, Counter) ->
+  {ConvertedArg, NewCounter} = convert_back(Arg, Env, Counter),
+  {{negation, ConvertedArg}, NewCounter};
+convert_back_other({fun_full, Args, Ret}, Env, Counter) ->
+  {ConvertedArgs, Counter1} = convert_back_list(Args, Env, Counter),
+  {ConvertedRet, NewCounter} = convert_back(Ret, Env, Counter1),
+  {{fun_full, ConvertedArgs, ConvertedRet}, NewCounter};
+convert_back_other({map, Assocs}, Env, Counter) ->
+  {ConvertedAssocs, NewCounter} = convert_back_assocs(Assocs, Env, Counter),
+  {{map, ConvertedAssocs}, NewCounter};
+convert_back_other({named, Loc, Ref, Args}, Env, Counter) ->
+  {ConvertedArgs, NewCounter} = convert_back_list(Args, Env, Counter),
+  {{named, Loc, Ref, ConvertedArgs}, NewCounter};
+convert_back_other(Type, _Env, Counter) ->
+  convert_back_rest(?assert_type(Type, ast_ty_cb_rest()), Counter).
+
+-spec convert_back_rest(ast_ty_cb_rest(), non_neg_integer()) -> {ast_ty(), non_neg_integer()}.
+convert_back_rest(Type, Counter) ->
+  {Type, Counter}. % For atomic types
 
 -spec convert_back_list([ast_ty()], var_env(), non_neg_integer()) -> {[ast_ty()], non_neg_integer()}.
 convert_back_list([], _Env, Counter) -> {[], Counter};
@@ -841,23 +972,25 @@ replace_locs(Term) ->
 
 -spec rewrite_map_to_representation(ast_ty()) -> ast_ty().
 rewrite_map_to_representation({map, AssocList}) ->
-  {_, TupPart, FunPart} = lists:foldl(
-    fun({Association, Key, Val}, {PrecedenceDomain, Tuples, Functions}) ->
-      case Association of
-        map_field_opt ->
-          % tuples only
-          Tup = {tuple, [{intersection, [Key, {negation, PrecedenceDomain}]}, Val]},
-          {{union, [PrecedenceDomain, Key]}, {union, [Tuples, Tup]}, Functions};
-        map_field_req ->
-          % tuples & functions
-          Tup = {tuple, [{intersection, [Key, {negation, PrecedenceDomain}]}, Val]},
-          Fun = {fun_full, [{intersection, [Key, {negation, PrecedenceDomain}]}], Val},
-          {{union, [PrecedenceDomain, Key]}, {union, [Tuples, Tup]}, {intersection, [Functions, Fun]}}
-      end
-    end, 
-    % a map type is never empty
-    % contrary to tuples, we can construct an empty map value: #{}
-    % since empty tuples are the empty type, we add an atom 'empty_map' to the tuple part
-    % so that the encoding is never empty
+  % a map type is never empty
+  % contrary to tuples, we can construct an empty map value: #{}
+  % since empty tuples are the empty type, we add an atom 'empty_map' to the tuple part
+  % so that the encoding is never empty
+  {_, TupPart, FunPart} = lists:foldl(fun rewrite_map_fold/2,
     {{predef, none}, {singleton, empty_map}, {fun_simple}}, AssocList),
   {tuple, [TupPart, FunPart]}.
+
+-spec rewrite_map_fold(ast:ty_map_assoc(), {ast_ty(), ast_ty(), ast_ty()}) -> {ast_ty(), ast_ty(), ast_ty()}.
+rewrite_map_fold({Association, Key, Val}, {PrecedenceDomain, Tuples, Functions}) ->
+  rewrite_map_assoc(Association, Key, Val, PrecedenceDomain, Tuples, Functions).
+
+-spec rewrite_map_assoc(map_field_opt | map_field_req, ast_ty(), ast_ty(), ast_ty(), ast_ty(), ast_ty()) -> {ast_ty(), ast_ty(), ast_ty()}.
+rewrite_map_assoc(map_field_opt, Key, Val, PrecedenceDomain, Tuples, Functions) ->
+  % tuples only
+  Tup = {tuple, [{intersection, [Key, {negation, PrecedenceDomain}]}, Val]},
+  {{union, [PrecedenceDomain, Key]}, {union, [Tuples, Tup]}, Functions};
+rewrite_map_assoc(map_field_req, Key, Val, PrecedenceDomain, Tuples, Functions) ->
+  % tuples & functions
+  Tup = {tuple, [{intersection, [Key, {negation, PrecedenceDomain}]}, Val]},
+  Fun = {fun_full, [{intersection, [Key, {negation, PrecedenceDomain}]}], Val},
+  {{union, [PrecedenceDomain, Key]}, {union, [Tuples, Tup]}, {intersection, [Functions, Fun]}}.

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -135,16 +135,16 @@ compare(#ty{
         ty_functions = F2, dnf_ty_map = M2
     }) ->
     
-    utils:compare_multiple([
-        {fun dnf_ty_predefined:compare/2, P1, P2},
-        {fun dnf_ty_atom:compare/2, A1, A2},
-        {fun dnf_ty_interval:compare/2, I1, I2},
-        {fun dnf_ty_list:compare/2, L1, L2},
-        {fun dnf_ty_bitstring:compare/2, B1, B2},
-        {fun ty_tuples:compare/2, T1, T2},
-        {fun ty_functions:compare/2, F1, F2},
-        {fun dnf_ty_map:compare/2, M1, M2}
-    ]).
+    maybe
+        eq ?= dnf_ty_predefined:compare(P1, P2),
+        eq ?= dnf_ty_atom:compare(A1, A2),
+        eq ?= dnf_ty_interval:compare(I1, I2),
+        eq ?= dnf_ty_list:compare(L1, L2),
+        eq ?= dnf_ty_bitstring:compare(B1, B2),
+        eq ?= ty_tuples:compare(T1, T2),
+        eq ?= ty_functions:compare(F1, F2),
+        dnf_ty_map:compare(M1, M2)
+    end.
 
 -spec equal(type(), type()) -> boolean().
 equal(Ty1, Ty2) -> compare(Ty1, Ty2) =:= eq.
@@ -499,22 +499,24 @@ unparse_h(#ty{
 unparse_any(_, _, {predef, none}) -> {predef, none};
 unparse_any(false, dnf_ty_predefined, Result) -> Result;
 unparse_any(false, _, Result) when Result /= {predef, any} -> Result;
-unparse_any(_, dnf_ty_predefined, {predef, any}) -> {union, [{empty_list}, {predef, float}, {predef, pid}, {predef, port}, {predef, reference}]};
-unparse_any(_, dnf_ty_predefined, Result) -> Result;
-unparse_any(_, dnf_ty_atom, {predef, any}) -> {predef, atom};
-unparse_any(_, dnf_ty_atom, Result) -> ast_lib:mk_intersection([{predef, atom}, Result]);
-unparse_any(_, dnf_ty_interval, {predef, any}) -> {predef, integer};
-unparse_any(_, dnf_ty_interval, Result) -> ast_lib:mk_intersection([{predef, integer}, Result]);
-unparse_any(_, dnf_ty_list, {predef, any}) -> {improper_list, {predef, any}, {predef, any}}; % TODO double-check
-unparse_any(_, dnf_ty_list, Result) -> ast_lib:mk_intersection([{improper_list, {predef, any}, {predef, any}}, Result]);
-unparse_any(_, dnf_ty_bitstring, {predef, any}) -> {bitstring};
-unparse_any(_, dnf_ty_bitstring, Result) -> ast_lib:mk_intersection([{bitstring}, Result]);
-unparse_any(_, ty_tuples, {predef, any}) -> {tuple_any};
-unparse_any(_, ty_tuples, Result) -> ast_lib:mk_intersection([{tuple_any}, Result]);
-% unparse_any(_, ty_functions, {predef_any}) -> {fun_simple}; % TODO check why can never match
-unparse_any(_, ty_functions, Result) -> ast_lib:mk_intersection([{fun_simple}, Result]);
-unparse_any(_, dnf_ty_map, {predef, any}) -> {map_any};
-unparse_any(_, dnf_ty_map, Result) -> ast_lib:mk_intersection([{map_any}, Result]).
+unparse_any(_, Module, Result) -> unparse_any_module(Module, Result).
+
+-spec unparse_any_module(type_module(), ast_ty()) -> ast_ty().
+unparse_any_module(dnf_ty_predefined, {predef, any}) -> {union, [{empty_list}, {predef, float}, {predef, pid}, {predef, port}, {predef, reference}]};
+unparse_any_module(dnf_ty_predefined, Result) -> Result;
+unparse_any_module(dnf_ty_atom, {predef, any}) -> {predef, atom};
+unparse_any_module(dnf_ty_atom, Result) -> ast_lib:mk_intersection([{predef, atom}, Result]);
+unparse_any_module(dnf_ty_interval, {predef, any}) -> {predef, integer};
+unparse_any_module(dnf_ty_interval, Result) -> ast_lib:mk_intersection([{predef, integer}, Result]);
+unparse_any_module(dnf_ty_list, {predef, any}) -> {improper_list, {predef, any}, {predef, any}};
+unparse_any_module(dnf_ty_list, Result) -> ast_lib:mk_intersection([{improper_list, {predef, any}, {predef, any}}, Result]);
+unparse_any_module(dnf_ty_bitstring, {predef, any}) -> {bitstring};
+unparse_any_module(dnf_ty_bitstring, Result) -> ast_lib:mk_intersection([{bitstring}, Result]);
+unparse_any_module(ty_tuples, {predef, any}) -> {tuple_any};
+unparse_any_module(ty_tuples, Result) -> ast_lib:mk_intersection([{tuple_any}, Result]);
+unparse_any_module(ty_functions, Result) -> ast_lib:mk_intersection([{fun_simple}, Result]);
+unparse_any_module(dnf_ty_map, {predef, any}) -> {map_any};
+unparse_any_module(dnf_ty_map, Result) -> ast_lib:mk_intersection([{map_any}, Result]).
 % unparse_any(_, Module, _) -> 
 %   error({no_unparse_implemented, Module}).
 

--- a/src/gradual_utils.erl
+++ b/src/gradual_utils.erl
@@ -54,7 +54,15 @@ fresh_framevar(Ctx) ->
 -spec preprocess_constrs(constr:collected_constrs(), ctx()) ->
     {constr:subty_constrs(), constr:subty_constrs(), constr:mater_constrs(), subst:base_subst()}.
 preprocess_constrs(Constrs, Ctx) ->
-    {SubtyConstrs, Maters} = sets:fold(
+    {SubtyConstrs, Maters} = separate_constrs(Constrs, Ctx),
+    UnificationSubst = build_unification_subst(Maters),
+    InlinedConstrs = inline_subst(UnificationSubst, SubtyConstrs),
+    {InlinedConstrs, SubtyConstrs, Maters, UnificationSubst}.
+
+-spec separate_constrs(constr:collected_constrs(), ctx()) ->
+    {constr:subty_constrs(), constr:mater_constrs()}.
+separate_constrs(Constrs, Ctx) ->
+    sets:fold(
         fun
             ({scsubty, Loc, T1, T2}, {Cs, Ms}) ->
               T1b = replace_dynamic(T1, Ctx),
@@ -62,21 +70,20 @@ preprocess_constrs(Constrs, Ctx) ->
               {sets:add_element({scsubty, Loc, T1b, T2b}, Cs), Ms};
             ({scmater, Loc, T1, T2}, {Cs, Ms}) ->
               T1b = replace_dynamic(T1, Ctx),
-              {Cs, sets:add_element({scmater, Loc, T1b, T2}, Ms)};
-            (Constr, {Cs, Ms}) ->
-              {sets:add_element(Constr, Cs), Ms}
+              {Cs, sets:add_element({scmater, Loc, T1b, T2}, Ms)}
         end,
         {sets:new(), sets:new()},
-        Constrs),
+        Constrs).
 
-    UnificationSubst = maps:from_list(lists:map(fun({scmater, _, Tau, Alpha}) -> {Alpha, Tau} end, sets:to_list(Maters))),
-    InlinedConstrs = sets:map(fun(Constr) ->
-      case Constr of
-        {scsubty, _Loc, T1, T2} -> {scsubty, _Loc, subst:apply_base(UnificationSubst, T1), subst:apply_base(UnificationSubst, T2)};
-        Other -> Other
-      end
-    end, SubtyConstrs),
-    {InlinedConstrs, SubtyConstrs, Maters, UnificationSubst}.
+-spec build_unification_subst(constr:mater_constrs()) -> subst:base_subst().
+build_unification_subst(Maters) ->
+    maps:from_list(lists:map(fun({scmater, _, Tau, Alpha}) -> {Alpha, Tau} end, sets:to_list(Maters))).
+
+-spec inline_subst(subst:base_subst(), constr:subty_constrs()) -> constr:subty_constrs().
+inline_subst(UnificationSubst, SubtyConstrs) ->
+    sets:map(fun({scsubty, Loc, T1, T2}) ->
+      {scsubty, Loc, subst:apply_base(UnificationSubst, T1), subst:apply_base(UnificationSubst, T2)}
+    end, SubtyConstrs).
 
 -spec replace_dynamic(ast:ty(), ctx()) -> ast:ty().
 replace_dynamic(Ty, Ctx) ->
@@ -94,16 +101,45 @@ postprocess({tally_subst, S, Fixed}, Constrs, Maters, SymTab) ->
         pretty:render_constr(Constrs),
         pretty:render_constr(Maters)),
     Ctx = new_ctx(),
+    A = compute_A(S, Constrs, Maters, SymTab),
+
+    % Step 3c): Get all frame variables from A
+    X = sets:filter(fun(Var) -> is_framevar(Var) end, A),
+
+    % Step 3d)
+    Alpha = compute_alpha(S, Constrs, A),
+
+    % Step 3e): Create fresh alpha and X
+    Sigma2 = build_sigma2(X, Alpha, Ctx),
+
+    % compose sigma2 and sigma
+    compose({tally_subst, S, Fixed}, Sigma2).
+
+-spec compute_A(subst:base_subst(), constr:subty_constrs(), constr:mater_constrs(), symtab:t()) ->
+    sets:set(ast:ty_varname()).
+compute_A(S, Constrs, Maters, SymTab) ->
     % Step 3b): find all type variables appearing in the gradual types in materialization constraints
     % and substitute them with the found tally solution
-    TypeVarsInMaters = sets:fold(
+    TypeVarsInMaters = collect_mater_tyvars(Maters),
+    TypeVarsInSubsts = collect_subst_tyvars(TypeVarsInMaters, S),
+    % Step 3b): find all variables that have at least both positive and negative occurrences in
+    % the subtyping constraints
+    PosNegTyvars = collect_pos_neg_constrs_tyvars(Constrs, SymTab),
+    sets:union(TypeVarsInSubsts, PosNegTyvars).
+
+-spec collect_mater_tyvars(constr:mater_constrs()) -> sets:set(ast:ty_varname()).
+collect_mater_tyvars(Maters) ->
+    sets:fold(
         fun({scmater, _, Tau, _}, Acc) ->
           TypeVars = collect_tyvars(Tau),
           sets:union(Acc, sets:from_list(TypeVars))
         end,
         sets:new(),
-        Maters),
-    TypeVarsInSubsts = sets:fold(
+        Maters).
+
+-spec collect_subst_tyvars(sets:set(ast:ty_varname()), subst:base_subst()) -> sets:set(ast:ty_varname()).
+collect_subst_tyvars(TypeVarsInMaters, S) ->
+    sets:fold(
       fun(Alpha, Acc) ->
         case maps:find(Alpha, S) of
           {ok, Ty} ->
@@ -114,11 +150,11 @@ postprocess({tally_subst, S, Fixed}, Constrs, Maters, SymTab) ->
       end,
       sets:new(),
       TypeVarsInMaters
-    ),
+    ).
 
-    % Step 3b): find all variables that have at least both positive and negative occurrences in
-    % the subtyping constraints
-    PosNegTyvars = sets:fold(
+-spec collect_pos_neg_constrs_tyvars(constr:subty_constrs(), symtab:t()) -> sets:set(ast:ty_varname()).
+collect_pos_neg_constrs_tyvars(Constrs, SymTab) ->
+    sets:fold(
       fun({scsubty, _, T1, T2}, Acc) ->
         Tyvars1 = collect_pos_neg_tyvars(T1, SymTab),
         Tyvars2 = collect_pos_neg_tyvars(T2, SymTab),
@@ -126,13 +162,12 @@ postprocess({tally_subst, S, Fixed}, Constrs, Maters, SymTab) ->
       end,
       sets:new(),
       Constrs
-    ),
-    A = sets:union(TypeVarsInSubsts, PosNegTyvars),
+    ).
 
-    % Step 3c): Get all frame variables from A
-    X = sets:filter(fun(Var) -> is_framevar(Var) end, A),
-
-    % Step 3d): Collect all type variables which are not fixed, in the domain of the substitution
+-spec compute_alpha(subst:base_subst(), constr:subty_constrs(), sets:set(ast:ty_varname())) ->
+    sets:set(ast:ty_varname()).
+compute_alpha(S, Constrs, A) ->
+    % Collect all type variables which are not fixed, in the domain of the substitution
     % or in A:  α = var(D)\(∆∪dom(σ0)∪A)
     Var_D = sets:fold(
       fun({scsubty, _, T1, T2}, Acc) ->
@@ -145,9 +180,10 @@ postprocess({tally_subst, S, Fixed}, Constrs, Maters, SymTab) ->
       Constrs
     ),
     Dom_Sigma = sets:from_list(lists:filter(fun(Var) -> is_typevar(Var) end, maps:keys(S))),
-    Alpha = sets:subtract(Var_D, sets:union(Dom_Sigma, A)),
+    sets:subtract(Var_D, sets:union(Dom_Sigma, A)).
 
-    % Step 3e): Create fresh alpha and X
+-spec build_sigma2(sets:set(ast:ty_varname()), sets:set(ast:ty_varname()), ctx()) -> subst:base_subst().
+build_sigma2(X, Alpha, Ctx) ->
     X_Subst = sets:fold(
       fun(Framevar, Acc) ->
         FreshVar = fresh_typevar(Ctx),
@@ -156,7 +192,6 @@ postprocess({tally_subst, S, Fixed}, Constrs, Maters, SymTab) ->
       #{},
       X
     ),
-
     Alpha_Subst = sets:fold(
       fun(Typevar, Acc) ->
         FreshVar = fresh_framevar(Ctx),
@@ -165,12 +200,7 @@ postprocess({tally_subst, S, Fixed}, Constrs, Maters, SymTab) ->
       #{},
       Alpha
     ),
-
-    % Step 3a): build sigma2
-    Sigma2 = maps:merge(X_Subst, Alpha_Subst),
-
-    % compose sigma2 and sigma
-    compose({tally_subst, S, Fixed}, Sigma2).
+    maps:merge(X_Subst, Alpha_Subst).
 
 % Returns the set of variable names appearing in both positive and negative positions in Ty.
 % Delegates to subst:collect_vars/4 for exhaustive AST traversal.
@@ -234,8 +264,7 @@ collect_tyvars(Ty) ->
   (ast:ty_varname()) -> boolean();
   (ast:ty_var()) -> boolean().
 is_framevar(Name) when is_atom(Name) -> starts_with(Name, "%");
-is_framevar({var, Name}) -> starts_with(Name, "%");
-is_framevar(_) -> false.
+is_framevar({var, Name}) -> starts_with(Name, "%").
 
 -spec is_typevar(ast:ty_varname()) -> boolean().
 is_typevar(Name) -> starts_with(Name, "$").

--- a/src/parse.erl
+++ b/src/parse.erl
@@ -13,6 +13,8 @@
     parse_transform/2
 ]).
 
+-include("etylizer.hrl").
+
 -define(TABLE, parse_result).
 -define(FORMS, forms).
 
@@ -23,42 +25,73 @@
 
 -spec parse_file(string(), parse_opts()) -> error | {ok, [ast_erl:form()]}.
 parse_file(Path, Opts) ->
-    case ets:whereis(?TABLE) of
-        undefined ->
-            ets:new(?TABLE, [named_table, public, set]);
-        _ -> ets:delete_all_objects(?TABLE)
-    end,
+    init_parse_table(),
     ?LOG_TRACE("Parsing ~s", Path),
     Ext = filename:extension(Path),
     if
         Ext == ".erl" ->
-            NoExt = filename:rootname(Path),
-            CompileOpts =
-                [{parse_transform,parse},basic_validation, report] ++
-                (if Opts#parse_opts.verbose -> [verbose]; true -> [] end) ++
-                lists:map(fun (X) -> {i,X} end, Opts#parse_opts.includes) ++
-                lists:map(fun ({Name, Val}) ->
-                    case string:len(Val) of
-                        0 -> {d, Name};
-                        _ -> {d, Name, Val}
-                    end
-                end, Opts#parse_opts.defines),
-            ?LOG_TRACE("Calling compile:file for ~s, options: ~200p", NoExt, CompileOpts),
-            case compile:file(NoExt, CompileOpts) of
-                {ok, _} ->
-                    ?LOG_TRACE("Done parsing ~s", Path),
-                    case ets:lookup(?TABLE, ?FORMS) of
-                        [{?FORMS, Forms}] -> {ok, Forms};
-                        _ ->
-                            ?LOG_ERROR("No result in ETS table after parsing"),
-                            error
-                    end;
-                error ->
-                    ?LOG_NOTE("Error parsing ~s", Path),
-                    error
-            end;
+            do_parse_erl(Path, Opts);
         true ->
             ?LOG_ERROR("Invalid input file: ~s", Path),
+            error
+    end.
+
+-spec init_parse_table() -> ok.
+init_parse_table() ->
+    case ets:whereis(?TABLE) of
+        undefined ->
+            ets:new(?TABLE, [named_table, public, set]),
+            ok;
+        _ ->
+            ets:delete_all_objects(?TABLE),
+            ok
+    end.
+
+-spec make_define_opt({atom(), string()}) -> {d, atom()} | {d, atom(), string()}.
+make_define_opt({Name, Val}) ->
+    case string:len(Val) of
+        0 -> {d, Name};
+        _ -> {d, Name, Val}
+    end.
+
+-spec build_compile_opts(parse_opts()) -> [compile:option()].
+build_compile_opts(Opts) ->
+    [{parse_transform,parse},basic_validation, report] ++
+    (case Opts#parse_opts.verbose of true -> [verbose]; _ -> [] end) ++
+    lists:map(fun (X) -> {i,X} end, Opts#parse_opts.includes) ++
+    lists:map(fun make_define_opt/1, Opts#parse_opts.defines).
+
+-spec do_parse_erl(string(), parse_opts()) -> error | {ok, [ast_erl:form()]}.
+do_parse_erl(Path, Opts) ->
+    NoExt = filename:rootname(Path),
+    CompileOpts = build_compile_opts(Opts),
+    case compile:file(NoExt, CompileOpts) of
+        {ok, _} ->
+            extract_parse_result(Path);
+        error ->
+            log_parse_error(Path);
+        _ ->
+            log_unexpected_compile(Path)
+    end.
+
+-spec log_parse_error(string()) -> error.
+log_parse_error(Path) ->
+    ?LOG_NOTE("Error parsing ~s", Path),
+    error.
+
+-spec log_unexpected_compile(string()) -> error.
+log_unexpected_compile(Path) ->
+    ?LOG_ERROR("Unexpected compile result for ~s", Path),
+    error.
+
+-spec extract_parse_result(string()) -> error | {ok, [ast_erl:form()]}.
+extract_parse_result(Path) ->
+    ?LOG_TRACE("Done parsing ~s", Path),
+    case ets:lookup(?TABLE, ?FORMS) of
+        [{_, StoredForms}] ->
+            {ok, ?assert_type(StoredForms, [ast_erl:form()])};
+        _ ->
+            ?LOG_ERROR("No result in ETS table after parsing"),
             error
     end.
 
@@ -72,15 +105,19 @@ parse_file_or_die(Path, Opts) ->
         error -> errors:parse_error(utils:sformat("Error parsing ~s", Path))
     end.
 
--spec parse_transform(any(), any()) -> ok.
+-spec parse_transform(any(), any()) -> any().
 parse_transform(Forms, _Opts) ->
     try
-        % ?LOG_TRACE("Forms: ~p", [Forms]),
         ets:insert(?TABLE, {?FORMS, Forms}),
-        % ?LOG_TRACE("done with parse_transform"),
         Forms
     catch
-        K:E ->
-            ?LOG_ERROR("Error ~p in parse_transform: ~p", K, E),
+        throw:E ->
+            ?LOG_ERROR("Error throw in parse_transform: ~p", E),
+            Forms;
+        error:E ->
+            ?LOG_ERROR("Error error in parse_transform: ~p", E),
+            Forms;
+        exit:E ->
+            ?LOG_ERROR("Error exit in parse_transform: ~p", E),
             Forms
     end.

--- a/src/parse_cache.erl
+++ b/src/parse_cache.erl
@@ -7,6 +7,8 @@
 -export([init/1, cleanup/0, parse/2, with_cache/2]).
 -export_type([file_kind/0]).
 
+-include("etylizer.hrl").
+
 -define(TABLE, forms_table).
 
 -spec init(#opts{}) -> ok.
@@ -34,75 +36,79 @@ with_cache(Opts, Fun) ->
     parse_cache:cleanup()
   end.
 
+-spec hash_file(file:filename()) -> string().
+hash_file(PathNorm) ->
+    case utils:hash_file(PathNorm) of
+        {error, Reason} ->
+            ?ABORT("Reading file ~p failed: ~200p", PathNorm, Reason);
+        H -> H
+    end.
+
+-spec check_kind(file_kind(), file_kind(), file:filename()) -> ok.
+check_kind(Kind, StoredKind, PathNorm) ->
+    if Kind =:= StoredKind -> ok;
+        true ->
+            ?ABORT("Previously parsed ~p with kind ~p, now requested for kind ~p",
+                PathNorm, StoredKind, Kind)
+    end.
+
+-spec parse_and_cache(file_kind(), file:filename(), string()) -> [ast:form()].
+parse_and_cache(Kind, PathNorm, Hash) ->
+    ?assert_pattern([{_, _}], ets:lookup(?TABLE, opts)),
+    [{_, Opts}] = ets:lookup(?TABLE, opts),
+    Forms = really_parse_file(Kind, PathNorm, ?assert_type(Opts, #opts{})),
+    ets:insert(?TABLE, {PathNorm, {Hash, Kind, Forms}}),
+    Forms.
+
 -spec parse(file_kind(), file:filename()) -> [ast:form()].
 parse(Kind, Path) ->
     PathNorm = utils:normalize_path(Path),
-    Hash =
-        case utils:hash_file(PathNorm) of
-            {error, Reason} ->
-                ?ABORT("Reading file ~p failed: ~200p", PathNorm, Reason);
-            H -> H
-        end,
+    Hash = hash_file(PathNorm),
     case ets:lookup(?TABLE, PathNorm) of
         [{_, {StoredHash, StoredKind, Forms}}] when Hash =:= StoredHash ->
-            if Kind =:= StoredKind -> ok;
-                true ->
-                    ?ABORT("Previously parsed ~p with kind ~p, now requested for kind ~p",
-                        PathNorm, StoredKind, Kind)
-            end,
+            check_kind(Kind, StoredKind, PathNorm),
             ?LOG_TRACE("Retrieving parse result for ~p from cache", PathNorm),
-            Forms;
+            ?assert_type(Forms, [ast:form()]);
         [] ->
-            [{_, Opts}] = ets:lookup(?TABLE, opts),
-            Forms = really_parse_file(Kind, PathNorm, Opts),
-            ets:insert(?TABLE, {PathNorm, {Hash, Kind, Forms}}),
-            Forms;
+            parse_and_cache(Kind, PathNorm, Hash);
         X -> ?ABORT("Unexpected entry in parse cache for key ~p: ~p", PathNorm, X)
     end.
 
--spec really_parse_file(file_kind(), file:filename(), #opts{}) -> [ast:form()].
-really_parse_file(Kind, File, Opts) ->
-    ParseOpts =
-        case Kind of
-            intern -> #parse_opts{
-                        includes = Opts#opts.includes,
-                        defines = Opts#opts.defines
-                    };
-            {extern, Includes} ->
-                #parse_opts{ verbose = false, includes = Includes, defines = Opts#opts.defines }
+-spec make_parse_opts(file_kind(), #opts{}) -> parse_opts().
+make_parse_opts(Kind, Opts) ->
+    case Kind of
+        intern -> #parse_opts{
+                    includes = Opts#opts.includes,
+                    defines = Opts#opts.defines
+                };
+        {extern, Includes} ->
+            #parse_opts{ verbose = false, includes = Includes, defines = Opts#opts.defines }
+    end.
+
+-spec maybe_sanity_check(file_kind(), boolean(), file:filename(), [ast_erl:form()]) -> ok.
+maybe_sanity_check(intern, true, File, RawForms) ->
+    ?LOG_INFO("Checking whether parse result for ~p conforms to AST in ast_erl.erl ...",
+        File),
+    {RawSpec, _} = ast_check:parse_spec("src/ast_erl.erl"),
+    lists:foreach(
+        fun({Idx,Form}) ->
+            case ast_check:check_against_type(RawSpec, ast_erl, form, Form) of
+                true ->
+                    ?LOG_DEBUG(
+                        "Parse result of form ~p from ~s conforms to AST in ast_erl.erl",
+                        Idx, File);
+                false ->
+                    ?ABORT("Parse result of form ~p from ~s violates AST in ast_erl.erl",
+                        Idx, File)
+            end
         end,
-    ?LOG_DEBUG("Parsing ~s ...", File),
-    RawForms = parse:parse_file_or_die(File, ParseOpts),
-    ?LOG_DEBUG("Finished parsing ~s", File),
-    if  Opts#opts.dump_raw -> ?LOG_NOTE("Raw forms in ~s:~n~p", File, RawForms);
-        true -> ok
-    end,
-    ?LOG_TRACE("Parse result (raw):~n~120p", RawForms),
+        lists:enumerate(1, RawForms)),
+    ok;
+maybe_sanity_check(_, _, _, _) -> ok.
 
+-spec transform_forms(file_kind(), file:filename(), [ast_erl:form()], #opts{}) -> [ast:form()].
+transform_forms(Kind, File, RawForms, Opts) ->
     IsIntern = Kind =:= intern,
-
-    % SW (2023-07-06): there are some features that are not covered by the ast_check module.
-    % Hence, we do not sanity check external modules. Especially some modules from the
-    % erlang stdlib would fail sanity checking.
-    if IsIntern andalso Opts#opts.sanity ->
-            ?LOG_INFO("Checking whether parse result for ~p conforms to AST in ast_erl.erl ...",
-                File),
-            {RawSpec, _} = ast_check:parse_spec("src/ast_erl.erl"),
-            lists:foreach(
-                fun({Idx,Form}) ->
-                    case ast_check:check_against_type(RawSpec, ast_erl, form, Form) of
-                        true ->
-                            ?LOG_DEBUG(
-                                "Parse result of form ~p from ~s conforms to AST in ast_erl.erl",
-                                Idx, File);
-                        false ->
-                            ?ABORT("Parse result of form ~p from ~s violates AST in ast_erl.erl",
-                                Idx, File)
-                    end
-                end,
-                lists:enumerate(1, RawForms));
-       true -> ok
-    end,
 
     % Inject synthetic attributes from CLI flags before transform
     ExtraForms = case IsIntern of
@@ -126,11 +132,28 @@ really_parse_file(Kind, File, Opts) ->
     end,
 
     ?LOG_DEBUG("Transforming ~s ...", File),
-    Forms = ast_transform:trans(File, ExtraForms ++ RawForms,
-        if IsIntern -> full; true -> flat end),
-    if  Opts#opts.dump ->
+    TransMode = case Kind of intern -> full; {extern, _} -> flat end,
+    Forms = ast_transform:trans(File, ExtraForms ++ RawForms, TransMode),
+    case Opts#opts.dump of
+        true ->
             ?LOG_NOTE("Transformed forms in ~s:~n~p", File, ast_utils:remove_locs(Forms));
-        true -> ok
+        _ -> ok
     end,
     ?LOG_TRACE("Parse result (after transform):~n~120p", Forms),
     Forms.
+
+-spec really_parse_file(file_kind(), file:filename(), #opts{}) -> [ast:form()].
+really_parse_file(Kind, File, Opts) ->
+    ParseOpts = make_parse_opts(Kind, Opts),
+    ?LOG_DEBUG("Parsing ~s ...", File),
+    RawForms = parse:parse_file_or_die(File, ParseOpts),
+    ?LOG_DEBUG("Finished parsing ~s", File),
+    case Opts#opts.dump_raw of
+        true -> ?LOG_NOTE("Raw forms in ~s:~n~p", File, RawForms);
+        _ -> ok
+    end,
+    ?LOG_TRACE("Parse result (raw):~n~120p", RawForms),
+
+    maybe_sanity_check(Kind, Opts#opts.sanity, File, RawForms),
+
+    transform_forms(Kind, File, RawForms, Opts).

--- a/src/records.erl
+++ b/src/records.erl
@@ -59,8 +59,6 @@ lookup_field_index({RecName, DefFields}, FieldName, L) ->
     case utils:assocs_find_index(FieldName, DefFields) of
         error ->
             errors:ty_error(L, "Field ~w not defined for record ~w", [FieldName, RecName]);
-        {ok, untyped, _} ->
-            errors:ty_error(L, "No type for field ~w of record ~w", [FieldName, RecName]);
         {ok, FieldTy, I} ->
             {FieldTy, I}
     end.

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -195,21 +195,30 @@ overlay_symtab(OverlayForms) ->
         end
     end, undefined, OverlayForms),
     lists:foldl(fun(Form, Tab) ->
-        case Form of
-            {attribute, _, spec, Name, Arity, T, _} ->
-                ?LOG_DEBUG("Overlay added for ~w/~p", Name, Arity),
-                [Module, FunName] = string:split(atom_to_list(Name), ":"),
-                Tab#tab { funs = maps:put(create_ref_tuple({qref, list_to_atom(Module)}, list_to_atom(FunName), Arity), T, Tab#tab.funs) };
-            {attribute, _, type, _Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}} when ModuleName =/= undefined ->
-                Arity = length(TyVars),
-                Key = {ty_key, ModuleName, Name, Arity},
-                ?LOG_DEBUG("Overlay type added: ~w/~p", Name, Arity),
-                Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) };
-            _ -> Tab
-        end
+        overlay_process_form(Form, Tab, ModuleName)
     end,
     empty(),
     OverlayForms).
+
+-spec overlay_process_form(ast:form(), t(), atom() | undefined) -> t().
+overlay_process_form({attribute, _, spec, Name, Arity, T, _}, Tab, _ModuleName) ->
+    overlay_add_spec(Name, Arity, T, Tab);
+overlay_process_form({attribute, _, type, _Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, Tab, ModuleName) when ModuleName =/= undefined ->
+    Arity = length(TyVars),
+    overlay_add_type(ModuleName, Name, Arity, TyScm, Tab);
+overlay_process_form(_, Tab, _ModuleName) -> Tab.
+
+-spec overlay_add_spec(atom(), arity(), ast:ty_scheme(), t()) -> t().
+overlay_add_spec(Name, Arity, T, Tab) ->
+    ?LOG_DEBUG("Overlay added for ~w/~p", Name, Arity),
+    [Module, FunName] = string:split(atom_to_list(Name), ":"),
+    Tab#tab { funs = maps:put(create_ref_tuple({qref, list_to_atom(Module)}, list_to_atom(FunName), Arity), T, Tab#tab.funs) }.
+
+-spec overlay_add_type(atom(), atom(), arity(), ast:ty_scheme(), t()) -> t().
+overlay_add_type(ModuleName, Name, Arity, TyScm, Tab) ->
+    Key = {ty_key, ModuleName, Name, Arity},
+    ?LOG_DEBUG("Overlay type added: ~w/~p", Name, Arity),
+    Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) }.
 
 -type ref() :: ref | {qref, ModuleName::atom()}.
 
@@ -245,38 +254,51 @@ extend_symtab_internal(Filename, Forms, RefType, Tab, OverlaySymtab) ->
     ModuleName = ast_utils:modname_from_path(Filename),
     lists:foldl(
         fun(Form, AccTab) ->
-            case Form of
-                {attribute, _, spec, Name, Arity, T, _} ->
-                    Ref = create_ref_tuple(RefType, Name, Arity),
-                    case find_fun(Ref, OverlaySymtab) of
-                        error ->
-                            ?LOG_TRACE("No Overlay found for ~w:~w/~p", ModuleName, Name, Arity),
-                            % if we are in local ref mode,
-                            % we might need to extend the symtab with the global ref, too,
-                            % if fun is exported
-                            maybe_add_qref(RefType, ModuleName, Name, Arity, T, Forms, AccTab);
-                        {ok, OverlayT} ->
-                            ?LOG_DEBUG("Overlay found for ~w:~w/~p", ModuleName, Name, Arity),
-                            AccTab#tab { funs = maps:put(create_ref_tuple(RefType, Name, Arity), OverlayT, AccTab#tab.funs) }
-                    end;
-                {attribute, _, type, _, {Name, TyScm = {ty_scheme, TyVars, _}}} ->
-                    Arity = length(TyVars),
-                    AccTab#tab { types = maps:put({ty_key, ModuleName, Name, Arity}, TyScm, AccTab#tab.types) };
-                {attribute, _, record, {RecordName, Fields}} ->
-                    RecordTy = records:record_ty_from_decl(RecordName, Fields),
-                    RecTypeName = records:record_type_name(RecordName),
-                    RecTupleType = records:encode_record_ty(RecordTy),
-                    RecTyScheme = {ty_scheme, [], RecTupleType},
-                    AccTab#tab {
-                        records = maps:put(RecordName, RecordTy, AccTab#tab.records),
-                        types = maps:put({ty_key, ModuleName, RecTypeName, 0}, RecTyScheme, AccTab#tab.types)
-                    };
-                _ ->
-                    AccTab
-            end
+            extend_process_form(Form, AccTab, RefType, ModuleName, Forms, OverlaySymtab)
         end,
         Tab#tab { modules = maps:put(ModuleName, Filename, Tab#tab.modules) },
         Forms).
+
+-spec extend_process_form(ast:form(), t(), ref(), atom(), ast:forms(), t()) -> t().
+extend_process_form({attribute, _, spec, Name, Arity, T, _}, AccTab, RefType, ModuleName, Forms, OverlaySymtab) ->
+    extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymtab);
+extend_process_form({attribute, _, type, _, {Name, TyScm = {ty_scheme, TyVars, _}}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
+    extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab);
+extend_process_form({attribute, _, record, {RecordName, Fields}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
+    extend_add_record(RecordName, Fields, ModuleName, AccTab);
+extend_process_form(_, AccTab, _RefType, _ModuleName, _Forms, _OverlaySymtab) ->
+    AccTab.
+
+-spec extend_add_spec(atom(), arity(), ast:ty_scheme(), t(), ref(), atom(), ast:forms(), t()) -> t().
+extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymtab) ->
+    Ref = create_ref_tuple(RefType, Name, Arity),
+    case find_fun(Ref, OverlaySymtab) of
+        error ->
+            ?LOG_TRACE("No Overlay found for ~w:~w/~p", ModuleName, Name, Arity),
+            % if we are in local ref mode,
+            % we might need to extend the symtab with the global ref, too,
+            % if fun is exported
+            maybe_add_qref(RefType, ModuleName, Name, Arity, T, Forms, AccTab);
+        {ok, OverlayT} ->
+            ?LOG_DEBUG("Overlay found for ~w:~w/~p", ModuleName, Name, Arity),
+            AccTab#tab { funs = maps:put(create_ref_tuple(RefType, Name, Arity), OverlayT, AccTab#tab.funs) }
+    end.
+
+-spec extend_add_type(atom(), ast:ty_scheme(), [{atom(), any()}], atom(), t()) -> t().
+extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab) ->
+    Arity = length(TyVars),
+    AccTab#tab { types = maps:put({ty_key, ModuleName, Name, Arity}, TyScm, AccTab#tab.types) }.
+
+-spec extend_add_record(atom(), list(), atom(), t()) -> t().
+extend_add_record(RecordName, Fields, ModuleName, AccTab) ->
+    RecordTy = records:record_ty_from_decl(RecordName, Fields),
+    RecTypeName = records:record_type_name(RecordName),
+    RecTupleType = records:encode_record_ty(RecordTy),
+    RecTyScheme = {ty_scheme, [], RecTupleType},
+    AccTab#tab {
+        records = maps:put(RecordName, RecordTy, AccTab#tab.records),
+        types = maps:put({ty_key, ModuleName, RecTypeName, 0}, RecTyScheme, AccTab#tab.types)
+    }.
 
 -spec extend_symtab_with_fun_env(fun_env(), t()) -> t().
 extend_symtab_with_fun_env(Env, Tab) -> Tab#tab { funs = maps:merge(Tab#tab.funs, Env) }.

--- a/src/typing_infer.erl
+++ b/src/typing_infer.erl
@@ -56,6 +56,12 @@ infer(Ctx, Decls) ->
             end,
             Decls),
 
+    SolveRes = simplify_and_log(SimpCtx, Cs, Ctx, Funs),
+    ResultEnvs = build_result_envs(SolveRes, Decls, Env, Ctx),
+    check_result_envs(ResultEnvs, Loc, FunsStr).
+
+-spec simplify_and_log(term(), term(), ctx(), [string()]) -> term().
+simplify_and_log(SimpCtx, Cs, Ctx, Funs) ->
     SimpConstrs = constr_simp:simp_constrs(SimpCtx, Cs),
     case Ctx#ctx.sanity of
         {ok, TyMap2} -> constr_simp:sanity_check(SimpConstrs, TyMap2);
@@ -65,29 +71,32 @@ infer(Ctx, Decls) ->
     ?LOG_DEBUG("Simplified constraint set for a group of mutually recursive functions ~s, now " ++
                 "checking constraints for solvability.~nConstraints:~n~s",
                 FunNamesStr, pretty:render_constr(SimpConstrs)),
-    SolveRes = constr_solve:solve_simp_constrs(Tab, SimpConstrs, "inference"),
-    ResultEnvs =
-        case SolveRes of
-            error -> [];
-            Substs ->
-                utils:map_flip(Substs,
-                    fun(Subst) ->
-                            ResultEnv = maps:from_list(utils:map_flip(
-                                Decls,
-                                fun({function, _Loc, Name, Arity, _}) ->
-                                        Ref = {ref, Name, Arity},
-                                        case maps:find(Ref, Env) of
-                                            error ->
-                                                errors:bug("Function ~w/~w not found in env",
-                                                            [Name, Arity]);
-                                            {ok, T} ->
-                                                {Ref, generalize(subst:apply(Subst, T, {clean, Ctx#ctx.symtab}))}
-                                        end
-                                end)),
-                            ?LOG_DEBUG("Environment:~n~s", [pretty:render_fun_env(ResultEnv)]),
-                            ResultEnv
-                    end)
-        end, % of case
+    Tab = Ctx#ctx.symtab,
+    constr_solve:solve_simp_constrs(Tab, SimpConstrs, "inference").
+
+-spec build_result_envs(term(), [ast:fun_decl()], map(), ctx()) -> [symtab:fun_env()].
+build_result_envs(error, _Decls, _Env, _Ctx) -> [];
+build_result_envs(Substs, Decls, Env, Ctx) ->
+    utils:map_flip(Substs,
+        fun(Subst) ->
+                ResultEnv = maps:from_list(utils:map_flip(
+                    Decls,
+                    fun({function, _Loc, Name, Arity, _}) ->
+                            Ref = {ref, Name, Arity},
+                            case maps:find(Ref, Env) of
+                                error ->
+                                    errors:bug("Function ~w/~w not found in env",
+                                                [Name, Arity]);
+                                {ok, T} ->
+                                    {Ref, generalize(subst:apply(Subst, T, {clean, Ctx#ctx.symtab}))}
+                            end
+                    end)),
+                ?LOG_DEBUG("Environment:~n~s", [pretty:render_fun_env(ResultEnv)]),
+                ResultEnv
+        end).
+
+-spec check_result_envs([symtab:fun_env()], ast:loc(), string()) -> [symtab:fun_env()].
+check_result_envs(ResultEnvs, Loc, FunsStr) ->
     case length(ResultEnvs) of
         0 ->
             errors:ty_error(Loc,
@@ -109,8 +118,8 @@ more_general(Loc, Ts1, Ts2, Tab) ->
     {Mono1, _, Next} = typing_common:mono_ty(Loc, Ts1, 0, Tab),
     % Arbitrary instantiation of Ts2, the type variables A2 are fix
     {Mono2, A2, _} = typing_common:mono_ty(Loc, Ts2, Next, Tab),
-    C = {scsubty, sets:new([{version, 2}]), Mono1, Mono2},
-    {SatisfyRes, Delta} = utils:timing(fun() -> tally:is_satisfiable(Tab, sets:from_list([C], [{version, 2}]), A2) end),
+    C = {scsubty, Loc, Mono1, Mono2},
+    {SatisfyRes, Delta} = utils:timing(fun() -> tally:is_satisfiable(Tab, sets:from_list([C]), A2) end),
     ?LOG_DEBUG("Tally time: ~pms", Delta),
     Result =
         case SatisfyRes of
@@ -138,9 +147,9 @@ ftv(T) ->
         utils:everything(
           fun(X) ->
                   case X of
-                      {var, Alpha} -> {ok, Alpha};
+                      {var, Alpha} when is_atom(Alpha) -> {ok, Alpha};
                       _ -> error
                   end
           end,
           T),
-    sets:from_list(L, [{version, 2}]).
+    sets:from_list(L).

--- a/src/tyutils.erl
+++ b/src/tyutils.erl
@@ -11,7 +11,7 @@
 free_in_ty(T) ->
     L = utils:everything(fun (U) ->
                                  case U of
-                                     {var, X} -> {ok, X};
+                                     {var, X} when is_atom(X) -> {ok, X};
                                      _ -> error
                                  end
                          end, T),

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -32,7 +32,6 @@
     compare_multiple/1,
     update_ets_from_map/2,
     format_tally_config/3,
-    flatten/1,
     parse_fun_id/1,
     parse_fun_ids/1
 ]).
@@ -196,7 +195,7 @@ shorten([X | Xs], N) ->
 map_flip(L, F) -> lists:map(F, L).
 
 -spec concat_map([A], fun((A) -> [B])) -> [B].
-concat_map(L, F) -> lists:concat(lists:map(F, L)).
+concat_map(L, F) -> lists:flatmap(F, L).
 
 -spec foreach([T], fun((T) -> any())) -> ok.
 foreach(L, F) -> lists:foreach(F, L).
@@ -419,18 +418,6 @@ format_tally_config(Constraints, FixedVars, Symtab) ->
     ++ io_lib:format("~p.", [symtab:get_types(Symtab)])
     ++ "\n" 
     ++ io_lib:format("~p.", [FixedVars]).
-
--spec flatten(deep_list(A)) -> [A].
-flatten(L) -> do_flatten(L, []).
-
--type deep_list(A) :: [etylizer:without(A, list()) | deep_list(A)].
--spec do_flatten(deep_list(A), [A]) -> [A].
-do_flatten([H|T], Tail) when is_list(H) ->
-    do_flatten(H, do_flatten(T, Tail));
-do_flatten([H|T], Tail) ->
-    [H|do_flatten(T, Tail)];
-do_flatten([], Tail) ->
-    Tail.
 
 % Parses a string like "name/arity" into {atom(), arity()}.
 -spec parse_fun_id(string()) -> {atom(), arity()}.

--- a/src/varenv_local.erl
+++ b/src/varenv_local.erl
@@ -85,6 +85,7 @@ find_ref(Name, {_, Map, _, Escaped}) ->
 % All variables kept must have the same unique name. It's a bug if this is not the case.
 % The list of varenvs must not be empty
 -spec merge_envs([t()]) -> t().
+merge_envs([]) -> errors:bug("merge_envs called with empty list");
 merge_envs([Init | Rest]) ->
     Combiner =
         fun (K, V1, V2) ->


### PR DESCRIPTION
Refactor functions to make type checking easier. Mostly splitting up big functions.

Semantic changes:
* fixed a bug in `search_failing_prefix`, callers match on `error` not on `false`; only relevant for type inference fails (crash instead of a nice error message)