### PR TITLE
Prototype: Support for nominal types

### DIFF
--- a/src/erlang_types/dnf_ty_nominal.erl
+++ b/src/erlang_types/dnf_ty_nominal.erl
@@ -1,0 +1,115 @@
+-module(dnf_ty_nominal).
+
+%% BDD layer for nominal type tags.
+%% Sits between dnf_ty_variable (above) and ty_rec (below).
+%% Atoms are ty_nominal (nominal tags), leaves are ty_rec (structural types).
+
+-export([
+  is_literal_empty/1,
+  tuple_to_map/1,
+  nominal/2
+]).
+
+-define(ATOM, ty_nominal).
+-define(LEAF, ty_rec).
+
+-include("dnf/bdd.hrl").
+
+%% ===== Additional exports beyond bdd.hrl =====
+
+-spec is_literal_empty(type()) -> boolean().
+is_literal_empty(Bdd) -> Bdd =:= empty().
+
+-spec tuple_to_map(type()) -> type().
+tuple_to_map({leaf, Internal}) -> {leaf, ty_rec:tuple_to_map(Internal)};
+tuple_to_map({node, Tag, Pos, Neg}) -> {node, Tag, tuple_to_map(Pos), tuple_to_map(Neg)}.
+
+%% Wrap a dnf_ty_nominal BDD with a nominal tag.
+-spec nominal(ty_nominal:type(), type()) -> type().
+nominal(NomTag, NomBdd) ->
+  intersect(singleton(NomTag), NomBdd).
+
+%% ===== BDD callbacks =====
+
+%% Subtyping: is_empty_line
+%%
+%% A DNF line at the nominal level has:
+%%   AllPos = list of positive nominal tags
+%%   Neg = list of negative nominal tags
+%%   T = ty_rec leaf (structural type)
+%%
+%% The line is empty if:
+%%   1. The structural leaf is empty
+%%   2. Two+ positive tags are mutually exclusive (neither derives from the other)
+%%   3. Nominal compatibility: no positive tags + some negative tags (structural <: nominal),
+%%      or every negative tag's body contains some positive tag (derivation upcast)
+
+-spec is_empty_line({[T], [T], ?LEAF:type()}, S) -> {boolean(), S} when S :: is_empty_cache(), T :: ?ATOM:type().
+is_empty_line({AllPos, Neg, T}, ST) ->
+  case nominal_line_is_compatible(AllPos, Neg) of
+    true -> {true, ST};
+    false -> ty_rec:is_empty(T, ST)
+  end.
+
+%% Tallying: normalize_line
+%%
+%% At this level there are no type variables. All atoms are nominal tags
+%% which are effectively "delta" (fixed). We check nominal compatibility
+%% and otherwise delegate to ty_rec:normalize for structural checking.
+
+-spec normalize_line({[T], [T], ?LEAF:type()}, monomorphic_variables(), S) ->
+    {set_of_constraint_sets(), S} when S :: normalize_cache(), T :: ?ATOM:type().
+normalize_line({[], [], TyRec}, Fixed, ST) ->
+  ty_rec:normalize(TyRec, Fixed, ST);
+normalize_line({PVar, NVar, TyRec}, Fixed, ST) ->
+  case nominal_line_is_compatible(PVar, NVar) of
+    true -> {constraint_set:sat(), ST};
+    false -> ty_rec:normalize(TyRec, Fixed, ST)
+  end.
+
+%% Variables: all_variables_line
+%%
+%% No variables at this level. Delegate to ty_rec.
+
+-spec all_variables_line([T], [T], ?LEAF:type(), all_variables_cache()) -> sets:set(variable()) when T :: ?ATOM:type().
+all_variables_line(_P, _N, Leaf, Cache) ->
+  ty_rec:all_variables(Leaf, Cache).
+
+%% ===== Nominal logic =====
+
+%% Check if a DNF line's nominal tags make the line empty.
+%% Returns true (= line is empty) if:
+%% - Two+ positive tags are mutually exclusive (neither derives from the other)
+%% - No positive tags + some negative tags (structural <: nominal compatibility)
+%% - Every negative tag's body contains some positive tag (derivation upcast)
+-spec nominal_line_is_compatible([?ATOM:type()], [?ATOM:type()]) -> boolean().
+nominal_line_is_compatible(AllPos, Neg) ->
+  PosKeys = [ty_nominal:key(A) || A <- AllPos],
+  NegKeys = [ty_nominal:key(A) || A <- Neg],
+  case {PosKeys, NegKeys} of
+    {[_|_], []} ->
+      % Only positive tags, no negative: check mutual exclusion
+      has_incompatible_pair(PosKeys);
+    {[], [_|_]} ->
+      % Only negative tags: structural <: nominal, always compatible
+      true;
+    {[_|_], [_|_]} ->
+      % Both positive and negative: check mutual exclusion among positives,
+      % or derivation compatibility between positive and negative
+      has_incompatible_pair(PosKeys) orelse
+      lists:all(fun(NegKey) ->
+        lists:any(fun(PosKey) ->
+          ty_parser:nominal_derives_from(NegKey, PosKey)
+        end, PosKeys)
+      end, NegKeys);
+    {[], []} ->
+      false
+  end.
+
+-spec has_incompatible_pair([ty_nominal:nominal_key()]) -> boolean().
+has_incompatible_pair([]) -> false;
+has_incompatible_pair([K | Rest]) ->
+  lists:any(fun(K2) ->
+    not ty_parser:nominal_derives_from(K, K2) andalso
+    not ty_parser:nominal_derives_from(K2, K)
+  end, Rest) orelse has_incompatible_pair(Rest).

--- a/src/erlang_types/dnf_ty_variable.erl
+++ b/src/erlang_types/dnf_ty_variable.erl
@@ -17,31 +17,32 @@
 ]).
 
 -define(ATOM, ty_variable).
--define(LEAF, ty_rec).
+-define(LEAF, dnf_ty_nominal).
 
 -include("dnf/bdd.hrl").
 
 % helper constructors (used by ty_parser)
+% Each wraps a ty_rec value in a dnf_ty_nominal leaf, then in a dnf_ty_variable leaf.
 -spec atom(dnf_ty_atom:type()) -> bdd().
-atom(DnfTyAtom) -> leaf(ty_rec:atom(DnfTyAtom)).
+atom(DnfTyAtom) -> leaf(dnf_ty_nominal:leaf(ty_rec:atom(DnfTyAtom))).
 -spec interval(dnf_ty_interval:type()) -> bdd().
-interval(DnfTyInterval) -> leaf(ty_rec:interval(DnfTyInterval)).
+interval(DnfTyInterval) -> leaf(dnf_ty_nominal:leaf(ty_rec:interval(DnfTyInterval))).
 -spec functions(ty_functions:type()) -> bdd().
-functions(DnfTyFunctions) -> leaf(ty_rec:functions(DnfTyFunctions)).
+functions(DnfTyFunctions) -> leaf(dnf_ty_nominal:leaf(ty_rec:functions(DnfTyFunctions))).
 -spec tuples(ty_tuples:type()) -> bdd().
-tuples(DnfTyTuples) -> leaf(ty_rec:tuples(DnfTyTuples)).
+tuples(DnfTyTuples) -> leaf(dnf_ty_nominal:leaf(ty_rec:tuples(DnfTyTuples))).
 -spec list(dnf_ty_list:type()) -> bdd().
-list(DnfTyList) -> leaf(ty_rec:list(DnfTyList)).
+list(DnfTyList) -> leaf(dnf_ty_nominal:leaf(ty_rec:list(DnfTyList))).
 -spec predefined(dnf_ty_predefined:type()) -> bdd().
-predefined(DnfTyPredef) -> leaf(ty_rec:predefined(DnfTyPredef)).
+predefined(DnfTyPredef) -> leaf(dnf_ty_nominal:leaf(ty_rec:predefined(DnfTyPredef))).
 -spec bitstring(dnf_ty_bitstring:type()) -> bdd().
-bitstring(Dnf) -> leaf(ty_rec:bitstring(Dnf)).
+bitstring(Dnf) -> leaf(dnf_ty_nominal:leaf(ty_rec:bitstring(Dnf))).
 -spec map(dnf_ty_map:type()) -> bdd().
-map(Dnf) -> leaf(ty_rec:map(Dnf)).
+map(Dnf) -> leaf(dnf_ty_nominal:leaf(ty_rec:map(Dnf))).
 
 % encoded map has to be a leaf during parsing
 -spec tuple_to_map(leaf()) -> leaf().
