### PR TITLE
CI stats

### DIFF
--- a/.github/scripts/typecheck_stats.sh
+++ b/.github/scripts/typecheck_stats.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# Generates markdown statistics tables from typecheck/test log files.
+# Usage: typecheck_stats.sh <pr_log> [base_log] [output_file]
+#   pr_log:      Log file from a typecheck or test run on the PR branch
+#   base_log:    Optional log file from the same run on the base branch
+#   output_file: Optional file to write the markdown table to
+
+set -euo pipefail
+
+PR_LOG="${1:-}"
+BASE_LOG="${2:-}"
+OUTPUT_FILE="${3:-}"
+
+if [ -z "$PR_LOG" ] || [ ! -f "$PR_LOG" ]; then
+    echo "Usage: typecheck_stats.sh <pr_log> [base_log] [output_file]" >&2
+    exit 1
+fi
+
+# Detect log format: "typecheck" uses "(NNN ms)", "eunit" uses "[N.NNN s] ok"
+detect_format() {
+    if grep -q '\[[0-9.]\+ s\]' "$1" 2>/dev/null; then
+        echo "eunit"
+    else
+        echo "typecheck"
+    fi
+}
+
+FORMAT=$(detect_format "$PR_LOG")
+
+# Parse a typecheck log file and set stats variables with a given prefix
+parse_typecheck_log() {
+    local file="$1"
+    local pfx="$2"
+
+    local total=0 ok=0 errors=0 timeouts=0 sum_ms=0 max_ms=0 min_ms=-1
+    local max_func="" min_func=""
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ \(([0-9]+)\ ms\) ]]; then
+            local ms="${BASH_REMATCH[1]}"
+            local func
+            func=$(echo "$line" | awk '{print $2}')
+
+            total=$((total + 1))
+            sum_ms=$((sum_ms + ms))
+
+            if [ "$ms" -gt "$max_ms" ]; then
+                max_ms=$ms
+                max_func=$func
+            fi
+            if [ "$min_ms" -lt 0 ] || [ "$ms" -lt "$min_ms" ]; then
+                min_ms=$ms
+                min_func=$func
+            fi
+
+            case "$line" in
+                Ok:*) ok=$((ok + 1)) ;;
+                Error:*) errors=$((errors + 1)) ;;
+                Timeout:*) timeouts=$((timeouts + 1)) ;;
+            esac
+        fi
+    done < "$file"
+
+    printf -v "${pfx}_TOTAL" '%s' "$total"
+    printf -v "${pfx}_OK" '%s' "$ok"
+    printf -v "${pfx}_ERRORS" '%s' "$errors"
+    printf -v "${pfx}_TIMEOUTS" '%s' "$timeouts"
+    printf -v "${pfx}_SUM_MS" '%s' "$sum_ms"
+    printf -v "${pfx}_MAX_MS" '%s' "$max_ms"
+    printf -v "${pfx}_MIN_MS" '%s' "$min_ms"
+    printf -v "${pfx}_MAX_FUNC" '%s' "$max_func"
+    printf -v "${pfx}_MIN_FUNC" '%s' "$min_func"
+}
+
+# Parse an eunit log file and set stats variables with a given prefix
+# Format: ...(test_files/tycheck_simple/file.erl/test_name (typecheck))...[1.234 s] ok
+parse_eunit_log() {
+    local file="$1"
+    local pfx="$2"
+
+    local total=0 ok=0 errors=0 sum_ms=0 max_ms=0 min_ms=-1
+    local max_func="" min_func=""
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ \[([0-9]+)\.([0-9]+)\ s\]\ (ok|FAILED) ]]; then
+            local secs="${BASH_REMATCH[1]}"
+            local frac="${BASH_REMATCH[2]}"
+            local status="${BASH_REMATCH[3]}"
+            # Convert to ms: seconds * 1000 + fraction
+            # frac could be 1-3 digits, pad/truncate to 3
+            frac="${frac}000"
+            frac="${frac:0:3}"
+            local ms=$(( secs * 1000 + 10#$frac ))
+
+            # Extract test name from parentheses before the timing
+            local func=""
+            local re='\((.+)\)\.\.\.\['
+            if [[ "$line" =~ $re ]]; then
+                func="${BASH_REMATCH[1]}"
+                # Shorten: "test_files/tycheck_simple/file.erl/test (mode)" -> "file.erl/test"
+                func=$(echo "$func" | sed 's|.*/\([^/]*/[^ ]*\).*|\1|')
+            fi
+
+            total=$((total + 1))
+            sum_ms=$((sum_ms + ms))
+
+            if [ "$ms" -gt "$max_ms" ]; then
+                max_ms=$ms
+                max_func=$func
+            fi
+            if [ "$min_ms" -lt 0 ] || [ "$ms" -lt "$min_ms" ]; then
+                min_ms=$ms
+                min_func=$func
+            fi
+
+            if [ "$status" = "ok" ]; then
+                ok=$((ok + 1))
+            else
+                errors=$((errors + 1))
+            fi
+        fi
+    done < "$file"
+
+    printf -v "${pfx}_TOTAL" '%s' "$total"
+    printf -v "${pfx}_OK" '%s' "$ok"
+    printf -v "${pfx}_ERRORS" '%s' "$errors"
+    printf -v "${pfx}_TIMEOUTS" '%s' "0"
+    printf -v "${pfx}_SUM_MS" '%s' "$sum_ms"
+    printf -v "${pfx}_MAX_MS" '%s' "$max_ms"
+    printf -v "${pfx}_MIN_MS" '%s' "$min_ms"
+    printf -v "${pfx}_MAX_FUNC" '%s' "$max_func"
+    printf -v "${pfx}_MIN_FUNC" '%s' "$min_func"
+}
+
+parse_log() {
+    if [ "$FORMAT" = "eunit" ]; then
+        parse_eunit_log "$1" "$2"
+    else
+        parse_typecheck_log "$1" "$2"
+    fi
+}
+
+fmt_time() {
+    local ms=$1
+    if [ "$ms" -ge 60000 ]; then
+        echo "$((ms / 60000))m $((ms % 60000 / 1000))s"
+    elif [ "$ms" -ge 1000 ]; then
+        echo "$((ms / 1000)).$((ms % 1000 / 100))s"
+    else
+        echo "${ms}ms"
+    fi
+}
+
+fmt_avg() {
+    local sum=$1 count=$2
+    if [ "$count" -eq 0 ]; then echo "0"; return; fi
+    local avg=$((sum * 10 / count))
+    echo "$((avg / 10)).$((avg % 10))"
+}
+
+fmt_delta() {
+    local pr_val=$1 base_val=$2
+    local diff=$((pr_val - base_val))
+    if [ "$diff" -gt 0 ]; then
+        echo "+$diff"
+    else
+        echo "$diff"
+    fi
+}
+
+# Parse PR log
+parse_log "$PR_LOG" "PR"
+
+if [ "$PR_TOTAL" -eq 0 ]; then
+    echo "No timing data found in PR log." >&2
+    exit 1
+fi
+
+PR_AVG=$(fmt_avg "$PR_SUM_MS" "$PR_TOTAL")
+PR_TIME_FMT=$(fmt_time "$PR_SUM_MS")
+
+# Check if we have base data
+HAS_BASE=false
+if [ -n "$BASE_LOG" ] && [ -f "$BASE_LOG" ]; then
+    parse_log "$BASE_LOG" "BASE"
+    if [ "$BASE_TOTAL" -gt 0 ]; then
+        HAS_BASE=true
+        BASE_AVG=$(fmt_avg "$BASE_SUM_MS" "$BASE_TOTAL")
+        BASE_TIME_FMT=$(fmt_time "$BASE_SUM_MS")
+    fi
+fi
+
+# Label for typecheck vs test
+if [ "$FORMAT" = "eunit" ]; then
+    LABEL="tests"
+    LABEL_SINGULAR="test"
+else
+    LABEL="functions"
+    LABEL_SINGULAR="function"
+fi
+
+if [ "$HAS_BASE" = true ]; then
+    DELTA_TOTAL=$(fmt_delta "$PR_TOTAL" "$BASE_TOTAL")
+    DELTA_OK=$(fmt_delta "$PR_OK" "$BASE_OK")
+    DELTA_ERRORS=$(fmt_delta "$PR_ERRORS" "$BASE_ERRORS")
+    DELTA_TIMEOUTS=$(fmt_delta "$PR_TIMEOUTS" "$BASE_TIMEOUTS")
+    DELTA_TIME_MS=$(fmt_delta "$PR_SUM_MS" "$BASE_SUM_MS")
+    DELTA_TIME_FMT=$(fmt_time "${DELTA_TIME_MS#[+-]}")
+    # Restore sign
+    case "$DELTA_TIME_MS" in
+        -*) DELTA_TIME_FMT="-$DELTA_TIME_FMT" ;;
+        +*) DELTA_TIME_FMT="+$DELTA_TIME_FMT" ;;
+        0)  DELTA_TIME_FMT="0" ;;
+    esac
+    DELTA_MAX=$(fmt_delta "$PR_MAX_MS" "$BASE_MAX_MS")
+    DELTA_MIN=$(fmt_delta "$PR_MIN_MS" "$BASE_MIN_MS")
+
+    # Compute avg delta
+    PR_AVG_X10=$((PR_SUM_MS * 10 / PR_TOTAL))
+    BASE_AVG_X10=$((BASE_SUM_MS * 10 / BASE_TOTAL))
+    DELTA_AVG_X10=$((PR_AVG_X10 - BASE_AVG_X10))
+    DELTA_AVG_SIGN=""
+    if [ "$DELTA_AVG_X10" -gt 0 ]; then DELTA_AVG_SIGN="+"; fi
+    DELTA_AVG="${DELTA_AVG_SIGN}$((DELTA_AVG_X10 / 10)).$((${DELTA_AVG_X10#-} % 10))"
+
+    MD="| Metric | PR | Base | Delta |
+|--------|----|------|-------|
+| Total $LABEL | $PR_TOTAL | $BASE_TOTAL | $DELTA_TOTAL |
+| OK | $PR_OK | $BASE_OK | $DELTA_OK |
+| Errors | $PR_ERRORS | $BASE_ERRORS | $DELTA_ERRORS |
+| Timeouts | $PR_TIMEOUTS | $BASE_TIMEOUTS | $DELTA_TIMEOUTS |
+| Total time | $PR_TIME_FMT | $BASE_TIME_FMT | $DELTA_TIME_FMT |
+| Avg per $LABEL_SINGULAR | ${PR_AVG}ms | ${BASE_AVG}ms | ${DELTA_AVG}ms |
+| Max | ${PR_MAX_MS}ms (\`$PR_MAX_FUNC\`) | ${BASE_MAX_MS}ms (\`$BASE_MAX_FUNC\`) | ${DELTA_MAX}ms |
+| Min | ${PR_MIN_MS}ms (\`$PR_MIN_FUNC\`) | ${BASE_MIN_MS}ms (\`$BASE_MIN_FUNC\`) | ${DELTA_MIN}ms |"
+else
+    MD="| Metric | Value |
+|--------|-------|
+| Total $LABEL | $PR_TOTAL |
+| OK | $PR_OK |
+| Errors | $PR_ERRORS |
+| Timeouts | $PR_TIMEOUTS |
+| Total time | $PR_TIME_FMT |
+| Avg per $LABEL_SINGULAR | ${PR_AVG}ms |
+| Max | ${PR_MAX_MS}ms (\`$PR_MAX_FUNC\`) |
+| Min | ${PR_MIN_MS}ms (\`$PR_MIN_FUNC\`) |"
+fi
+
+echo "$MD"
+
+if [ -n "$OUTPUT_FILE" ]; then
+    echo "$MD" > "$OUTPUT_FILE"
+fi

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -29,13 +29,39 @@ jobs:
           - name: dialyzer
             cmd: rebar3 as test dialyzer
           - name: typecheck
-            cmd: ./typecheck_erlang_types
+            cmd: ./typecheck_erlang_types --report-mode report --report-timeout 30000 2>&1 | tee /tmp/typecheck_report.log
           - name: syntax transformation
             cmd: ./_build/default/bin/etylizer --sanity --no-type-checking -I ./include -I ./src ./src/*.erl
     steps:
     - uses: actions/checkout@v4
     - run: make build
     - run: ${{ matrix.cmd }}
+    - name: Upload typecheck report
+      if: matrix.name == 'typecheck'
+      uses: actions/upload-artifact@v4
+      with:
+        name: typecheck-pr
+        path: /tmp/typecheck_report.log
+
+  typecheck-base:
+    name: "typecheck (base)"
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: erlang:28
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+    - run: make build
+    - run: ./typecheck_erlang_types --report-mode report --report-timeout 30000 2>&1 | tee /tmp/typecheck_report.log || true
+    - name: Upload typecheck report
+      uses: actions/upload-artifact@v4
+      with:
+        name: typecheck-base
+        path: /tmp/typecheck_report.log
 
   test:
     name: "test: ${{ matrix.name }}"
@@ -48,9 +74,11 @@ jobs:
       matrix:
         include:
           - name: typecheck
-            cmd: ./run_test.escript typecheck
+            cmd: ./run_test.escript typecheck 2>&1 | tee /tmp/test_report.log
+            artifact: test-typecheck-pr
           - name: infer
-            cmd: ./run_test.escript infer
+            cmd: ./run_test.escript infer 2>&1 | tee /tmp/test_report.log
+            artifact: test-infer-pr
           - name: property-based
             cmd: rebar3 proper
           - name: unit-test tests
@@ -61,6 +89,105 @@ jobs:
     - uses: actions/checkout@v4
     - run: make build
     - run: ${{ matrix.cmd }}
+    - name: Upload test report
+      if: matrix.artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact }}
+        path: /tmp/test_report.log
+
+  test-base:
+    name: "test (base): ${{ matrix.name }}"
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: erlang:28
+    strategy:
+      matrix:
+        include:
+          - name: typecheck
+            cmd: ./run_test.escript typecheck 2>&1 | tee /tmp/test_report.log
+            artifact: test-typecheck-base
+          - name: infer
+            cmd: ./run_test.escript infer 2>&1 | tee /tmp/test_report.log
+            artifact: test-infer-base
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+    - run: make build
+    - run: ${{ matrix.cmd }} || true
+    - name: Upload test report
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact }}
+        path: /tmp/test_report.log
+
+  ci-stats:
+    name: "CI stats"
+    needs: [verify, typecheck-base, test, test-base]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        path: /tmp/artifacts
+    - name: Generate stats
+      run: |
+        echo "## Typecheck Statistics" > /tmp/ci_stats.md
+        echo "" >> /tmp/ci_stats.md
+        .github/scripts/typecheck_stats.sh \
+          /tmp/artifacts/typecheck-pr/typecheck_report.log \
+          /tmp/artifacts/typecheck-base/typecheck_report.log \
+          >> /tmp/ci_stats.md
+        echo "" >> /tmp/ci_stats.md
+        echo "## Test Statistics: typecheck" >> /tmp/ci_stats.md
+        echo "" >> /tmp/ci_stats.md
+        .github/scripts/typecheck_stats.sh \
+          /tmp/artifacts/test-typecheck-pr/test_report.log \
+          /tmp/artifacts/test-typecheck-base/test_report.log \
+          >> /tmp/ci_stats.md
+        echo "" >> /tmp/ci_stats.md
+        echo "## Test Statistics: infer" >> /tmp/ci_stats.md
+        echo "" >> /tmp/ci_stats.md
+        .github/scripts/typecheck_stats.sh \
+          /tmp/artifacts/test-infer-pr/test_report.log \
+          /tmp/artifacts/test-infer-base/test_report.log \
+          >> /tmp/ci_stats.md
+    - name: Post stats to PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const statsFile = '/tmp/ci_stats.md';
+          if (!fs.existsSync(statsFile)) return;
+          const body = fs.readFileSync(statsFile, 'utf8');
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          const existing = comments.find(c =>
+            c.user.type === 'Bot' && c.body.includes('## Typecheck Statistics')
+          );
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }
 
   case-study:
     name: "case study: ${{ matrix.name }}"


### PR DESCRIPTION
 The typecheck verify job now prints statistics to any PR

- Added a step using actions/github-script@v7 that posts the markdown table as a PR comment (only on pull_request events)
- If a comment with "Typecheck Statistics" already exists (from a previous push), it updates it instead of creating a duplicate
- Added similar statistics for the typecheck simple test harness

The delta should not be given too much weight; being slower or faster usually depends on the current runner, and +-1 minute is not too unusual. It's included as a sanity check to not increase the test harness time by more than 200%, for example.