-tuple_to_map({leaf, Internal}) -> {leaf, ty_rec:tuple_to_map(Internal)}.
+tuple_to_map({leaf, Internal}) -> {leaf, dnf_ty_nominal:tuple_to_map(Internal)}.
 
 % =============
 % Subtyping
@@ -49,11 +50,11 @@ tuple_to_map({leaf, Internal}) -> {leaf, ty_rec:tuple_to_map(Internal)}.
 
 -spec is_empty_line({[T], [T], ?LEAF:type()}, S) -> {boolean(), S} when S :: is_empty_cache(), T :: ?ATOM:type().
 is_empty_line({AllPos, Neg, T}, ST) ->
-  case {AllPos, Neg, ty_rec:is_literal_empty(T)} of
-    {_, _, true} -> 
+  case {AllPos, Neg, dnf_ty_nominal:is_literal_empty(T)} of
+    {_, _, true} ->
       {true, ST};
     {_PositiveVariables, _NegativeVariables, false} -> % ignore variables for emptiness
-      ty_rec:is_empty(T, ST)
+      dnf_ty_nominal:is_empty(T, ST)
   end.
 
 % =============
@@ -61,10 +62,10 @@ is_empty_line({AllPos, Neg, T}, ST) ->
 % =============
 
 % (NTLV rule)
--spec normalize_line({[T], [T], ?LEAF:type()}, monomorphic_variables(), S) -> 
+-spec normalize_line({[T], [T], ?LEAF:type()}, monomorphic_variables(), S) ->
     {set_of_constraint_sets(), S} when S :: normalize_cache(),T :: ?ATOM:type().
 normalize_line({[], [], TyRec}, Fixed, ST) ->
-  ty_rec:normalize(TyRec, Fixed, ST);
+  dnf_ty_nominal:normalize(TyRec, Fixed, ST);
 normalize_line({PVar, NVar, TyRec}, Fixed, ST) ->
   SmallestVar = smallest(PVar, NVar, Fixed),
   %io:format(user, "Got smallest var ~p~n", [SmallestVar]),
@@ -79,12 +80,12 @@ normalize_line({PVar, NVar, TyRec}, Fixed, ST) ->
       {[[{Var, ty_node:make(Singled), ty_node:any()}]], ST};
     {{{delta, _}, _}, _} ->
       % part 1 paper Lemma C.3 and C.11 all fixed variables can be eliminated
-      ty_rec:normalize(TyRec, Fixed, ST)
+      dnf_ty_nominal:normalize(TyRec, Fixed, ST)
   end.
 
 % assumption: PVars U NVars is not empty
 -type tagged_variable() :: {pos | neg | {delta, pos | neg}, ?ATOM:type()}.
--spec smallest([T], [T], monomorphic_variables()) -> 
+-spec smallest([T], [T], monomorphic_variables()) ->
     {tagged_variable(), [tagged_variable()]} when T :: ?ATOM:type().
 smallest(PositiveVariables, NegativeVariables, FixedVariables) ->
   ?assert_pattern(true, (length(PositiveVariables) + length(NegativeVariables)) > 0),
@@ -98,23 +99,23 @@ smallest(PositiveVariables, NegativeVariables, FixedVariables) ->
     [{{delta, pos}, V} || V <- PositiveVariables, maps:is_key(V, FixedVariables)],
 
   Sort = fun({_, V}, {_, V2}) -> ty_variable:leq(V, V2) end,
-  [X | Z] = 
-  ?assert_pattern([_ | _], 
-                  lists:sort(Sort, PositiveVariablesTagged++NegativeVariablesTagged) ++ 
+  [X | Z] =
+  ?assert_pattern([_ | _],
+                  lists:sort(Sort, PositiveVariablesTagged++NegativeVariablesTagged) ++
                   lists:sort(Sort, RestTagged)),
 
   {X, Z}.
 
 -spec single(boolean(), [T], [T], ?LEAF:type()) -> bdd() when T :: ?ATOM:type().
 single(Pol, VPos, VNeg, Ty) ->
-  AccP = lists:foldl(fun(Var, TTy) -> 
+  AccP = lists:foldl(fun(Var, TTy) ->
     VVar = dnf_ty_variable:singleton(Var),
-    intersect(TTy, VVar) 
+    intersect(TTy, VVar)
   end, leaf(Ty), VPos),
 
-  AccN = lists:foldl(fun(Var, TTy) -> 
+  AccN = lists:foldl(fun(Var, TTy) ->
     VVar = dnf_ty_variable:singleton(Var),
-    union(TTy, VVar) 
+    union(TTy, VVar)
   end, empty(), VNeg),
 
   S = difference(AccP, AccN),
@@ -127,5 +128,5 @@ single(Pol, VPos, VNeg, Ty) ->
 all_variables_line(P, N, Leaf, Cache) ->
   sets:union([sets:from_list(P),
               sets:from_list(N),
-              ty_rec:all_variables(Leaf, Cache)
+              dnf_ty_nominal:all_variables(Leaf, Cache)
              ]).

--- a/src/erlang_types/dnf_ty_variable.erl
+++ b/src/erlang_types/dnf_ty_variable.erl
@@ -17,7 +17,7 @@
 ]).
 
 -define(ATOM, ty_variable).
--define(LEAF, ty_rec).
+-define(LEAF, dnf_ty_nominal).
 % the variable BDD substitutes variables, so it supplies its own substitute/3
 % instead of the node-remapping default in bdd.hrl
 -define(VARIABLE_BDD, true).
@@ -25,26 +25,27 @@
 -include("dnf/bdd.hrl").
 
 % helper constructors (used by ty_parser)
+% Each wraps a ty_rec value in a dnf_ty_nominal leaf, then in a dnf_ty_variable leaf.
 -spec atom(dnf_ty_atom:type()) -> bdd().
-atom(DnfTyAtom) -> leaf(ty_rec:atom(DnfTyAtom)).
+atom(DnfTyAtom) -> leaf(dnf_ty_nominal:leaf(ty_rec:atom(DnfTyAtom))).
 -spec interval(dnf_ty_interval:type()) -> bdd().
-interval(DnfTyInterval) -> leaf(ty_rec:interval(DnfTyInterval)).
+interval(DnfTyInterval) -> leaf(dnf_ty_nominal:leaf(ty_rec:interval(DnfTyInterval))).
 -spec functions(ty_functions:type()) -> bdd().
-functions(DnfTyFunctions) -> leaf(ty_rec:functions(DnfTyFunctions)).
+functions(DnfTyFunctions) -> leaf(dnf_ty_nominal:leaf(ty_rec:functions(DnfTyFunctions))).
 -spec tuples(ty_tuples:type()) -> bdd().
-tuples(DnfTyTuples) -> leaf(ty_rec:tuples(DnfTyTuples)).
+tuples(DnfTyTuples) -> leaf(dnf_ty_nominal:leaf(ty_rec:tuples(DnfTyTuples))).
 -spec list(dnf_ty_list:type()) -> bdd().
-list(DnfTyList) -> leaf(ty_rec:list(DnfTyList)).
+list(DnfTyList) -> leaf(dnf_ty_nominal:leaf(ty_rec:list(DnfTyList))).
 -spec predefined(dnf_ty_predefined:type()) -> bdd().
-predefined(DnfTyPredef) -> leaf(ty_rec:predefined(DnfTyPredef)).
+predefined(DnfTyPredef) -> leaf(dnf_ty_nominal:leaf(ty_rec:predefined(DnfTyPredef))).
 -spec bitstring(dnf_ty_bitstring:type()) -> bdd().
-bitstring(Dnf) -> leaf(ty_rec:bitstring(Dnf)).
+bitstring(Dnf) -> leaf(dnf_ty_nominal:leaf(ty_rec:bitstring(Dnf))).
 -spec map(dnf_ty_map:type()) -> bdd().
-map(Dnf) -> leaf(ty_rec:map(Dnf)).
+map(Dnf) -> leaf(dnf_ty_nominal:leaf(ty_rec:map(Dnf))).
 
 % encoded map has to be a leaf during parsing
 -spec tuple_to_map(leaf()) -> leaf().
-tuple_to_map({leaf, Internal}) -> {leaf, ty_rec:tuple_to_map(Internal)}.
+tuple_to_map({leaf, Internal}) -> {leaf, dnf_ty_nominal:tuple_to_map(Internal)}.
 
 % =============
 % Subtyping
@@ -52,11 +53,11 @@ tuple_to_map({leaf, Internal}) -> {leaf, ty_rec:tuple_to_map(Internal)}.
 
 -spec is_empty_line({[T], [T], ?LEAF:type()}, S) -> {boolean(), S} when S :: is_empty_cache(), T :: ?ATOM:type().
 is_empty_line({AllPos, Neg, T}, ST) ->
-  case {AllPos, Neg, ty_rec:is_literal_empty(T)} of
-    {_, _, true} -> 
+  case {AllPos, Neg, dnf_ty_nominal:is_literal_empty(T)} of
+    {_, _, true} ->
       {true, ST};
     {_PositiveVariables, _NegativeVariables, false} -> % ignore variables for emptiness
-      ty_rec:is_empty(T, ST)
+      dnf_ty_nominal:is_empty(T, ST)
   end.
 
 % =============
@@ -64,10 +65,10 @@ is_empty_line({AllPos, Neg, T}, ST) ->
 % =============
 
 % (NTLV rule)
--spec normalize_line({[T], [T], ?LEAF:type()}, monomorphic_variables(), S) -> 
+-spec normalize_line({[T], [T], ?LEAF:type()}, monomorphic_variables(), S) ->
     {set_of_constraint_sets(), S} when S :: normalize_cache(),T :: ?ATOM:type().
 normalize_line({[], [], TyRec}, Fixed, ST) ->
-  ty_rec:normalize(TyRec, Fixed, ST);
+  dnf_ty_nominal:normalize(TyRec, Fixed, ST);
 normalize_line({PVar, NVar, TyRec}, Fixed, ST) ->
   SmallestVar = smallest(PVar, NVar, Fixed),
   %io:format(user, "Got smallest var ~p~n", [SmallestVar]),
@@ -82,12 +83,12 @@ normalize_line({PVar, NVar, TyRec}, Fixed, ST) ->
       {[[{Var, ty_node:make(Singled), ty_node:any()}]], ST};
     {{{delta, _}, _}, _} ->
       % part 1 paper Lemma C.3 and C.11 all fixed variables can be eliminated
-      ty_rec:normalize(TyRec, Fixed, ST)
+      dnf_ty_nominal:normalize(TyRec, Fixed, ST)
   end.
 
 % assumption: PVars U NVars is not empty
 -type tagged_variable() :: {pos | neg | {delta, pos | neg}, ?ATOM:type()}.
--spec smallest([T], [T], monomorphic_variables()) -> 
+-spec smallest([T], [T], monomorphic_variables()) ->
     {tagged_variable(), [tagged_variable()]} when T :: ?ATOM:type().
 smallest(PositiveVariables, NegativeVariables, FixedVariables) ->
   ?assert_pattern(true, (length(PositiveVariables) + length(NegativeVariables)) > 0),
@@ -101,23 +102,23 @@ smallest(PositiveVariables, NegativeVariables, FixedVariables) ->
     [{{delta, pos}, V} || V <- PositiveVariables, maps:is_key(V, FixedVariables)],
 
   Sort = fun({_, V}, {_, V2}) -> ty_variable:leq(V, V2) end,
-  [X | Z] = 
-  ?assert_pattern([_ | _], 
-                  lists:sort(Sort, PositiveVariablesTagged++NegativeVariablesTagged) ++ 
+  [X | Z] =
+  ?assert_pattern([_ | _],
+                  lists:sort(Sort, PositiveVariablesTagged++NegativeVariablesTagged) ++
                   lists:sort(Sort, RestTagged)),
 
   {X, Z}.
 
 -spec single(boolean(), [T], [T], ?LEAF:type()) -> bdd() when T :: ?ATOM:type().
 single(Pol, VPos, VNeg, Ty) ->
-  AccP = lists:foldl(fun(Var, TTy) -> 
+  AccP = lists:foldl(fun(Var, TTy) ->
     VVar = dnf_ty_variable:singleton(Var),
-    intersect(TTy, VVar) 
+    intersect(TTy, VVar)
   end, leaf(Ty), VPos),
 
-  AccN = lists:foldl(fun(Var, TTy) -> 
+  AccN = lists:foldl(fun(Var, TTy) ->
     VVar = dnf_ty_variable:singleton(Var),
-    union(TTy, VVar) 
+    union(TTy, VVar)
   end, empty(), VNeg),
 
   S = difference(AccP, AccN),
@@ -130,7 +131,7 @@ single(Pol, VPos, VNeg, Ty) ->
 all_variables_line(P, N, Leaf, Cache) ->
   sets:union([sets:from_list(P),
               sets:from_list(N),
-              ty_rec:all_variables(Leaf, Cache)
+              dnf_ty_nominal:all_variables(Leaf, Cache)
              ]).
 
 % Substitute variables (Sigma) and node references (NodeMap) in this BDD. 
@@ -140,7 +141,7 @@ all_variables_line(P, N, Leaf, Cache) ->
 -spec substitute(bdd(), #{variable() => ty_node:type()}, #{ty_node:type() => ty_node:type()}) -> bdd().
 substitute(BDD, Sigma, NodeMap) ->
   substitute_bdd(BDD,
-    fun(Leaf) -> ty_rec:substitute(Leaf, NodeMap) end,
+    fun(Leaf) -> dnf_ty_nominal:substitute(Leaf, #{}, NodeMap) end,
     fun(Var) ->
       case maps:find(Var, Sigma) of
         {ok, TNode} -> ty_node:load(TNode);

--- a/src/erlang_types/ty_function.erl
+++ b/src/erlang_types/ty_function.erl
@@ -41,7 +41,7 @@ function(Refs, Ref2) when is_list(Refs) ->
 % domain is returned as a type, not as a list of types!
 -spec domain(type()) -> ?NODE:type().
 domain({ty_function, Domains, _}) ->
-  D = dnf_ty_variable:leaf(ty_rec:tuples(ty_tuples:singleton(length(Domains), dnf_ty_tuple:singleton(ty_tuple:tuple(Domains))))),
+  D = dnf_ty_variable:tuples(ty_tuples:singleton(length(Domains), dnf_ty_tuple:singleton(ty_tuple:tuple(Domains)))),
   ty_node:make(D).
 
 -spec codomain(type()) -> ?NODE:type().

--- a/src/erlang_types/ty_function.erl
+++ b/src/erlang_types/ty_function.erl
@@ -42,7 +42,7 @@ function(Refs, Ref2) when is_list(Refs) ->
 % domain is returned as a type, not as a list of types!
 -spec domain(type()) -> ?NODE:type().
 domain({ty_function, Domains, _}) ->
-  D = dnf_ty_variable:leaf(ty_rec:tuples(ty_tuples:singleton(length(Domains), dnf_ty_tuple:singleton(ty_tuple:tuple(Domains))))),
+  D = dnf_ty_variable:tuples(ty_tuples:singleton(length(Domains), dnf_ty_tuple:singleton(ty_tuple:tuple(Domains)))),
   ty_node:make(D).
 
 -spec codomain(type()) -> ?NODE:type().

--- a/src/erlang_types/ty_map.erl
+++ b/src/erlang_types/ty_map.erl
@@ -39,10 +39,10 @@ unparse({ty_tuple, 2, [TupPart, FunPart]}, ST0) ->
 
 -spec unparse_fun_part(ty_node:type(), S) -> {ast_ty(), S} when S :: unparse_cache().
 unparse_fun_part(FunPart, ST) ->
-    % a map should definitely not have any variables
-    {leaf, TyFunPart} = case ty_node:load(FunPart) of 
-                             {leaf, TyFunPart1} -> {leaf, TyFunPart1}; 
-                             _ -> error(badarg) 
+    % a map should definitely not have any variables or nominal tags
+    {leaf, {leaf, TyFunPart}} = case ty_node:load(FunPart) of
+                             {leaf, {leaf, TyFunPart1}} -> {leaf, {leaf, TyFunPart1}};
+                             _ -> error(badarg)
                          end, % non-exhaustive
     case TyFunPart of
         empty -> error(badarg);
@@ -68,10 +68,10 @@ unparse_fun_part_dnf(FunsDnf, ST) ->
 
 -spec unparse_tuple_part(ty_node:type(), S) -> {{predef, none} | {union, [ast:ty_tuple()]}, S} when S :: unparse_cache().
 unparse_tuple_part(TupPart, ST) ->
-    % a map should definitely not have any variables
-    {leaf, TyTupPart0} = case ty_node:load(TupPart) of 
-                             {leaf, TyTupPart1} -> {leaf, TyTupPart1}; 
-                             _ -> error(badarg) 
+    % a map should definitely not have any variables or nominal tags
+    {leaf, {leaf, TyTupPart0}} = case ty_node:load(TupPart) of
+                             {leaf, {leaf, TyTupPart1}} -> {leaf, {leaf, TyTupPart1}};
+                             _ -> error(badarg)
                          end, % non-exhaustive
 
     % remove the part that makes the tuple part always non-empty

--- a/src/erlang_types/ty_map.erl
+++ b/src/erlang_types/ty_map.erl
@@ -43,10 +43,10 @@ unparse({ty_tuple, 2, [TupPart, FunPart]}, ST0) ->
 
 -spec unparse_fun_part(ty_node:type(), S) -> {ast_ty(), S} when S :: unparse_cache().
 unparse_fun_part(FunPart, ST) ->
-    % a map should definitely not have any variables
-    {leaf, TyFunPart} = case ty_node:load(FunPart) of 
-                             {leaf, TyFunPart1} -> {leaf, TyFunPart1}; 
-                             _ -> error(badarg) 
+    % a map should definitely not have any variables or nominal tags
+    {leaf, {leaf, TyFunPart}} = case ty_node:load(FunPart) of
+                             {leaf, {leaf, TyFunPart1}} -> {leaf, {leaf, TyFunPart1}};
+                             _ -> error(badarg)
                          end, % non-exhaustive
     case TyFunPart of
         empty -> error(badarg);
@@ -72,10 +72,10 @@ unparse_fun_part_dnf(FunsDnf, ST) ->
 
 -spec unparse_tuple_part(ty_node:type(), S) -> {{predef, none} | {union, [ast:ty_tuple()]}, S} when S :: unparse_cache().
 unparse_tuple_part(TupPart, ST) ->
-    % a map should definitely not have any variables
-    {leaf, TyTupPart0} = case ty_node:load(TupPart) of 
-                             {leaf, TyTupPart1} -> {leaf, TyTupPart1}; 
-                             _ -> error(badarg) 
+    % a map should definitely not have any variables or nominal tags
+    {leaf, {leaf, TyTupPart0}} = case ty_node:load(TupPart) of
+                             {leaf, {leaf, TyTupPart1}} -> {leaf, {leaf, TyTupPart1}};
+                             _ -> error(badarg)
                          end, % non-exhaustive
 
     % remove the part that makes the tuple part always non-empty

--- a/src/erlang_types/ty_node.erl
+++ b/src/erlang_types/ty_node.erl
@@ -159,7 +159,7 @@ force_load(Reference = {node, Id}, Node) ->
   % update counter
   CurrentId = ets:update_counter(?ID, id, 0),
   case CurrentId < Id of
-    true -> 
+    true ->
       ets:update_counter(?ID, id, (Id - CurrentId + 1));
     _ -> ok
   end,

--- a/src/erlang_types/ty_node.erl
+++ b/src/erlang_types/ty_node.erl
@@ -143,7 +143,7 @@ force_load(Reference = {node, Id}, Node) ->
   % update counter
   CurrentId = ets:update_counter(?ID, id, 0),
   case CurrentId < Id of
-    true -> 
+    true ->
       ets:update_counter(?ID, id, (Id - CurrentId + 1));
     _ -> ok
   end,

--- a/src/erlang_types/ty_nominal.erl
+++ b/src/erlang_types/ty_nominal.erl
@@ -1,0 +1,40 @@
+-module(ty_nominal).
+
+%% Atom type for nominal BDD nodes.
+%% A nominal key identifies a nominal type by its module, name, and arity.
+
+-export([
+  equal/2,
+  compare/2,
+  leq/2,
+  unparse/2,
+  new/1,
+  key/1
+]).
+
+-export_type([type/0, nominal_key/0]).
+
+-type nominal_key() :: {atom(), atom(), non_neg_integer()}.
+-opaque type() :: {nominal_tag, nominal_key()}.
+
+-spec new(nominal_key()) -> type().
+new(Key) -> {nominal_tag, Key}.
+
+-spec key(type()) -> nominal_key().
+key({nominal_tag, Key}) -> Key.
+
+-spec equal(type(), type()) -> boolean().
+equal(T1, T2) -> compare(T1, T2) =:= eq.
+
+-spec compare(type(), type()) -> lt | eq | gt.
+compare({nominal_tag, K1}, {nominal_tag, K2}) ->
+  if K1 < K2 -> lt; K1 > K2 -> gt; true -> eq end.
+
+-spec leq(type(), type()) -> boolean().
+leq(T1, T2) ->
+  C = compare(T1, T2),
+  C =:= eq orelse C =:= lt.
+
+-spec unparse(type(), ST) -> {ast:ty(), ST}.
+unparse({nominal_tag, {Mod, Name, Arity}}, C) ->
+  {{named, ast:loc_auto(), {ty_ref, Mod, Name, Arity}, []}, C}.

--- a/src/erlang_types/ty_nominal.erl
+++ b/src/erlang_types/ty_nominal.erl
@@ -1,0 +1,46 @@
+-module(ty_nominal).
+
+%% Atom type for nominal BDD nodes.
+%% A nominal key identifies a nominal type by its module, name, and arity.
+
+-export([
+  equal/2,
+  compare/2,
+  leq/2,
+  substitute/2,
+  unparse/2,
+  new/1,
+  key/1
+]).
+
+-export_type([type/0, nominal_key/0]).
+
+-type nominal_key() :: {atom(), atom(), non_neg_integer()}.
+-opaque type() :: {nominal_tag, nominal_key()}.
+
+-spec new(nominal_key()) -> type().
+new(Key) -> {nominal_tag, Key}.
+
+-spec key(type()) -> nominal_key().
+key({nominal_tag, Key}) -> Key.
+
+-spec equal(type(), type()) -> boolean().
+equal(T1, T2) -> compare(T1, T2) =:= eq.
+
+-spec compare(type(), type()) -> lt | eq | gt.
+compare({nominal_tag, K1}, {nominal_tag, K2}) ->
+  if K1 < K2 -> lt; K1 > K2 -> gt; true -> eq end.
+
+-spec leq(type(), type()) -> boolean().
+leq(T1, T2) ->
+  C = compare(T1, T2),
+  C =:= eq orelse C =:= lt.
+
+% A nominal tag is just a {Mod, Name, Arity} key with no embedded ty_node refs,
+% so node-remapping substitution (called via dnf_ty_nominal's ?ATOM) is identity.
+-spec substitute(type(), #{ty_node:type() => ty_node:type()}) -> type().
+substitute(T, _NodeMap) -> T.
+
+-spec unparse(type(), ST) -> {ast:ty(), ST}.
+unparse({nominal_tag, {Mod, Name, Arity}}, C) ->
+  {{named, ast:loc_auto(), {ty_ref, Mod, Name, Arity}, []}, C}.

--- a/src/erlang_types/ty_parser.erl
+++ b/src/erlang_types/ty_parser.erl
@@ -49,7 +49,12 @@
 -define(UNPARSE_NAMED_QUEUE, ty_parser_unparse_queue).
 -define(UNPARSE_NAMED_FINISHED, ty_parser_unparse_finish).
 
--define(ALL_ETS, [?CACHE, ?SYMTAB, ?TERMREFS, ?UNIFY, ?UNPARSE_CACHE, ?UNPARSE_NAMED_QUEUE, ?UNPARSE_NAMED_FINISHED, ?UNPARSE_NAMED_MAPPING, ?LOCAL_TO_NODE_MAPPING]).
+% set of nominal type keys (from symtab)
+-define(NOMINALS, ty_parser_nominals).
+% derivation map: {NomKey1, NomKey2} means NomKey1's body contains NomKey2
+-define(NOMINAL_DERIVES, ty_parser_nominal_derives).
+
+-define(ALL_ETS, [?CACHE, ?SYMTAB, ?TERMREFS, ?UNIFY, ?UNPARSE_CACHE, ?UNPARSE_NAMED_QUEUE, ?UNPARSE_NAMED_FINISHED, ?UNPARSE_NAMED_MAPPING, ?LOCAL_TO_NODE_MAPPING, ?NOMINALS, ?NOMINAL_DERIVES]).
 
 -define(TY, dnf_ty_variable).
 -define(NODE, ty_node).
@@ -138,7 +143,61 @@ clean() ->
 set_symtab(SymTab) ->
   Types = symtab:get_types(SymTab),
   % elp:ignore W0034
-  [ty_parser:extend_symtab(K, V) || {K, V} <- maps:to_list(Types)].
+  [ty_parser:extend_symtab(K, V) || {K, V} <- maps:to_list(Types)],
+  % Store nominal type keys for wrapping during parsing
+  Nominals = symtab:get_nominals(SymTab),
+  ets:delete_all_objects(?NOMINALS),
+  NomList = sets:to_list(Nominals),
+  lists:foreach(fun(Key) -> ets:insert(?NOMINALS, {Key}) end, NomList),
+  % Build and store derivation map for nominal types
+  ets:delete_all_objects(?NOMINAL_DERIVES),
+  build_and_store_derivation_map(SymTab, NomList).
+
+-spec build_and_store_derivation_map(symtab:t(), [symtab:ty_key()]) -> ok.
+build_and_store_derivation_map(Tab, NomKeys) ->
+  lists:foreach(fun({ty_key, M, N, A} = Key) ->
+    Ref = {ty_ref, M, N, A},
+    Derives = find_derived_nominals(Tab, Key, Ref, sets:new()),
+    lists:foreach(fun(DerivedKey) ->
+      ets:insert(?NOMINAL_DERIVES, {{Key, DerivedKey}})
+    end, sets:to_list(Derives))
+  end, NomKeys),
+  ok.
+
+-spec find_derived_nominals(symtab:t(), symtab:ty_key(), ast:ty_ref(), sets:set(symtab:ty_key())) -> sets:set(symtab:ty_key()).
+find_derived_nominals(Tab, Key, Ref, Visited) ->
+  case sets:is_element(Key, Visited) of
+    true -> sets:new();
+    false ->
+      {ty_scheme, Vars, Body} = symtab:lookup_ty(Ref, ast:loc_auto(), Tab),
+      VarNames = [V || {V, _Bound} <- Vars],
+      Args = [{predef, any} || _ <- VarNames],
+      SubstBody = case length(VarNames) =:= length(Args) andalso Args =/= [] of
+        true ->
+          Map = subst:from_list(lists:zip(VarNames, Args)),
+          subst:apply(Map, Body, no_clean);
+        false -> Body
+      end,
+      Visited1 = sets:add_element(Key, Visited),
+      DirectNominals = collect_nominal_refs(Tab, SubstBody),
+      sets:fold(fun(DerivedKey, Acc) ->
+        {ty_key, DM, DN, DA} = DerivedKey,
+        Transitive = find_derived_nominals(Tab, DerivedKey, {ty_ref, DM, DN, DA}, Visited1),
+        sets:union(sets:add_element(DerivedKey, Transitive), Acc)
+      end, DirectNominals, DirectNominals)
+  end.
+
+-spec collect_nominal_refs(symtab:t(), ast:ty()) -> sets:set(symtab:ty_key()).
+collect_nominal_refs(Tab, Ty) ->
+  Refs = utils:everything(
+    fun ({named, _, Ref, _}) ->
+      case symtab:is_nominal(Ref, Tab) of
+        true -> {ok, symtab:ref_to_key(Ref)};
+        false -> error
+      end;
+      (_) -> error
+    end, Ty),
+  sets:from_list(Refs).
 
 -spec lookup_ref(temporary_ref()) -> type(). 
 lookup_ref(Ref) ->
@@ -452,6 +511,28 @@ new_local_ref(RawTerm) ->
 
   Final.
 
+-spec nominal_derives_from(ty_nominal:nominal_key(), ty_nominal:nominal_key()) -> boolean().
+nominal_derives_from({M1, N1, A1}, {M2, N2, A2}) ->
+  ets:member(?NOMINAL_DERIVES, {{ty_key, M1, N1, A1}, {ty_key, M2, N2, A2}}).
+
+% Wrap each leaf of a dnf_ty_variable BDD with a nominal tag at the dnf_ty_nominal level.
+-spec wrap_nominal_tag(ty_nominal:type(), dnf_ty_variable:type()) -> dnf_ty_variable:type().
+wrap_nominal_tag(NomTag, {leaf, NomBdd}) ->
+  {leaf, dnf_ty_nominal:nominal(NomTag, NomBdd)};
+wrap_nominal_tag(NomTag, {node, Var, Pos, Neg}) ->
+  {node, Var, wrap_nominal_tag(NomTag, Pos), wrap_nominal_tag(NomTag, Neg)}.
+
+-spec is_nominal_ref(ety_ref()) -> boolean().
+is_nominal_ref({ty_ref, M, N, A}) ->
+  ets:member(?NOMINALS, {ty_key, M, N, A});
+is_nominal_ref({ty_qref, M, N, A}) ->
+  ets:member(?NOMINALS, {ty_key, M, N, A});
+is_nominal_ref(_) -> false.
+
+-spec ref_to_nominal_key(ety_ref()) -> ty_nominal:nominal_key().
+ref_to_nominal_key({ty_ref, M, N, A}) -> {M, N, A};
+ref_to_nominal_key({ty_qref, M, N, A}) -> {M, N, A}.
+
 -spec extend_symtab(ast:ty_ref(), ety_ty_scheme()) -> _.
 extend_symtab({_, Namespace, Type, ArgsCount}, RawTyScheme) ->
   Ref = {Namespace, Type, ArgsCount},
@@ -523,7 +604,14 @@ do_convert_named_new(X, Ref, Args, R, Q, Cache) ->
   case ets:lookup(?CACHE, NewRef) of
     [] ->
       % create a new reference (ref args pair), memoize, and add continue converting
-      {InternalTy, NewQ, {R0, R1}, C0} = do_convert({NewTy, R}, Q, Cache#{{Ref, Args} => NewRef}),
+      {InternalTy0, NewQ, {R0, R1}, C0} = do_convert({NewTy, R}, Q, Cache#{{Ref, Args} => NewRef}),
+      % If the type is nominal, wrap with a nominal tag at the dnf_ty_nominal level
+      InternalTy = case is_nominal_ref(Ref) of
+        true ->
+          NomTag = ty_nominal:new(ref_to_nominal_key(Ref)),
+          wrap_nominal_tag(NomTag, InternalTy0);
+        false -> InternalTy0
+      end,
       {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}, C0};
     [{NewRef, CachedNode}] ->
       % reuse type representation of the global cache

--- a/src/erlang_types/ty_parser.erl
+++ b/src/erlang_types/ty_parser.erl
@@ -36,7 +36,12 @@
 -define(UNPARSE_NAMED_QUEUE, ty_parser_unparse_queue).
 -define(UNPARSE_NAMED_FINISHED, ty_parser_unparse_finish).
 
--define(ALL_ETS, [?CACHE, ?SYMTAB, ?TERMREFS, ?UNIFY, ?UNPARSE_CACHE, ?UNPARSE_NAMED_QUEUE, ?UNPARSE_NAMED_FINISHED, ?UNPARSE_NAMED_MAPPING]).
+% set of nominal type keys (from symtab)
+-define(NOMINALS, ty_parser_nominals).
+% derivation map: {NomKey1, NomKey2} means NomKey1's body contains NomKey2
+-define(NOMINAL_DERIVES, ty_parser_nominal_derives).
+
+-define(ALL_ETS, [?CACHE, ?SYMTAB, ?TERMREFS, ?UNIFY, ?UNPARSE_CACHE, ?UNPARSE_NAMED_QUEUE, ?UNPARSE_NAMED_FINISHED, ?UNPARSE_NAMED_MAPPING, ?NOMINALS, ?NOMINAL_DERIVES]).
 
 -define(TY, dnf_ty_variable).
 -define(NODE, ty_node).
@@ -128,7 +133,61 @@ clean() ->
 set_symtab(SymTab) ->
   Types = symtab:get_types(SymTab),
   % elp:ignore W0034
-  [ty_parser:extend_symtab(K, V) || {K, V} <- maps:to_list(Types)].
+  [ty_parser:extend_symtab(K, V) || {K, V} <- maps:to_list(Types)],
+  % Store nominal type keys for wrapping during parsing
+  Nominals = symtab:get_nominals(SymTab),
+  ets:delete_all_objects(?NOMINALS),
+  NomList = sets:to_list(Nominals),
+  lists:foreach(fun(Key) -> ets:insert(?NOMINALS, {Key}) end, NomList),
+  % Build and store derivation map for nominal types
+  ets:delete_all_objects(?NOMINAL_DERIVES),
+  build_and_store_derivation_map(SymTab, NomList).
+
+-spec build_and_store_derivation_map(symtab:t(), [symtab:ty_key()]) -> ok.
+build_and_store_derivation_map(Tab, NomKeys) ->
+  lists:foreach(fun({ty_key, M, N, A} = Key) ->
+    Ref = {ty_ref, M, N, A},
+    Derives = find_derived_nominals(Tab, Key, Ref, sets:new()),
+    lists:foreach(fun(DerivedKey) ->
+      ets:insert(?NOMINAL_DERIVES, {{Key, DerivedKey}})
+    end, sets:to_list(Derives))
+  end, NomKeys),
+  ok.
+
+-spec find_derived_nominals(symtab:t(), symtab:ty_key(), ast:ty_ref(), sets:set(symtab:ty_key())) -> sets:set(symtab:ty_key()).
+find_derived_nominals(Tab, Key, Ref, Visited) ->
+  case sets:is_element(Key, Visited) of
+    true -> sets:new();
+    false ->
+      {ty_scheme, Vars, Body} = symtab:lookup_ty(Ref, ast:loc_auto(), Tab),
+      VarNames = [V || {V, _Bound} <- Vars],
+      Args = [{predef, any} || _ <- VarNames],
+      SubstBody = case length(VarNames) =:= length(Args) andalso Args =/= [] of
+        true ->
+          Map = subst:from_list(lists:zip(VarNames, Args)),
+          subst:apply(Map, Body, no_clean);
+        false -> Body
+      end,
+      Visited1 = sets:add_element(Key, Visited),
+      DirectNominals = collect_nominal_refs(Tab, SubstBody),
+      sets:fold(fun(DerivedKey, Acc) ->
+        {ty_key, DM, DN, DA} = DerivedKey,
+        Transitive = find_derived_nominals(Tab, DerivedKey, {ty_ref, DM, DN, DA}, Visited1),
+        sets:union(sets:add_element(DerivedKey, Transitive), Acc)
+      end, DirectNominals, DirectNominals)
+  end.
+
+-spec collect_nominal_refs(symtab:t(), ast:ty()) -> sets:set(symtab:ty_key()).
+collect_nominal_refs(Tab, Ty) ->
+  Refs = utils:everything(
+    fun ({named, _, Ref, _}) ->
+      case symtab:is_nominal(Ref, Tab) of
+        true -> {ok, symtab:ref_to_key(Ref)};
+        false -> error
+      end;
+      (_) -> error
+    end, Ty),
+  sets:from_list(Refs).
 
 -spec parse(ast_ty()) -> type().
 parse(RawTy) ->
@@ -415,6 +474,28 @@ new_local_ref(RawTerm) ->
     _ -> Reff
   end.
 
+-spec nominal_derives_from(ty_nominal:nominal_key(), ty_nominal:nominal_key()) -> boolean().
+nominal_derives_from({M1, N1, A1}, {M2, N2, A2}) ->
+  ets:member(?NOMINAL_DERIVES, {{ty_key, M1, N1, A1}, {ty_key, M2, N2, A2}}).
+
+% Wrap each leaf of a dnf_ty_variable BDD with a nominal tag at the dnf_ty_nominal level.
+-spec wrap_nominal_tag(ty_nominal:type(), dnf_ty_variable:type()) -> dnf_ty_variable:type().
+wrap_nominal_tag(NomTag, {leaf, NomBdd}) ->
+  {leaf, dnf_ty_nominal:nominal(NomTag, NomBdd)};
+wrap_nominal_tag(NomTag, {node, Var, Pos, Neg}) ->
+  {node, Var, wrap_nominal_tag(NomTag, Pos), wrap_nominal_tag(NomTag, Neg)}.
+
+-spec is_nominal_ref(ety_ref()) -> boolean().
+is_nominal_ref({ty_ref, M, N, A}) ->
+  ets:member(?NOMINALS, {ty_key, M, N, A});
+is_nominal_ref({ty_qref, M, N, A}) ->
+  ets:member(?NOMINALS, {ty_key, M, N, A});
+is_nominal_ref(_) -> false.
+
+-spec ref_to_nominal_key(ety_ref()) -> ty_nominal:nominal_key().
+ref_to_nominal_key({ty_ref, M, N, A}) -> {M, N, A};
+ref_to_nominal_key({ty_qref, M, N, A}) -> {M, N, A}.
+
 -spec extend_symtab(ast:ty_ref(), ety_ty_scheme()) -> _.
 extend_symtab({_, Namespace, Type, ArgsCount}, RawTyScheme) ->
   Ref = {Namespace, Type, ArgsCount},
@@ -486,7 +567,14 @@ do_convert_named_new(X, Ref, Args, R, Q, Cache) ->
   case ets:lookup(?CACHE, NewRef) of
     [] ->
       % create a new reference (ref args pair), memoize, and add continue converting
-      {InternalTy, NewQ, {R0, R1}, C0} = do_convert({NewTy, R}, Q, Cache#{{Ref, Args} => NewRef}),
+      {InternalTy0, NewQ, {R0, R1}, C0} = do_convert({NewTy, R}, Q, Cache#{{Ref, Args} => NewRef}),
+      % If the type is nominal, wrap with a nominal tag at the dnf_ty_nominal level
+      InternalTy = case is_nominal_ref(Ref) of
+        true ->
+          NomTag = ty_nominal:new(ref_to_nominal_key(Ref)),
+          wrap_nominal_tag(NomTag, InternalTy0);
+        false -> InternalTy0
+      end,
       {InternalTy, NewQ, {R0#{NewRef => InternalTy}, group(R1, InternalTy, NewRef)}, C0};
     [{NewRef, CachedNode}] ->
       % reuse type representation of the global cache

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -8,6 +8,7 @@
 
 -export_type([
     t/0,
+    ty_key/0,
     fun_env/0,
     ty_env/0,
     record_env/0,
@@ -26,7 +27,11 @@
     empty/0,
     extend_symtab_with_module_list/4,
     dump_symtab/2, overlay_symtab/1,
-    get_types/1
+    get_types/1,
+    has_any_nominals/1,
+    is_nominal/2,
+    get_nominals/1,
+    ref_to_key/1
 ]).
 
 -ifdef(TEST). % for tally tests
@@ -48,13 +53,29 @@
               ops :: op_env(),
               types :: ty_env(),
               records :: record_env(),
-              modules :: mod_env()
+              modules :: mod_env(),
+              nominals :: sets:set(ty_key())
 }).
 
 -type t() :: #tab{}.
 
 -spec get_types(t()) -> ty_env().
 get_types(#tab{types = Types}) -> Types.
+
+-spec ref_to_key(ast:ty_ref()) -> ty_key().
+ref_to_key({ty_ref, M, N, A}) -> {ty_key, M, N, A};
+ref_to_key({ty_qref, M, N, A}) -> {ty_key, M, N, A}.
+
+-spec has_any_nominals(t()) -> boolean().
+has_any_nominals(Tab) ->
+    sets:size(Tab#tab.nominals) > 0.
+
+-spec is_nominal(ast:ty_ref(), t()) -> boolean().
+is_nominal(Ref, Tab) ->
+    sets:is_element(ref_to_key(Ref), Tab#tab.nominals).
+
+-spec get_nominals(t()) -> sets:set(ty_key()).
+get_nominals(#tab{nominals = Nominals}) -> Nominals.
 
 -spec dump_symtab(string(), t()) -> ok.
 dump_symtab(Msg, Tab) ->
@@ -119,11 +140,7 @@ lookup_ty(Ref, Loc, Tab) ->
 
 -spec find_ty(ast:ty_ref(), t()) -> t:opt(ast:ty_scheme()).
 find_ty(Ref, Tab) ->
-    TyRef = case Ref of
-                {ty_ref, M, N, A} -> {ty_key, M, N, A};
-                {ty_qref, M, N ,A} -> {ty_key, M, N, A}
-            end ,
-    maps:find(TyRef, Tab#tab.types).
+    maps:find(ref_to_key(Ref), Tab#tab.types).
 
 -spec lookup_record(atom(), ast:loc(), t()) -> records:record_ty().
 lookup_record(Name, Loc, Tab) ->
@@ -151,7 +168,7 @@ symbols_for_module(Mod, Tab) ->
         ).
 
 -spec empty() -> t().
-empty() -> #tab { funs = #{}, ops = #{}, types = #{}, records = #{}, modules = #{} }.
+empty() -> #tab { funs = #{}, ops = #{}, types = #{}, records = #{}, modules = #{}, nominals = sets:new() }.
 
 -spec std_symtab(paths:search_path(), t()) -> t().
 std_symtab(SearchPath, OverlaySymtab) ->
@@ -178,7 +195,7 @@ build_std_symtab(SearchPath, OverlaySymtab) ->
         lists:foldl(fun({Name, Arity, T}, Map) -> maps:put({Name, Arity}, T, Map) end,
                     #{},
                     stdtypes:builtin_ops()),
-    Tab = #tab { funs = Funs, ops = Ops, types = #{}, records = #{}, modules = #{} },
+    Tab = #tab { funs = Funs, ops = Ops, types = #{}, records = #{}, modules = #{}, nominals = sets:new() },
     ExtTab = extend_symtab_with_module_list(Tab, SearchPath, [erlang], OverlaySymtab),
     % Merge overlay types into the main symtab so they are available for type resolution
     ExtTab2 = ExtTab#tab { types = maps:merge(ExtTab#tab.types, OverlaySymtab#tab.types) },
@@ -203,9 +220,9 @@ overlay_symtab(OverlayForms) ->
 -spec overlay_process_form(ast:form(), t(), atom() | undefined) -> t().
 overlay_process_form({attribute, _, spec, Name, Arity, T, _}, Tab, _ModuleName) ->
     overlay_add_spec(Name, Arity, T, Tab);
-overlay_process_form({attribute, _, type, _Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, Tab, ModuleName) when ModuleName =/= undefined ->
+overlay_process_form({attribute, _, type, Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, Tab, ModuleName) when ModuleName =/= undefined ->
     Arity = length(TyVars),
-    overlay_add_type(ModuleName, Name, Arity, TyScm, Tab);
+    overlay_add_type(ModuleName, Name, Arity, TyScm, Visibility, Tab);
 overlay_process_form(_, Tab, _ModuleName) -> Tab.
 
 -spec overlay_add_spec(atom(), arity(), ast:ty_scheme(), t()) -> t().
@@ -214,11 +231,15 @@ overlay_add_spec(Name, Arity, T, Tab) ->
     [Module, FunName] = string:split(atom_to_list(Name), ":"),
     Tab#tab { funs = maps:put(create_ref_tuple({qref, list_to_atom(Module)}, list_to_atom(FunName), Arity), T, Tab#tab.funs) }.
 
--spec overlay_add_type(atom(), atom(), arity(), ast:ty_scheme(), t()) -> t().
-overlay_add_type(ModuleName, Name, Arity, TyScm, Tab) ->
+-spec overlay_add_type(atom(), atom(), arity(), ast:ty_scheme(), atom(), t()) -> t().
+overlay_add_type(ModuleName, Name, Arity, TyScm, Visibility, Tab) ->
     Key = {ty_key, ModuleName, Name, Arity},
     ?LOG_DEBUG("Overlay type added: ~w/~p", Name, Arity),
-    Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) }.
+    Tab1 = Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) },
+    case Visibility of
+        nominal -> Tab1#tab { nominals = sets:add_element(Key, Tab1#tab.nominals) };
+        _ -> Tab1
+    end.
 
 -type ref() :: ref | {qref, ModuleName::atom()}.
 
@@ -262,8 +283,8 @@ extend_symtab_internal(Filename, Forms, RefType, Tab, OverlaySymtab) ->
 -spec extend_process_form(ast:form(), t(), ref(), atom(), ast:forms(), t()) -> t().
 extend_process_form({attribute, _, spec, Name, Arity, T, _}, AccTab, RefType, ModuleName, Forms, OverlaySymtab) ->
     extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymtab);
-extend_process_form({attribute, _, type, _, {Name, TyScm = {ty_scheme, TyVars, _}}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
-    extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab);
+extend_process_form({attribute, _, type, Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
+    extend_add_type(Name, TyScm, TyVars, ModuleName, Visibility, AccTab);
 extend_process_form({attribute, _, record, {RecordName, Fields}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
     extend_add_record(RecordName, Fields, ModuleName, AccTab);
 extend_process_form(_, AccTab, _RefType, _ModuleName, _Forms, _OverlaySymtab) ->
@@ -284,10 +305,15 @@ extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymta
             AccTab#tab { funs = maps:put(create_ref_tuple(RefType, Name, Arity), OverlayT, AccTab#tab.funs) }
     end.
 
--spec extend_add_type(atom(), ast:ty_scheme(), [{atom(), any()}], atom(), t()) -> t().
-extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab) ->
+-spec extend_add_type(atom(), ast:ty_scheme(), [{atom(), any()}], atom(), atom(), t()) -> t().
+extend_add_type(Name, TyScm, TyVars, ModuleName, Visibility, AccTab) ->
     Arity = length(TyVars),
-    AccTab#tab { types = maps:put({ty_key, ModuleName, Name, Arity}, TyScm, AccTab#tab.types) }.
+    Key = {ty_key, ModuleName, Name, Arity},
+    AccTab1 = AccTab#tab { types = maps:put(Key, TyScm, AccTab#tab.types) },
+    case Visibility of
+        nominal -> AccTab1#tab { nominals = sets:add_element(Key, AccTab1#tab.nominals) };
+        _ -> AccTab1
+    end.
 
 -spec extend_add_record(atom(), list(), atom(), t()) -> t().
 extend_add_record(RecordName, Fields, ModuleName, AccTab) ->

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -8,6 +8,7 @@
 
 -export_type([
     t/0,
+    ty_key/0,
     fun_env/0,
     ty_env/0,
     record_env/0,
@@ -26,7 +27,11 @@
     empty/0,
     extend_symtab_with_module_list/4,
     dump_symtab/2, overlay_symtab/1,
-    get_types/1
+    get_types/1,
+    has_any_nominals/1,
+    is_nominal/2,
+    get_nominals/1,
+    ref_to_key/1
 ]).
 
 -ifdef(TEST). % for tally tests
@@ -49,13 +54,29 @@
               types :: ty_env(),
               records :: record_env(),
               modules :: mod_env(),
-              gradual = dynamic :: feature_flags:gradual_typing_mode()
+              gradual = dynamic :: feature_flags:gradual_typing_mode(),
+              nominals :: sets:set(ty_key())
 }).
 
 -type t() :: #tab{}.
 
 -spec get_types(t()) -> ty_env().
 get_types(#tab{types = Types}) -> Types.
+
+-spec ref_to_key(ast:ty_ref()) -> ty_key().
+ref_to_key({ty_ref, M, N, A}) -> {ty_key, M, N, A};
+ref_to_key({ty_qref, M, N, A}) -> {ty_key, M, N, A}.
+
+-spec has_any_nominals(t()) -> boolean().
+has_any_nominals(Tab) ->
+    sets:size(Tab#tab.nominals) > 0.
+
+-spec is_nominal(ast:ty_ref(), t()) -> boolean().
+is_nominal(Ref, Tab) ->
+    sets:is_element(ref_to_key(Ref), Tab#tab.nominals).
+
+-spec get_nominals(t()) -> sets:set(ty_key()).
+get_nominals(#tab{nominals = Nominals}) -> Nominals.
 
 -spec dump_symtab(string(), t()) -> ok.
 dump_symtab(Msg, Tab) ->
@@ -120,11 +141,7 @@ lookup_ty(Ref, Loc, Tab) ->
 
 -spec find_ty(ast:ty_ref(), t()) -> t:opt(ast:ty_scheme()).
 find_ty(Ref, Tab) ->
-    TyRef = case Ref of
-                {ty_ref, M, N, A} -> {ty_key, M, N, A};
-                {ty_qref, M, N ,A} -> {ty_key, M, N, A}
-            end ,
-    maps:find(TyRef, Tab#tab.types).
+    maps:find(ref_to_key(Ref), Tab#tab.types).
 
 -spec lookup_record(atom(), ast:loc(), t()) -> ety_records:record_ty().
 lookup_record(Name, Loc, Tab) ->
@@ -152,7 +169,7 @@ symbols_for_module(Mod, Tab) ->
         ).
 
 -spec empty() -> t().
-empty() -> #tab { funs = #{}, ops = #{}, types = #{}, records = #{}, modules = #{} }.
+empty() -> #tab { funs = #{}, ops = #{}, types = #{}, records = #{}, modules = #{}, nominals = sets:new() }.
 
 -spec std_symtab(paths:search_path(), t(), feature_flags:gradual_typing_mode()) -> t().
 std_symtab(SearchPath, OverlaySymtab, Gradual) ->
@@ -179,7 +196,7 @@ build_std_symtab(SearchPath, OverlaySymtab, Gradual) ->
         lists:foldl(fun({Name, Arity, T}, Map) -> maps:put({Name, Arity}, T, Map) end,
                     #{},
                     stdtypes:builtin_ops()),
-    Tab = #tab { funs = Funs, ops = Ops, types = #{}, records = #{}, modules = #{}, gradual = Gradual },
+    Tab = #tab { funs = Funs, ops = Ops, types = #{}, records = #{}, modules = #{}, gradual = Gradual, nominals = sets:new() },
     ExtTab = extend_symtab_with_module_list(Tab, SearchPath, [erlang], OverlaySymtab),
     % Merge overlay types into the main symtab so they are available for type resolution
     ExtTab2 = ExtTab#tab { types = maps:merge(ExtTab#tab.types, OverlaySymtab#tab.types) },
@@ -204,9 +221,9 @@ overlay_symtab(OverlayForms) ->
 -spec overlay_process_form(ast:form(), t(), atom() | undefined) -> t().
 overlay_process_form({attribute, _, spec, Name, Arity, T, _}, Tab, _ModuleName) ->
     overlay_add_spec(Name, Arity, T, Tab);
-overlay_process_form({attribute, _, type, _Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, Tab, ModuleName) when ModuleName =/= undefined ->
+overlay_process_form({attribute, _, type, Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, Tab, ModuleName) when ModuleName =/= undefined ->
     Arity = length(TyVars),
-    overlay_add_type(ModuleName, Name, Arity, TyScm, Tab);
+    overlay_add_type(ModuleName, Name, Arity, TyScm, Visibility, Tab);
 overlay_process_form(_, Tab, _ModuleName) -> Tab.
 
 -spec overlay_add_spec(atom(), arity(), ast:ty_scheme(), t()) -> t().
@@ -215,11 +232,15 @@ overlay_add_spec(Name, Arity, T, Tab) ->
     [Module, FunName] = string:split(atom_to_list(Name), ":"),
     Tab#tab { funs = maps:put(create_ref_tuple({qref, list_to_atom(Module)}, list_to_atom(FunName), Arity), T, Tab#tab.funs) }.
 
--spec overlay_add_type(atom(), atom(), arity(), ast:ty_scheme(), t()) -> t().
-overlay_add_type(ModuleName, Name, Arity, TyScm, Tab) ->
+-spec overlay_add_type(atom(), atom(), arity(), ast:ty_scheme(), atom(), t()) -> t().
+overlay_add_type(ModuleName, Name, Arity, TyScm, Visibility, Tab) ->
     Key = {ty_key, ModuleName, Name, Arity},
     ?LOG_DEBUG("Overlay type added: ~w/~p", Name, Arity),
-    Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) }.
+    Tab1 = Tab#tab { types = maps:put(Key, TyScm, Tab#tab.types) },
+    case Visibility of
+        nominal -> Tab1#tab { nominals = sets:add_element(Key, Tab1#tab.nominals) };
+        _ -> Tab1
+    end.
 
 -type ref() :: ref | {qref, ModuleName::atom()}.
 
@@ -288,8 +309,8 @@ dynamic_fun_scheme(Arity) ->
 -spec extend_process_form(ast:form(), t(), ref(), atom(), ast:forms(), t()) -> t().
 extend_process_form({attribute, _, spec, Name, Arity, T, _}, AccTab, RefType, ModuleName, Forms, OverlaySymtab) ->
     extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymtab);
-extend_process_form({attribute, _, type, _, {Name, TyScm = {ty_scheme, TyVars, _}}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
-    extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab);
+extend_process_form({attribute, _, type, Visibility, {Name, TyScm = {ty_scheme, TyVars, _}}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
+    extend_add_type(Name, TyScm, TyVars, ModuleName, Visibility, AccTab);
 extend_process_form({attribute, _, record, {RecordName, Fields}}, AccTab, _RefType, ModuleName, _Forms, _OverlaySymtab) ->
     extend_add_record(RecordName, Fields, ModuleName, AccTab);
 extend_process_form(_, AccTab, _RefType, _ModuleName, _Forms, _OverlaySymtab) ->
@@ -310,10 +331,15 @@ extend_add_spec(Name, Arity, T, AccTab, RefType, ModuleName, Forms, OverlaySymta
             AccTab#tab { funs = maps:put(create_ref_tuple(RefType, Name, Arity), OverlayT, AccTab#tab.funs) }
     end.
 
--spec extend_add_type(atom(), ast:ty_scheme(), [{atom(), any()}], atom(), t()) -> t().
-extend_add_type(Name, TyScm, TyVars, ModuleName, AccTab) ->
+-spec extend_add_type(atom(), ast:ty_scheme(), [{atom(), any()}], atom(), atom(), t()) -> t().
+extend_add_type(Name, TyScm, TyVars, ModuleName, Visibility, AccTab) ->
     Arity = length(TyVars),
-    AccTab#tab { types = maps:put({ty_key, ModuleName, Name, Arity}, TyScm, AccTab#tab.types) }.
+    Key = {ty_key, ModuleName, Name, Arity},
+    AccTab1 = AccTab#tab { types = maps:put(Key, TyScm, AccTab#tab.types) },
+    case Visibility of
+        nominal -> AccTab1#tab { nominals = sets:add_element(Key, AccTab1#tab.nominals) };
+        _ -> AccTab1
+    end.
 
 -spec extend_add_record(atom(), list(), atom(), t()) -> t().
 extend_add_record(RecordName, Fields, ModuleName, AccTab) ->

--- a/test/erlang_types/parser/parser_representation_tests.erl
+++ b/test/erlang_types/parser/parser_representation_tests.erl
@@ -8,7 +8,7 @@ variable_test() ->
     Ty = ty_parser:parse({var, alpha}),
     Tyy = ty_node:dump(Ty),
     #{{node, 1} := {node, _, {leaf, Any}, {leaf, Empty}}} = Tyy,
-    gt = ty_rec:compare(Any, Empty),
+    gt = dnf_ty_nominal:compare(Any, Empty),
     ok
   end).
 

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -107,7 +107,7 @@ check_decls_in_file(F, What, NoInfer) ->
         Ty = symtab:lookup_fun({ref, Name, Arity}, Loc, Tab),
         ShouldFail = utils:string_ends_with(NameStr, "_fail"),
         RunTest =
-          {timeout, 10, {FullNameStr ++ " (typecheck)", fun() ->
+          {timeout, 15, {FullNameStr ++ " (typecheck)", fun() ->
                 ?LOG_NOTE("Type checking ~s from ~s", NameStr, F),
                 global_state:with_new_state(fun() ->
                   case ShouldFail of
@@ -119,7 +119,7 @@ check_decls_in_file(F, What, NoInfer) ->
               end}
             },
         InferTest =
-          {timeout, 10, {FullNameStr ++ " (infer)", fun() ->
+          {timeout, 15, {FullNameStr ++ " (infer)", fun() ->
                 ?LOG_NOTE("Infering type for ~s from ~s", NameStr, F),
                 global_state:with_new_state(fun() ->
                   check_infer_ok_fun(F, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, Decl, Ty)

--- a/test_files/erlang_types/normalize/mk_diff_good.config
+++ b/test_files/erlang_types/normalize/mk_diff_good.config
@@ -1,2 +1,0 @@
-{error, 'generate dump first with ty_node:dumpp/1'}.
-


### PR DESCRIPTION
Implements nominal semantics according to 'Nominal Types for Erlang (ICFP Erlang '24)'.

Integrated as a BDD tag layer between variables and type record. The implementation is quite simple, although it does impact the representation of types.

For non-nominal code, the performance impact is negligible. For the worst case of changing every `-type` to `-nominal`, the impact is substantial in the order of magnitudes, without optimizations, causing a few new timeouts for the `typecheck_erlang_types` script.

Compared to #317, this is a much smaller but at the same time an exact implementation.