### PR TITLE
[Feat] Improved compilation manager

### DIFF
--- a/ety
+++ b/ety
@@ -4,9 +4,9 @@ D=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ "$1" == "--build" ]; then
     shift
-    pushd $D
-    make build || exit 1
-    popd
+    pushd "$D" > /dev/null
+    (make build > /dev/null) || exit 1
+    popd > /dev/null
 fi
 
 $D/_build/default/bin/etylizer "$@"

--- a/ety-watch
+++ b/ety-watch
@@ -1,0 +1,662 @@
+#!/usr/bin/env bash
+# ety-watch: Watch mode for etylizer - re-runs type checking on file changes.
+
+set -euo pipefail
+
+# ─── Constants & Defaults ────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VERSION="0.1.0"
+
+DEFAULT_CMD="./typecheck_etylizer.sh"
+DEFAULT_DIRS="src,include,overlays"
+DEFAULT_POLL_INTERVAL=1
+DEFAULT_DEBOUNCE_MS=500
+DEFAULT_REPORT_TIMEOUT=8000
+
+CMD="$DEFAULT_CMD"
+WATCH_DIRS="$DEFAULT_DIRS"
+POLL_INTERVAL="$DEFAULT_POLL_INTERVAL"
+DEBOUNCE_MS="$DEFAULT_DEBOUNCE_MS"
+REPORT_TIMEOUT="$DEFAULT_REPORT_TIMEOUT"
+USE_COLOR="auto"
+USE_BELL=1
+USE_NOTIFY=1
+QUIET=0
+CLEAR=0
+ONCE=0
+EXTRA_ARGS=()
+
+# ─── State ───────────────────────────────────────────────────────────────────
+
+INOTIFY_PID=""
+TYPECHECK_PID=""
+TMPFILE=""
+SENTINEL=""
+WATCH_FIFO=""
+PREV_STATUS=""  # "ok" or "errors"
+HAS_INOTIFYWAIT=0
+
+# ─── Argument Parsing ────────────────────────────────────────────────────────
+
+usage() {
+    cat <<'EOF'
+Usage: ./ety-watch [OPTIONS] [-- EXTRA_ETY_ARGS...]
+
+Watch for .erl/.hrl file changes and re-run etylizer type checking.
+
+Options:
+  --cmd CMD          Type-check command (default: ./typecheck_etylizer.sh)
+  --dirs D1,D2,...   Directories to watch (default: src,include,overlays)
+  --poll-interval N  Poll interval in seconds for fallback mode (default: 1)
+  --debounce N       Debounce window in ms (default: 500)
+  --report-timeout N Per-function timeout in ms (default: 5000)
+  --no-color         Disable colors
+  --no-bell          Disable terminal bell
+  --no-notify        Disable desktop notifications
+  -q, --quiet        Only show errors/timeouts and summary (hide OK lines)
+  --clear            Clear terminal before each run
+  --once             Run once and exit (exit code reflects result)
+  -h, --help         Show usage
+
+Extra args after -- are passed through to etylizer.
+Example: ./ety-watch -- -o typing
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cmd)       CMD="$2"; shift 2 ;;
+            --dirs)      WATCH_DIRS="$2"; shift 2 ;;
+            --poll-interval) POLL_INTERVAL="$2"; shift 2 ;;
+            --debounce)  DEBOUNCE_MS="$2"; shift 2 ;;
+            --report-timeout) REPORT_TIMEOUT="$2"; shift 2 ;;
+            --no-color)  USE_COLOR="never"; shift ;;
+            --no-bell)   USE_BELL=0; shift ;;
+            --no-notify) USE_NOTIFY=0; shift ;;
+            -q|--quiet)  QUIET=1; shift ;;
+            --clear)     CLEAR=1; shift ;;
+            --once)      ONCE=1; shift ;;
+            -h|--help)   usage; exit 0 ;;
+            --)          shift; EXTRA_ARGS=("$@"); break ;;
+            *)           echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+        esac
+    done
+}
+
+# ─── Color Setup ─────────────────────────────────────────────────────────────
+
+color_init() {
+    if [[ "$USE_COLOR" == "never" ]]; then
+        C_RESET="" C_RED="" C_GREEN="" C_YELLOW="" C_CYAN="" C_BOLD="" C_DIM=""
+        return
+    fi
+    if [[ "$USE_COLOR" == "auto" ]] && ! [[ -t 1 ]]; then
+        C_RESET="" C_RED="" C_GREEN="" C_YELLOW="" C_CYAN="" C_BOLD="" C_DIM=""
+        return
+    fi
+    C_RESET=$'\033[0m'
+    C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'
+    C_YELLOW=$'\033[33m'
+    C_CYAN=$'\033[36m'
+    C_BOLD=$'\033[1m'
+    C_DIM=$'\033[2m'
+}
+
+# ─── Terminal Title & Notifications ──────────────────────────────────────────
+
+set_title() {
+    # Set terminal title via OSC escape
+    if [[ -t 1 ]]; then
+        printf '\033]0;%s\007' "$1"
+    fi
+}
+
+notify() {
+    local urgency="$1"
+    local summary="$2"
+    local body="${3:-}"
+    if [[ "$USE_NOTIFY" -eq 1 ]] && command -v notify-send &>/dev/null; then
+        notify-send -u "$urgency" "$summary" "$body" 2>/dev/null || true
+    fi
+}
+
+bell() {
+    if [[ "$USE_BELL" -eq 1 ]] && [[ -t 1 ]]; then
+        printf '\a'
+    fi
+}
+
+# ─── Output Formatting ──────────────────────────────────────────────────────
+
+BAR="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+print_header() {
+    local timestamp="$1"
+    local trigger="${2:-initial run}"
+    echo ""
+    echo "${C_DIM}${BAR}${C_RESET}"
+    printf "  ${C_BOLD}ety-watch${C_RESET}  |  %s  |  %s\n" "$timestamp" "$trigger"
+    echo "${C_DIM}${BAR}${C_RESET}"
+}
+
+print_footer() {
+    local ok_count="$1"
+    local err_count="$2"
+    local timeout_count="$3"
+    local elapsed="$4"
+
+    echo "${C_DIM}${BAR}${C_RESET}"
+
+    local status_parts=()
+    if [[ "$ok_count" -gt 0 ]]; then
+        status_parts+=("${C_GREEN}${ok_count} ok${C_RESET}")
+    fi
+    if [[ "$err_count" -gt 0 ]]; then
+        status_parts+=("${C_RED}${C_BOLD}${err_count} error${C_RESET}")
+    fi
+    if [[ "$timeout_count" -gt 0 ]]; then
+        status_parts+=("${C_YELLOW}${timeout_count} timeout${C_RESET}")
+    fi
+
+    local status_str=""
+    local sep=""
+    for part in "${status_parts[@]}"; do
+        status_str+="${sep}${part}"
+        sep=", "
+    done
+    printf "  RESULT: %s  |  %s\n" "$status_str" "$elapsed"
+    echo "${C_DIM}${BAR}${C_RESET}"
+}
+
+# ─── Output Parsing ─────────────────────────────────────────────────────────
+
+# ─── Type Check Runner ──────────────────────────────────────────────────────
+
+run_typecheck() {
+    local trigger="${1:-initial run}"
+    local timestamp
+    timestamp="$(date +%H:%M:%S)"
+
+    if [[ "$CLEAR" -eq 1 ]]; then
+        clear
+    fi
+
+    print_header "$timestamp" "$trigger"
+
+    set_title "[...] ety-watch"
+
+    # Counters
+    local ok_count=0
+    local err_count=0
+    local timeout_count=0
+    local unsupported_count=0
+    local other_count=0
+    local in_error_msg=0
+    local suppress_continuation=0
+    local msg_color=""
+    local had_parseable_output=0
+    local exit_code=0
+    local buffered_lines=()
+
+    # Regex patterns stored in variables to avoid bash parsing issues with parens
+    local re_ok='^Ok: (.+) \(([0-9]+) ms\)$'
+    local re_err_typed='^Error: \(([^)]+)\) (.+) \(([0-9]+) ms\)$'
+    local re_err='^Error: (.+) \(([0-9]+) ms\)$'
+    local re_timeout='^Timeout: (.+) \(([0-9]+) ms\)$'
+    local re_unsupported='^Unsupported: (.+)$'
+    local re_other='^Other: (.+)$'
+
+    local start_time
+    start_time=$(date +%s%N 2>/dev/null || date +%s)
+
+    # Stream output line by line using process substitution.
+    # The sentinel __ETY_EXIT:N carries the command's exit code.
+    while IFS= read -r line; do
+        # Extract exit code from sentinel
+        if [[ "$line" == __ETY_EXIT:* ]]; then
+            exit_code="${line#__ETY_EXIT:}"
+            continue
+        fi
+
+        # Parse and display each line as it arrives
+        if [[ "$line" =~ $re_ok ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            ok_count=$((ok_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            local ms="${BASH_REMATCH[2]}"
+            if [[ "$QUIET" -eq 0 ]]; then
+                printf "  ${C_GREEN}[OK]${C_RESET}          %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+            fi
+
+        elif [[ "$line" =~ $re_err_typed ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            suppress_continuation=0
+            err_count=$((err_count + 1))
+            local err_type="${BASH_REMATCH[1]}"
+            local func="${BASH_REMATCH[2]}"
+            local ms="${BASH_REMATCH[3]}"
+            printf "  ${C_RED}${C_BOLD}[ERROR]${C_RESET}       %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+            printf "                ${C_DIM}type: %s${C_RESET}\n" "$err_type"
+            in_error_msg=1
+            msg_color="$C_RED"
+
+        elif [[ "$line" =~ $re_err ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            suppress_continuation=0
+            err_count=$((err_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            local ms="${BASH_REMATCH[2]}"
+            printf "  ${C_RED}${C_BOLD}[ERROR]${C_RESET}       %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+            in_error_msg=1
+            msg_color="$C_RED"
+
+        elif [[ "$line" =~ $re_timeout ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            timeout_count=$((timeout_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            local ms="${BASH_REMATCH[2]}"
+            printf "  ${C_YELLOW}[TIMEOUT]${C_RESET}     %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+
+        elif [[ "$line" =~ $re_unsupported ]]; then
+            had_parseable_output=1
+            in_error_msg=1
+            unsupported_count=$((unsupported_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            msg_color="$C_CYAN"
+            if [[ "$QUIET" -eq 0 ]]; then
+                suppress_continuation=0
+                printf "  ${C_CYAN}[UNSUPPORTED]${C_RESET} %s\n" "$func"
+            else
+                suppress_continuation=1
+            fi
+
+        elif [[ "$line" =~ $re_other ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            suppress_continuation=0
+            other_count=$((other_count + 1))
+            local rest="${BASH_REMATCH[1]}"
+            printf "  ${C_YELLOW}[OTHER]${C_RESET}       %s\n" "$rest"
+
+        elif [[ "$in_error_msg" -eq 1 ]] && [[ "$line" =~ ^[[:space:]] ]]; then
+            # Indented continuation of error/unsupported message
+            if [[ "$suppress_continuation" -eq 0 ]]; then
+                printf "                ${msg_color}%s${C_RESET}\n" "$line"
+            fi
+
+        else
+            in_error_msg=0
+            # Buffer non-report lines for possible build failure display
+            if [[ -n "$line" ]]; then
+                buffered_lines+=("$line")
+                if [[ "$QUIET" -eq 0 ]]; then
+                    printf "  ${C_DIM}%s${C_RESET}\n" "$line"
+                fi
+            fi
+        fi
+    done < <($CMD --report-mode report --report-timeout "$REPORT_TIMEOUT" \
+                "${EXTRA_ARGS[@]}" 2>&1; echo "__ETY_EXIT:$?")
+
+    local end_time
+    end_time=$(date +%s%N 2>/dev/null || date +%s)
+
+    # Calculate elapsed time
+    if [[ ${#start_time} -gt 10 ]]; then
+        local elapsed_ns=$((end_time - start_time))
+        local elapsed_s=$((elapsed_ns / 1000000000))
+        local elapsed_ms=$(( (elapsed_ns / 1000000) % 1000 ))
+        RUN_ELAPSED="${elapsed_s}.$(printf '%01d' $((elapsed_ms / 100)))s"
+    else
+        local elapsed_s=$((end_time - start_time))
+        RUN_ELAPSED="${elapsed_s}s"
+    fi
+
+    # Handle no report-mode output
+    if [[ "$had_parseable_output" -eq 0 ]]; then
+        if [[ "$exit_code" -ne 0 ]] && [[ ${#buffered_lines[@]} -gt 0 ]]; then
+            # Build failure: non-zero exit with non-report output
+            # Lines were already printed above if not quiet; in quiet mode, show them now
+            if [[ "$QUIET" -eq 1 ]]; then
+                echo ""
+                echo "  ${C_RED}${C_BOLD}[BUILD FAILURE]${C_RESET}"
+                for l in "${buffered_lines[@]}"; do
+                    echo "    $l"
+                done
+            fi
+            PREV_STATUS="errors"
+            set_title "[BUILD ERR] ety-watch"
+            bell
+            notify "critical" "ety-watch: Build failure" "Build failed"
+        elif [[ ${#buffered_lines[@]} -eq 0 ]]; then
+            echo "  ${C_DIM}Nothing to check.${C_RESET}"
+        fi
+        return "$exit_code"
+    fi
+
+    # Print summary footer
+    local total_errors=$((err_count + timeout_count + other_count))
+    print_footer "$ok_count" "$err_count" "$timeout_count" "${RUN_ELAPSED}"
+
+    # Status transitions & notifications
+    local new_status="ok"
+    if [[ "$total_errors" -gt 0 ]]; then
+        new_status="errors"
+    fi
+
+    if [[ "$new_status" == "errors" ]]; then
+        local err_label="${total_errors} ERR"
+        set_title "[${err_label}] ety-watch"
+        bell
+        if [[ "$PREV_STATUS" == "ok" ]]; then
+            notify "critical" "ety-watch: ${total_errors} problem(s)" \
+                "${err_count} error(s), ${timeout_count} timeout(s)"
+        fi
+    else
+        set_title "[OK] ety-watch"
+        if [[ "$PREV_STATUS" == "errors" ]]; then
+            notify "normal" "ety-watch: All clear" "All ${ok_count} functions passed"
+        fi
+    fi
+
+    PREV_STATUS="$new_status"
+
+    if [[ "$total_errors" -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# ─── File Watching ───────────────────────────────────────────────────────────
+
+setup_watch_dirs() {
+    # Convert comma-separated dirs to array, filter to existing dirs
+    IFS=',' read -ra DIR_ARRAY <<< "$WATCH_DIRS"
+    EXISTING_DIRS=()
+    for d in "${DIR_ARRAY[@]}"; do
+        if [[ -d "$d" ]]; then
+            EXISTING_DIRS+=("$d")
+        fi
+    done
+
+    if [[ ${#EXISTING_DIRS[@]} -eq 0 ]]; then
+        echo "${C_RED}Error: No watch directories found. Checked: ${WATCH_DIRS}${C_RESET}" >&2
+        exit 1
+    fi
+}
+
+parse_event_line() {
+    local event_line="$1"
+    local event="${event_line%% *}"
+    local filepath="${event_line#* }"
+    local filename
+    filename="$(basename "$filepath")"
+    case "$event" in
+        *CREATE*|*MOVED_TO*)  echo "$filename added" ;;
+        *DELETE*|*MOVED_FROM*) echo "$filename removed" ;;
+        *)                     echo "$filename changed" ;;
+    esac
+}
+
+# Start a persistent inotifywait monitor. Events are readable from fd 3.
+start_inotify_monitor() {
+    WATCH_FIFO="$(mktemp -u)"
+    mkfifo "$WATCH_FIFO"
+
+    inotifywait -m -r -e modify,create,delete,moved_to,moved_from \
+        --include '.*\.(erl|hrl)$' \
+        --format '%e %w%f' \
+        "${EXISTING_DIRS[@]}" > "$WATCH_FIFO" 2>/dev/null &
+    INOTIFY_PID=$!
+
+    # Open FIFO once with a persistent fd
+    exec 3< "$WATCH_FIFO"
+}
+
+# Block until an inotify event arrives, then debounce.
+wait_inotify_event() {
+    local event_line=""
+    if IFS= read -r event_line <&3; then
+        local debounce_sec
+        debounce_sec=$(awk "BEGIN {printf \"%.1f\", ${DEBOUNCE_MS}/1000}")
+        while IFS= read -r -t "$debounce_sec" _ <&3; do
+            : # drain
+        done
+    fi
+    if [[ -n "$event_line" ]]; then
+        parse_event_line "$event_line"
+    else
+        echo "file change"
+    fi
+}
+
+# Non-blocking: drain any inotify events that arrived during a typecheck run.
+# Prints trigger description if events were found, nothing otherwise.
+drain_inotify_pending() {
+    local last_event="" event_line=""
+    while IFS= read -r -t 0.01 event_line <&3 2>/dev/null; do
+        [[ -n "$event_line" ]] && last_event="$event_line"
+    done
+    if [[ -n "$last_event" ]]; then
+        # Debounce: wait for more events to settle
+        local debounce_sec
+        debounce_sec=$(awk "BEGIN {printf \"%.1f\", ${DEBOUNCE_MS}/1000}")
+        while IFS= read -r -t "$debounce_sec" event_line <&3; do
+            [[ -n "$event_line" ]] && last_event="$event_line"
+        done
+        parse_event_line "$last_event"
+    fi
+}
+
+# Wait for changes using find -newer polling (fallback)
+# Also detects file additions and removals by comparing file lists.
+wait_for_changes_poll() {
+    SENTINEL="_etylizer/.watch_sentinel"
+    local filelist="_etylizer/.watch_filelist"
+    mkdir -p _etylizer
+    touch "$SENTINEL"
+
+    # Snapshot current file list for add/remove detection
+    find "${EXISTING_DIRS[@]}" \
+        \( -name '*.erl' -o -name '*.hrl' \) \
+        2>/dev/null | sort > "$filelist"
+
+    while true; do
+        sleep "$POLL_INTERVAL"
+
+        # Check for modified files
+        local changed
+        changed=$(find "${EXISTING_DIRS[@]}" \
+            -newer "$SENTINEL" \
+            \( -name '*.erl' -o -name '*.hrl' \) \
+            -print -quit 2>/dev/null || true)
+
+        if [[ -n "$changed" ]]; then
+            touch "$SENTINEL"
+            # Update file list snapshot
+            find "${EXISTING_DIRS[@]}" \
+                \( -name '*.erl' -o -name '*.hrl' \) \
+                2>/dev/null | sort > "$filelist"
+            echo "$(basename "$changed") changed"
+            return
+        fi
+
+        # Check for added/removed files
+        local current_list
+        current_list=$(find "${EXISTING_DIRS[@]}" \
+            \( -name '*.erl' -o -name '*.hrl' \) \
+            2>/dev/null | sort)
+
+        local added removed
+        added=$(comm -13 "$filelist" <(echo "$current_list") | head -1)
+        removed=$(comm -23 "$filelist" <(echo "$current_list") | head -1)
+
+        if [[ -n "$added" ]]; then
+            touch "$SENTINEL"
+            echo "$current_list" | sort > "$filelist"
+            echo "$(basename "$added") added"
+            return
+        fi
+
+        if [[ -n "$removed" ]]; then
+            touch "$SENTINEL"
+            echo "$current_list" | sort > "$filelist"
+            echo "$(basename "$removed") removed"
+            return
+        fi
+    done
+}
+
+touch_poll_sentinel() {
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then return; fi
+    SENTINEL="_etylizer/.watch_sentinel"
+    mkdir -p _etylizer
+    touch "$SENTINEL"
+}
+
+# Non-blocking: check if files changed since sentinel (for poll mode).
+check_poll_immediate() {
+    if [[ ! -f "$SENTINEL" ]]; then return; fi
+    local changed
+    changed=$(find "${EXISTING_DIRS[@]}" \
+        -newer "$SENTINEL" \
+        \( -name '*.erl' -o -name '*.hrl' \) \
+        -print -quit 2>/dev/null || true)
+    if [[ -n "$changed" ]]; then
+        touch "$SENTINEL"
+        echo "$(basename "$changed") changed"
+    fi
+}
+
+# Blocking: wait for the next file change.
+wait_for_changes() {
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        wait_inotify_event
+    else
+        wait_for_changes_poll
+    fi
+}
+
+# Non-blocking: check if changes happened during a typecheck run.
+check_pending_changes() {
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        drain_inotify_pending
+    else
+        check_poll_immediate
+    fi
+}
+
+# ─── Cleanup ─────────────────────────────────────────────────────────────────
+
+cleanup() {
+    # Close inotify fd if open
+    exec 3<&- 2>/dev/null || true
+
+    # Kill inotifywait if running
+    if [[ -n "$INOTIFY_PID" ]]; then
+        kill "$INOTIFY_PID" 2>/dev/null || true
+        wait "$INOTIFY_PID" 2>/dev/null || true
+    fi
+
+    # Remove FIFO
+    if [[ -n "$WATCH_FIFO" ]] && [[ -e "$WATCH_FIFO" ]]; then
+        rm -f "$WATCH_FIFO"
+    fi
+
+    # Kill typecheck if running
+    if [[ -n "$TYPECHECK_PID" ]]; then
+        kill "$TYPECHECK_PID" 2>/dev/null || true
+        wait "$TYPECHECK_PID" 2>/dev/null || true
+    fi
+
+    # Remove temp files
+    if [[ -n "$TMPFILE" ]] && [[ -f "$TMPFILE" ]]; then
+        rm -f "$TMPFILE"
+    fi
+
+    # Remove sentinel and file list
+    if [[ -n "$SENTINEL" ]] && [[ -f "$SENTINEL" ]]; then
+        rm -f "$SENTINEL"
+    fi
+    rm -f "_etylizer/.watch_filelist"
+
+    # Restore terminal title
+    set_title ""
+
+    echo ""
+    echo "ety-watch stopped."
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+    parse_args "$@"
+    color_init
+
+    cd "$SCRIPT_DIR"
+
+    # Detect inotifywait
+    if command -v inotifywait &>/dev/null; then
+        HAS_INOTIFYWAIT=1
+    else
+        echo "${C_YELLOW}inotifywait not found. Using polling (${POLL_INTERVAL}s interval).${C_RESET}"
+        echo "${C_DIM}Install inotify-tools for event-driven watching.${C_RESET}"
+    fi
+
+    setup_watch_dirs
+
+    trap cleanup SIGINT SIGTERM EXIT
+
+    echo "${C_BOLD}ety-watch${C_RESET} v${VERSION}"
+    echo "Watching: ${EXISTING_DIRS[*]}"
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        echo "Mode: inotifywait (event-driven)"
+    else
+        echo "Mode: polling (${POLL_INTERVAL}s)"
+    fi
+    echo ""
+
+    # Start persistent inotify monitor so events during typecheck are captured
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        start_inotify_monitor
+    fi
+
+    # Initial run
+    touch_poll_sentinel
+    local result=0
+    run_typecheck "initial run" || result=$?
+
+    if [[ "$ONCE" -eq 1 ]]; then
+        exit "$result"
+    fi
+
+    # Watch loop
+    while true; do
+        # Check if files changed during the last typecheck run
+        local pending
+        pending=$(check_pending_changes)
+
+        if [[ -n "$pending" ]]; then
+            # Re-run immediately with the pending trigger
+            touch_poll_sentinel
+            run_typecheck "${pending}" || true
+        else
+            echo ""
+            echo "${C_DIM}Watching for changes...${C_RESET}"
+
+            local changed_file
+            changed_file=$(wait_for_changes)
+
+            touch_poll_sentinel
+            run_typecheck "${changed_file}" || true
+        fi
+    done
+}
+
+main "$@"

--- a/ety-watch
+++ b/ety-watch
@@ -1,0 +1,679 @@
+#!/usr/bin/env bash
+# ety-watch: Watch mode for etylizer - re-runs type checking on file changes.
+
+set -euo pipefail
+
+# ─── Constants & Defaults ────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VERSION="0.1.0"
+
+DEFAULT_CMD="./typecheck_etylizer"
+DEFAULT_DIRS="src,include,overlays"
+DEFAULT_POLL_INTERVAL=1
+DEFAULT_DEBOUNCE_MS=500
+DEFAULT_REPORT_TIMEOUT=8000
+
+CMD="$DEFAULT_CMD"
+WATCH_DIRS="$DEFAULT_DIRS"
+POLL_INTERVAL="$DEFAULT_POLL_INTERVAL"
+DEBOUNCE_MS="$DEFAULT_DEBOUNCE_MS"
+REPORT_TIMEOUT="$DEFAULT_REPORT_TIMEOUT"
+USE_COLOR="auto"
+USE_BELL=1
+USE_NOTIFY=1
+QUIET=0
+CLEAR=0
+ONCE=0
+EXTRA_ARGS=()
+
+# ─── State ───────────────────────────────────────────────────────────────────
+
+INOTIFY_PID=""
+TYPECHECK_PID=""
+TMPFILE=""
+SENTINEL=""
+WATCH_FIFO=""
+PREV_STATUS=""  # "ok" or "errors"
+HAS_INOTIFYWAIT=0
+
+# ─── Argument Parsing ────────────────────────────────────────────────────────
+
+usage() {
+    cat <<'EOF'
+Usage: ./ety-watch [OPTIONS] [-- EXTRA_ETY_ARGS...]
+
+Watch for .erl/.hrl file changes and re-run etylizer type checking.
+
+Options:
+  --cmd CMD          Type-check command (default: ./typecheck_etylizer.sh)
+  --dirs D1,D2,...   Directories to watch (default: src,include,overlays)
+  --poll-interval N  Poll interval in seconds for fallback mode (default: 1)
+  --debounce N       Debounce window in ms (default: 500)
+  --report-timeout N Per-function timeout in ms (default: 5000)
+  --no-color         Disable colors
+  --no-bell          Disable terminal bell
+  --no-notify        Disable desktop notifications
+  -q, --quiet        Only show errors/timeouts and summary (hide OK lines)
+  --clear            Clear terminal before each run
+  --once             Run once and exit (exit code reflects result)
+  -h, --help         Show usage
+
+Extra args after -- are passed through to etylizer.
+Example: ./ety-watch -- -o typing
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cmd)       CMD="$2"; shift 2 ;;
+            --dirs)      WATCH_DIRS="$2"; shift 2 ;;
+            --poll-interval) POLL_INTERVAL="$2"; shift 2 ;;
+            --debounce)  DEBOUNCE_MS="$2"; shift 2 ;;
+            --report-timeout) REPORT_TIMEOUT="$2"; shift 2 ;;
+            --no-color)  USE_COLOR="never"; shift ;;
+            --no-bell)   USE_BELL=0; shift ;;
+            --no-notify) USE_NOTIFY=0; shift ;;
+            -q|--quiet)  QUIET=1; shift ;;
+            --clear)     CLEAR=1; shift ;;
+            --once)      ONCE=1; shift ;;
+            -h|--help)   usage; exit 0 ;;
+            --)          shift; EXTRA_ARGS=("$@"); break ;;
+            *)           echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+        esac
+    done
+}
+
+# ─── Color Setup ─────────────────────────────────────────────────────────────
+
+color_init() {
+    if [[ "$USE_COLOR" == "never" ]]; then
+        C_RESET="" C_RED="" C_GREEN="" C_YELLOW="" C_CYAN="" C_BOLD="" C_DIM=""
+        return
+    fi
+    if [[ "$USE_COLOR" == "auto" ]] && ! [[ -t 1 ]]; then
+        C_RESET="" C_RED="" C_GREEN="" C_YELLOW="" C_CYAN="" C_BOLD="" C_DIM=""
+        return
+    fi
+    C_RESET=$'\033[0m'
+    C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'
+    C_YELLOW=$'\033[33m'
+    C_CYAN=$'\033[36m'
+    C_BOLD=$'\033[1m'
+    C_DIM=$'\033[2m'
+}
+
+# ─── Terminal Title & Notifications ──────────────────────────────────────────
+
+set_title() {
+    # Set terminal title via OSC escape
+    if [[ -t 1 ]]; then
+        printf '\033]0;%s\007' "$1"
+    fi
+}
+
+notify() {
+    local urgency="$1"
+    local summary="$2"
+    local body="${3:-}"
+    if [[ "$USE_NOTIFY" -eq 1 ]] && command -v notify-send &>/dev/null; then
+        notify-send -u "$urgency" "$summary" "$body" 2>/dev/null || true
+    fi
+}
+
+bell() {
+    if [[ "$USE_BELL" -eq 1 ]] && [[ -t 1 ]]; then
+        printf '\a'
+    fi
+}
+
+# ─── Output Formatting ──────────────────────────────────────────────────────
+
+BAR="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+print_header() {
+    local timestamp="$1"
+    local trigger="${2:-initial run}"
+    echo ""
+    echo "${C_DIM}${BAR}${C_RESET}"
+    printf "  ${C_BOLD}ety-watch${C_RESET}  |  %s  |  %s\n" "$timestamp" "$trigger"
+    echo "${C_DIM}${BAR}${C_RESET}"
+}
+
+print_footer() {
+    local ok_count="$1"
+    local err_count="$2"
+    local timeout_count="$3"
+    local elapsed="$4"
+
+    echo "${C_DIM}${BAR}${C_RESET}"
+
+    local status_parts=()
+    if [[ "$ok_count" -gt 0 ]]; then
+        status_parts+=("${C_GREEN}${ok_count} ok${C_RESET}")
+    fi
+    if [[ "$err_count" -gt 0 ]]; then
+        status_parts+=("${C_RED}${C_BOLD}${err_count} error${C_RESET}")
+    fi
+    if [[ "$timeout_count" -gt 0 ]]; then
+        status_parts+=("${C_YELLOW}${timeout_count} timeout${C_RESET}")
+    fi
+
+    local status_str=""
+    local sep=""
+    for part in "${status_parts[@]}"; do
+        status_str+="${sep}${part}"
+        sep=", "
+    done
+    printf "  RESULT: %s  |  %s\n" "$status_str" "$elapsed"
+    echo "${C_DIM}${BAR}${C_RESET}"
+}
+
+# ─── Output Parsing ─────────────────────────────────────────────────────────
+
+# ─── Type Check Runner ──────────────────────────────────────────────────────
+
+run_typecheck() {
+    local trigger="${1:-initial run}"
+    local timestamp
+    timestamp="$(date +%H:%M:%S)"
+
+    if [[ "$CLEAR" -eq 1 ]]; then
+        clear
+    fi
+
+    print_header "$timestamp" "$trigger"
+
+    set_title "[...] ety-watch"
+
+    # Counters
+    local ok_count=0
+    local err_count=0
+    local timeout_count=0
+    local unsupported_count=0
+    local other_count=0
+    local in_error_msg=0
+    local suppress_continuation=0
+    local msg_color=""
+    local had_parseable_output=0
+    local exit_code=0
+    local buffered_lines=()
+
+    # Regex patterns stored in variables to avoid bash parsing issues with parens
+    local re_ok='^Ok: (.+) \(([0-9]+) ms\)$'
+    local re_err_typed='^Error: \(([^)]+)\) (.+) \(([0-9]+) ms\)$'
+    local re_err='^Error: (.+) \(([0-9]+) ms\)$'
+    local re_timeout='^Timeout: (.+) \(([0-9]+) ms\)$'
+    local re_unsupported='^Unsupported: (.+)$'
+    local re_other='^Other: (.+)$'
+
+    local start_time
+    start_time=$(date +%s%N 2>/dev/null || date +%s)
+
+    # Stream output line by line using process substitution.
+    # The sentinel __ETY_EXIT:N carries the command's exit code.
+    while IFS= read -r line; do
+        # Extract exit code from sentinel
+        if [[ "$line" == __ETY_EXIT:* ]]; then
+            exit_code="${line#__ETY_EXIT:}"
+            continue
+        fi
+
+        # Parse and display each line as it arrives
+        if [[ "$line" =~ $re_ok ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            ok_count=$((ok_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            local ms="${BASH_REMATCH[2]}"
+            if [[ "$QUIET" -eq 0 ]]; then
+                printf "  ${C_GREEN}[OK]${C_RESET}          %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+            fi
+
+        elif [[ "$line" =~ $re_err_typed ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            suppress_continuation=0
+            err_count=$((err_count + 1))
+            local err_type="${BASH_REMATCH[1]}"
+            local func="${BASH_REMATCH[2]}"
+            local ms="${BASH_REMATCH[3]}"
+            printf "  ${C_RED}${C_BOLD}[ERROR]${C_RESET}       %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+            printf "                ${C_DIM}type: %s${C_RESET}\n" "$err_type"
+            in_error_msg=1
+            msg_color="$C_RED"
+
+        elif [[ "$line" =~ $re_err ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            suppress_continuation=0
+            err_count=$((err_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            local ms="${BASH_REMATCH[2]}"
+            printf "  ${C_RED}${C_BOLD}[ERROR]${C_RESET}       %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+            in_error_msg=1
+            msg_color="$C_RED"
+
+        elif [[ "$line" =~ $re_timeout ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            timeout_count=$((timeout_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            local ms="${BASH_REMATCH[2]}"
+            printf "  ${C_YELLOW}[TIMEOUT]${C_RESET}     %-45s ${C_DIM}(%s ms)${C_RESET}\n" "$func" "$ms"
+
+        elif [[ "$line" =~ $re_unsupported ]]; then
+            had_parseable_output=1
+            in_error_msg=1
+            unsupported_count=$((unsupported_count + 1))
+            local func="${BASH_REMATCH[1]}"
+            msg_color="$C_CYAN"
+            if [[ "$QUIET" -eq 0 ]]; then
+                suppress_continuation=0
+                printf "  ${C_CYAN}[UNSUPPORTED]${C_RESET} %s\n" "$func"
+            else
+                suppress_continuation=1
+            fi
+
+        elif [[ "$line" =~ $re_other ]]; then
+            had_parseable_output=1
+            in_error_msg=0
+            suppress_continuation=0
+            other_count=$((other_count + 1))
+            local rest="${BASH_REMATCH[1]}"
+            printf "  ${C_YELLOW}[OTHER]${C_RESET}       %s\n" "$rest"
+
+        elif [[ "$in_error_msg" -eq 1 ]] && [[ "$line" =~ ^[[:space:]] ]]; then
+            # Indented continuation of error/unsupported message
+            if [[ "$suppress_continuation" -eq 0 ]]; then
+                printf "                ${msg_color}%s${C_RESET}\n" "$line"
+            fi
+
+        else
+            in_error_msg=0
+            # Buffer non-report lines for possible build failure display
+            if [[ -n "$line" ]]; then
+                buffered_lines+=("$line")
+                if [[ "$QUIET" -eq 0 ]]; then
+                    printf "  ${C_DIM}%s${C_RESET}\n" "$line"
+                fi
+            fi
+        fi
+    done < <($CMD --report-mode report --report-timeout "$REPORT_TIMEOUT" \
+                --only-recheck-changed \
+                "${EXTRA_ARGS[@]}" 2>&1; echo "__ETY_EXIT:$?")
+
+    local end_time
+    end_time=$(date +%s%N 2>/dev/null || date +%s)
+
+    # Calculate elapsed time
+    if [[ ${#start_time} -gt 10 ]]; then
+        local elapsed_ns=$((end_time - start_time))
+        local elapsed_s=$((elapsed_ns / 1000000000))
+        local elapsed_ms=$(( (elapsed_ns / 1000000) % 1000 ))
+        RUN_ELAPSED="${elapsed_s}.$(printf '%01d' $((elapsed_ms / 100)))s"
+    else
+        local elapsed_s=$((end_time - start_time))
+        RUN_ELAPSED="${elapsed_s}s"
+    fi
+
+    # Handle no report-mode output
+    if [[ "$had_parseable_output" -eq 0 ]]; then
+        if [[ "$exit_code" -ne 0 ]] && [[ ${#buffered_lines[@]} -gt 0 ]]; then
+            # Build failure: non-zero exit with non-report output
+            # Lines were already printed above if not quiet; in quiet mode, show them now
+            if [[ "$QUIET" -eq 1 ]]; then
+                echo ""
+                echo "  ${C_RED}${C_BOLD}[BUILD FAILURE]${C_RESET}"
+                for l in "${buffered_lines[@]}"; do
+                    echo "    $l"
+                done
+            fi
+            PREV_STATUS="errors"
+            set_title "[BUILD ERR] ety-watch"
+            bell
+            notify "critical" "ety-watch: Build failure" "Build failed"
+        elif [[ ${#buffered_lines[@]} -eq 0 ]]; then
+            echo "  ${C_DIM}Nothing to check.${C_RESET}"
+        fi
+        return "$exit_code"
+    fi
+
+    # Print summary footer
+    local total_errors=$((err_count + timeout_count + other_count))
+    print_footer "$ok_count" "$err_count" "$timeout_count" "${RUN_ELAPSED}"
+
+    # Status transitions & notifications
+    local new_status="ok"
+    if [[ "$total_errors" -gt 0 ]]; then
+        new_status="errors"
+    fi
+
+    if [[ "$new_status" == "errors" ]]; then
+        local err_label="${total_errors} ERR"
+        set_title "[${err_label}] ety-watch"
+        bell
+        if [[ "$PREV_STATUS" == "ok" ]]; then
+            notify "critical" "ety-watch: ${total_errors} problem(s)" \
+                "${err_count} error(s), ${timeout_count} timeout(s)"
+        fi
+    else
+        set_title "[OK] ety-watch"
+        if [[ "$PREV_STATUS" == "errors" ]]; then
+            notify "normal" "ety-watch: All clear" "All ${ok_count} functions passed"
+        fi
+    fi
+
+    PREV_STATUS="$new_status"
+
+    if [[ "$total_errors" -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# ─── File Watching ───────────────────────────────────────────────────────────
+
+setup_watch_dirs() {
+    # Convert comma-separated dirs to array, filter to existing dirs
+    IFS=',' read -ra DIR_ARRAY <<< "$WATCH_DIRS"
+    EXISTING_DIRS=()
+    for d in "${DIR_ARRAY[@]}"; do
+        if [[ -d "$d" ]]; then
+            EXISTING_DIRS+=("$d")
+        fi
+    done
+
+    if [[ ${#EXISTING_DIRS[@]} -eq 0 ]]; then
+        echo "${C_RED}Error: No watch directories found. Checked: ${WATCH_DIRS}${C_RESET}" >&2
+        exit 1
+    fi
+}
+
+parse_event_line() {
+    local event_line="$1"
+    local event="${event_line%% *}"
+    local filepath="${event_line#* }"
+    local filename
+    filename="$(basename "$filepath")"
+    case "$event" in
+        *CREATE*|*MOVED_TO*)  echo "$filename added" ;;
+        *DELETE*|*MOVED_FROM*) echo "$filename removed" ;;
+        *)                     echo "$filename changed" ;;
+    esac
+}
+
+# Start a persistent inotifywait monitor. Events are readable from fd 3.
+start_inotify_monitor() {
+    WATCH_FIFO="$(mktemp -u)"
+    mkfifo "$WATCH_FIFO"
+
+    inotifywait -m -r -e modify,create,delete,moved_to,moved_from \
+        --include '.*\.(erl|hrl)$' \
+        --format '%e %w%f' \
+        "${EXISTING_DIRS[@]}" > "$WATCH_FIFO" 2>/dev/null &
+    INOTIFY_PID=$!
+
+    # Open FIFO once with a persistent fd
+    exec 3< "$WATCH_FIFO"
+}
+
+# Block until an inotify event arrives, then debounce.
+wait_inotify_event() {
+    local event_line=""
+    if IFS= read -r event_line <&3; then
+        local debounce_sec
+        debounce_sec=$(awk "BEGIN {printf \"%.1f\", ${DEBOUNCE_MS}/1000}")
+        while IFS= read -r -t "$debounce_sec" _ <&3; do
+            : # drain
+        done
+    fi
+    if [[ -n "$event_line" ]]; then
+        parse_event_line "$event_line"
+    else
+        echo "file change"
+    fi
+}
+
+# Non-blocking: drain any inotify events that arrived during a typecheck run.
+# Prints trigger description if events were found, nothing otherwise.
+drain_inotify_pending() {
+    local last_event="" event_line=""
+    while IFS= read -r -t 0.01 event_line <&3 2>/dev/null; do
+        [[ -n "$event_line" ]] && last_event="$event_line"
+    done
+    if [[ -n "$last_event" ]]; then
+        # Debounce: wait for more events to settle
+        local debounce_sec
+        debounce_sec=$(awk "BEGIN {printf \"%.1f\", ${DEBOUNCE_MS}/1000}")
+        while IFS= read -r -t "$debounce_sec" event_line <&3; do
+            [[ -n "$event_line" ]] && last_event="$event_line"
+        done
+        parse_event_line "$last_event"
+    fi
+}
+
+# Wait for changes using find -newer polling (fallback)
+# Also detects file additions and removals by comparing file lists.
+wait_for_changes_poll() {
+    SENTINEL="_etylizer/.watch_sentinel"
+    local filelist="_etylizer/.watch_filelist"
+    mkdir -p _etylizer
+    touch "$SENTINEL"
+
+    # Snapshot current file list for add/remove detection
+    find "${EXISTING_DIRS[@]}" \
+        \( -name '*.erl' -o -name '*.hrl' \) \
+        2>/dev/null | sort > "$filelist"
+
+    while true; do
+        sleep "$POLL_INTERVAL"
+
+        # Check for modified files
+        local changed
+        changed=$(find "${EXISTING_DIRS[@]}" \
+            -newer "$SENTINEL" \
+            \( -name '*.erl' -o -name '*.hrl' \) \
+            -print -quit 2>/dev/null || true)
+
+        if [[ -n "$changed" ]]; then
+            touch "$SENTINEL"
+            # Update file list snapshot
+            find "${EXISTING_DIRS[@]}" \
+                \( -name '*.erl' -o -name '*.hrl' \) \
+                2>/dev/null | sort > "$filelist"
+            echo "$(basename "$changed") changed"
+            return
+        fi
+
+        # Check for added/removed files
+        local current_list
+        current_list=$(find "${EXISTING_DIRS[@]}" \
+            \( -name '*.erl' -o -name '*.hrl' \) \
+            2>/dev/null | sort)
+
+        local added removed
+        added=$(comm -13 "$filelist" <(echo "$current_list") | head -1)
+        removed=$(comm -23 "$filelist" <(echo "$current_list") | head -1)
+
+        if [[ -n "$added" ]]; then
+            touch "$SENTINEL"
+            echo "$current_list" | sort > "$filelist"
+            echo "$(basename "$added") added"
+            return
+        fi
+
+        if [[ -n "$removed" ]]; then
+            touch "$SENTINEL"
+            echo "$current_list" | sort > "$filelist"
+            echo "$(basename "$removed") removed"
+            return
+        fi
+    done
+}
+
+touch_poll_sentinel() {
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then return; fi
+    SENTINEL="_etylizer/.watch_sentinel"
+    mkdir -p _etylizer
+    touch "$SENTINEL"
+}
+
+# Non-blocking: check if files changed since sentinel (for poll mode).
+check_poll_immediate() {
+    if [[ ! -f "$SENTINEL" ]]; then return; fi
+    local changed
+    changed=$(find "${EXISTING_DIRS[@]}" \
+        -newer "$SENTINEL" \
+        \( -name '*.erl' -o -name '*.hrl' \) \
+        -print -quit 2>/dev/null || true)
+    if [[ -n "$changed" ]]; then
+        touch "$SENTINEL"
+        echo "$(basename "$changed") changed"
+    fi
+}
+
+# Blocking: wait for the next file change.
+wait_for_changes() {
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        wait_inotify_event
+    else
+        wait_for_changes_poll
+    fi
+}
+
+# Non-blocking: check if changes happened during a typecheck run.
+check_pending_changes() {
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        drain_inotify_pending
+    else
+        check_poll_immediate
+    fi
+}
+
+# ─── Cleanup ─────────────────────────────────────────────────────────────────
+
+# Recursively kill a process and all its descendants.
+kill_tree() {
+    local pid=$1 sig=${2:-TERM}
+    [[ -z "$pid" ]] && return
+    kill -0 "$pid" 2>/dev/null || return
+    local child
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+        kill_tree "$child" "$sig"
+    done
+    kill -"$sig" "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+    # Disarm traps so this cleanup doesn't re-enter itself.
+    trap '' SIGINT SIGTERM EXIT
+
+    # Close inotify fd if open
+    exec 3<&- 2>/dev/null || true
+
+    # Kill every descendant of this script (typecheck subshell + etylizer,
+    # inotifywait, and anything else we spawned). The escript ignores plain
+    # SIGINT, so we have to deliver the signal explicitly.
+    local child
+    for child in $(pgrep -P $$ 2>/dev/null); do
+        kill_tree "$child" TERM
+    done
+    sleep 0.1
+    for child in $(pgrep -P $$ 2>/dev/null); do
+        kill_tree "$child" KILL
+    done
+
+    # Remove FIFO
+    if [[ -n "$WATCH_FIFO" ]] && [[ -e "$WATCH_FIFO" ]]; then
+        rm -f "$WATCH_FIFO"
+    fi
+
+    # Remove temp files
+    if [[ -n "$TMPFILE" ]] && [[ -f "$TMPFILE" ]]; then
+        rm -f "$TMPFILE"
+    fi
+
+    # Remove sentinel and file list
+    if [[ -n "$SENTINEL" ]] && [[ -f "$SENTINEL" ]]; then
+        rm -f "$SENTINEL"
+    fi
+    rm -f "_etylizer/.watch_filelist"
+
+    # Restore terminal title
+    set_title ""
+
+    echo ""
+    echo "ety-watch stopped."
+    exit 130
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+    parse_args "$@"
+    color_init
+
+    cd "$SCRIPT_DIR"
+
+    # Detect inotifywait
+    if command -v inotifywait &>/dev/null; then
+        HAS_INOTIFYWAIT=1
+    else
+        echo "${C_YELLOW}inotifywait not found. Using polling (${POLL_INTERVAL}s interval).${C_RESET}"
+        echo "${C_DIM}Install inotify-tools for event-driven watching.${C_RESET}"
+    fi
+
+    setup_watch_dirs
+
+    trap cleanup SIGINT SIGTERM EXIT
+
+    echo "${C_BOLD}ety-watch${C_RESET} v${VERSION}"
+    echo "Watching: ${EXISTING_DIRS[*]}"
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        echo "Mode: inotifywait (event-driven)"
+    else
+        echo "Mode: polling (${POLL_INTERVAL}s)"
+    fi
+    echo ""
+
+    # Start persistent inotify monitor so events during typecheck are captured
+    if [[ "$HAS_INOTIFYWAIT" -eq 1 ]]; then
+        start_inotify_monitor
+    fi
+
+    # Initial run
+    touch_poll_sentinel
+    local result=0
+    run_typecheck "initial run" || result=$?
+
+    if [[ "$ONCE" -eq 1 ]]; then
+        exit "$result"
+    fi
+
+    # Watch loop
+    while true; do
+        # Check if files changed during the last typecheck run
+        local pending
+        pending=$(check_pending_changes)
+
+        if [[ -n "$pending" ]]; then
+            # Re-run immediately with the pending trigger
+            touch_poll_sentinel
+            run_typecheck "${pending}" || true
+        else
+            echo ""
+            echo "${C_DIM}Watching for changes...${C_RESET}"
+
+            local changed_file
+            changed_file=$(wait_for_changes)
+
+            touch_poll_sentinel
+            run_typecheck "${changed_file}" || true
+        fi
+    done
+}
+
+main "$@"

--- a/src/cm_check.erl
+++ b/src/cm_check.erl
@@ -1,11 +1,13 @@
 -module(cm_check).
 
 % @doc This module is responsible for orchestrating the execution of the type checks and
-% updating the index.
+% updating the index. Supports function-level incremental type checking.
 
 -export([
     perform_type_checks/4
 ]).
+
+-export_type([check_list/0]).
 
 -ifdef(TEST).
 -export([perform_sanity_check/3, perform_sanity_check/4]).
@@ -14,112 +16,431 @@
 -include("log.hrl").
 -include("etylizer_main.hrl").
 -include("parse.hrl").
+-include("etylizer.hrl").
+
+-type check_entry() :: {file:filename(), all | [{atom(), arity()}]}.
+-type check_list() :: [check_entry()].
 
 -spec perform_type_checks(
     paths:search_path(),
     [file:filename()],
     cm_depgraph:dep_graph(),
-    cmd_opts()) -> [file:filename()].
+    cmd_opts()) -> check_list().
 perform_type_checks(SearchPath, SourceList, DepGraph, Opts) ->
     IndexFile = paths:index_file_name(Opts),
     RebarLockFile = paths:rebar_lock_file(Opts),
     Index = cm_index:load_index(RebarLockFile, IndexFile, Opts#opts.mode),
-    ?LOG_DEBUG("All sources: ~p", SourceList),
-    {DepsChanged, NewIndex1} =
+    {DepsChanged, NewIndex0} =
         cm_index:has_external_dep_changed(RebarLockFile, Index),
-    CheckList =
-        case {DepsChanged, Opts#opts.force} of
-            {true, false} ->
-                ?LOG_DEBUG("Some external dependency has changed, rechecking everything"),
-                SourceList;
-            {false, true} ->
-                ?LOG_TRACE("Forced to recheck everything"),
-                SourceList;
-            _ ->
-                ?LOG_TRACE("No external dependency has changed"),
-                create_check_list(SourceList, NewIndex1, DepGraph)
-        end,
-    case CheckList of
-        [] -> ?LOG_DEBUG("Need to check 0 of ~p files", length(CheckList));
-        _ ->
-            ?LOG_DEBUG("Need to check ~p of ~p files: ~p",
-                length(CheckList), length(SourceList), CheckList)
+    NewIndex1 = case Opts#opts.no_deps of
+        true -> NewIndex0;
+        false -> cm_index:prune(NewIndex0, SourceList)
     end,
+    CheckList = compute_check_list(SourceList, NewIndex1, DepGraph, DepsChanged, Opts),
+    rebuild_dep_graphs_if_needed(CheckList, SearchPath, DepGraph, Opts),
+    _ = rebuild_fun_dep_graph(SourceList, CheckList, paths:fun_depgraph_file_name(Opts)),
+    run_checks_and_save(CheckList, SearchPath, Opts, NewIndex1, IndexFile).
+
+% @doc Run type checks and save the index.
+-spec run_checks_and_save(
+    check_list(), paths:search_path(), cmd_opts(), cm_index:index(), file:filename()
+) -> check_list().
+run_checks_and_save(CheckList, SearchPath, Opts, Index, IndexFile) ->
     OverlaySymtab = overlay_symtab(Opts),
-    NewIndex2 = traverse_and_check(CheckList, symtab:std_symtab(SearchPath, OverlaySymtab),
-        OverlaySymtab, SearchPath, Opts, NewIndex1),
-    cm_index:save_index(IndexFile, NewIndex2),
+    Symtab = symtab:std_symtab(SearchPath, OverlaySymtab),
+    NewIndex = traverse_and_check(CheckList, Symtab,
+        OverlaySymtab, SearchPath, Opts, Index),
+    cm_index:save_index(IndexFile, NewIndex),
     CheckList.
 
--spec create_check_list([file:filename()], cm_index:index(), cm_depgraph:dep_graph()) -> [file:filename()].
-create_check_list(SourceList, Index, DepGraph) ->
-    CheckList = lists:foldl(
-                  fun(Path, FilesToCheck) ->
-                          case cm_index:has_file_changed(Path, Index) of
-                              true ->
-                                ?LOG_INFO("Need to check ~p because the file has changed.", Path),
-                                ChangedFile = [Path];
-                              false -> ChangedFile = []
-                          end,
-                          Forms = parse_cache:parse(intern, Path),
-                          case cm_index:has_exported_interface_changed(Path, Forms, Index) of
-                              true ->
-                                Deps = cm_depgraph:find_dependent_files(Path, DepGraph),
-                                case Deps of
-                                    [] -> ok;
-                                    _ ->
-                                        ?LOG_INFO("Need to check the following files because the " ++
-                                            "interface of ~p has changed: ~200p", Path, Deps)
-                                end;
-                              false -> Deps = []
-                          end,
-                          FilesToCheck ++ ChangedFile ++ Deps
-                  end, [], SourceList),
-    lists:uniq(CheckList).
+% @doc Determine which check list to use based on deps/force status.
+-spec compute_check_list(
+    [file:filename()], cm_index:index(), cm_depgraph:dep_graph(), boolean(), cmd_opts()
+) -> check_list().
+compute_check_list(SourceList, Index, DepGraph, DepsChanged, Opts) ->
+    FunDepGraphFile = paths:fun_depgraph_file_name(Opts),
+    FunDepGraph = case cm_depgraph:load_fun_depgraph(FunDepGraphFile) of
+        {ok, G} -> G;
+        stale -> ?assert_type(maps:new(), cm_depgraph:fun_dep_graph())
+    end,
+    CheckList =
+        case {DepsChanged, Opts#opts.force} of
+            {false, false} ->
+                ?LOG_TRACE("No external dependency has changed"),
+                create_check_list(SourceList, Index, DepGraph, FunDepGraph);
+            {true, _} ->
+                ?LOG_DEBUG("Some external dependency has changed, rechecking everything"),
+                [{F, all} || F <- SourceList];
+            {_, true} ->
+                ?LOG_TRACE("Forced to recheck everything"),
+                [{F, all} || F <- SourceList]
+        end,
+    log_check_list(CheckList, SourceList),
+    CheckList.
+
+% @doc Log check list summary.
+-spec log_check_list(check_list(), [file:filename()]) -> ok.
+log_check_list([], SourceList) ->
+    ?LOG_DEBUG("Need to check 0 of ~p files", length(SourceList)), ok;
+log_check_list(CheckList, SourceList) ->
+    ?LOG_DEBUG("Need to check ~p of ~p files: ~p",
+        length(CheckList), length(SourceList), CheckList), ok.
+
+% @doc Incrementally update and save the module-level dep graph for changed files.
+-spec rebuild_dep_graphs_if_needed(
+    check_list(), paths:search_path(), cm_depgraph:dep_graph(), cmd_opts()
+) -> ok.
+rebuild_dep_graphs_if_needed(CheckList, SearchPath, DepGraph, Opts) ->
+    ChangedFiles = [F || {F, _} <- CheckList],
+    DepGraphFile = paths:depgraph_file_name(Opts),
+    case ChangedFiles =/= [] andalso not Opts#opts.no_deps of
+        true ->
+            ?LOG_DEBUG("Incrementally updating dependency graph (~p changed files)",
+                length(ChangedFiles)),
+            % Remove old edges for changed files, then re-add from current AST
+            Pruned = lists:foldl(
+                fun(F, G) -> cm_depgraph:remove_dependent(F, G) end,
+                DepGraph, ChangedFiles),
+            Updated = lists:foldl(
+                fun(F, G) ->
+                    Forms = parse_cache:parse(intern, F),
+                    cm_depgraph:update_dep_graph(F, Forms, SearchPath, G)
+                end,
+                Pruned, ChangedFiles),
+            cm_depgraph:save_depgraph(DepGraphFile, Updated);
+        false -> ok
+    end.
+
+% @doc Rebuild function dep graph, incrementally if possible.
+-spec rebuild_fun_dep_graph([file:filename()], check_list(), file:filename()) -> cm_depgraph:fun_dep_graph().
+rebuild_fun_dep_graph(SourceList, CheckList, FunDepGraphFile) ->
+    ChangedFiles = [F || {F, _} <- CheckList],
+    case ChangedFiles of
+        [] ->
+            % Nothing changed, reuse existing graph
+            case cm_depgraph:load_fun_depgraph(FunDepGraphFile) of
+                {ok, G} -> G;
+                stale -> ?assert_type(maps:new(), cm_depgraph:fun_dep_graph())
+            end;
+        _ ->
+            case cm_depgraph:load_fun_depgraph(FunDepGraphFile) of
+                {ok, OldGraph} ->
+                    % Incremental: only re-analyze changed files
+                    ?LOG_DEBUG("Incrementally updating function dependency graph (~p changed files)",
+                        length(ChangedFiles)),
+                    ChangedMods = sets:from_list(
+                        [ast_utils:modname_from_path(F) || F <- ChangedFiles],
+                        [{version, 2}]),
+                    ChangedModInfos = analyze_files(ChangedFiles),
+                    Graph = cm_depgraph:update_fun_dep_graph(
+                        OldGraph, ChangedMods, ChangedModInfos),
+                    cm_depgraph:save_fun_depgraph(FunDepGraphFile, Graph),
+                    Graph;
+                stale ->
+                    % No existing graph, full rebuild from all files
+                    ?LOG_DEBUG("Building function dependency graph from scratch"),
+                    ModInfos = analyze_files(SourceList),
+                    Graph = cm_depgraph:build_fun_dep_graph(ModInfos),
+                    cm_depgraph:save_fun_depgraph(FunDepGraphFile, Graph),
+                    Graph
+            end
+    end.
+
+% @doc Parse and analyze a list of source files.
+-spec analyze_files([file:filename()]) -> [{file:filename(), cm_fun_deps:module_info()}].
+analyze_files(Files) ->
+    lists:map(
+        fun(Path) ->
+            Forms = parse_cache:parse(intern, Path),
+            ModName = ast_utils:modname_from_path(Path),
+            {Path, cm_fun_deps:analyze_module(ModName, Forms)}
+        end, Files).
+
+-spec create_check_list(
+    [file:filename()], cm_index:index(), cm_depgraph:dep_graph(), cm_depgraph:fun_dep_graph()
+) -> check_list().
+create_check_list(SourceList, Index, DepGraph, FunDepGraph) ->
+    ModToPath = maps:from_list(
+        [{ast_utils:modname_from_path(P), P} || P <- SourceList]),
+    CheckEntries = lists:foldl(
+        fun(Path, Acc) ->
+            process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, Acc)
+        end, [], SourceList),
+    merge_check_entries(CheckEntries).
+
+% @doc Process a single source file and determine what needs rechecking.
+-spec process_source_file(
+    file:filename(), cm_index:index(), cm_depgraph:dep_graph(),
+    cm_depgraph:fun_dep_graph(), #{atom() => file:filename()}, check_list()
+) -> check_list().
+process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, Acc) ->
+    case cm_index:has_file_changed(Path, Index) of
+        false -> Acc;
+        true ->
+            ?LOG_DEBUG("Need to check ~p because the file has changed.", Path),
+            Forms = parse_cache:parse(intern, Path),
+            ModName = ast_utils:modname_from_path(Path),
+            ModInfo = cm_fun_deps:analyze_module(ModName, Forms),
+            {ChangedFuns, DeclsChanged} = cm_index:changed_functions(Path, ModInfo, Index),
+            process_changed_file(Path, Forms, ModName, ModInfo, ChangedFuns,
+                DeclsChanged, Index, DepGraph, FunDepGraph, ModToPath, Acc)
+    end.
+
+% @doc Handle a file that has changed, determining check entries.
+-spec process_changed_file(
+    file:filename(), ast:forms(), atom(), cm_fun_deps:module_info(),
+    all | [ast:fun_with_arity()], boolean(),
+    cm_index:index(), cm_depgraph:dep_graph(), cm_depgraph:fun_dep_graph(),
+    #{atom() => file:filename()}, check_list()
+) -> check_list().
+process_changed_file(Path, Forms, _ModName, _ModInfo, _ChangedFuns,
+        true, Index, DepGraph, _FunDepGraph, _ModToPath, Acc) ->
+    % Types/records/exports changed: recheck all in this file.
+    % Only recheck dependents if the exported interface actually changed
+    % (e.g. a local type change doesn't affect dependents).
+    Deps = case cm_index:has_exported_interface_changed(Path, Forms, Index) of
+        true ->
+            FoundDeps = cm_depgraph:find_dependent_files(Path, DepGraph),
+            case FoundDeps of
+                [] -> ok;
+                _ ->
+                    ?LOG_DEBUG("Need to check the following files because the " ++
+                        "interface of ~p has changed: ~200p", Path, FoundDeps)
+            end,
+            [{D, all} || D <- FoundDeps];
+        false -> []
+    end,
+    Acc ++ [{Path, all}] ++ Deps;
+process_changed_file(Path, _Forms, ModName, ModInfo, ChangedFuns,
+        false, Index, _DepGraph, FunDepGraph, ModToPath, Acc) ->
+    case ChangedFuns of
+        all ->
+            % All functions changed but decls didn't. Find callers of spec-changed funs.
+            AllFunIds = [FId || FId <- maps:keys(
+                ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}))],
+            SpecChangedFunIds = find_all_spec_changed_funs(AllFunIds, ModInfo, Path, Index),
+            {LocalCallers, CrossEntries} = find_affected_callers(
+                SpecChangedFunIds, FunDepGraph, ModName, ModToPath),
+            Acc ++ [{Path, all}] ++ [{Path, LocalCallers} || LocalCallers =/= []] ++ CrossEntries;
+        [] ->
+            % No functions changed (only whitespace/comments?)
+            Acc ++ [{Path, []}];
+        Funs ->
+            SpecChangedFuns = find_spec_changed_funs(ModName, Funs, ModInfo, Path, Index),
+            {LocalCallers, CrossEntries} = find_affected_callers(
+                SpecChangedFuns, FunDepGraph, ModName, ModToPath),
+            AllLocalFuns = lists:uniq(Funs ++ LocalCallers),
+            Acc ++ [{Path, AllLocalFuns}] ++ CrossEntries
+    end.
+
+% @doc Find functions whose specs changed from the set of changed functions.
+-spec find_spec_changed_funs(
+    atom(), [ast:fun_with_arity()], cm_fun_deps:module_info(),
+    file:filename(), cm_index:index()
+) -> [cm_fun_deps:fun_id()].
+find_spec_changed_funs(ModName, ChangedFuns, ModInfo, Path, {_, IndexMap}) ->
+    lists:filtermap(
+        fun(FA) ->
+            check_spec_changed(ModName, FA, ModInfo, Path, IndexMap)
+        end, ChangedFuns).
+
+% @doc Check all fun_ids for spec changes (used when ChangedFuns = all).
+-spec find_all_spec_changed_funs(
+    [cm_fun_deps:fun_id()], cm_fun_deps:module_info(),
+    file:filename(), cm_index:index()
+) -> [cm_fun_deps:fun_id()].
+find_all_spec_changed_funs(FunIds, ModInfo, Path, {_, IndexMap}) ->
+    lists:filtermap(
+        fun({ModName, Name, Arity}) ->
+            check_spec_changed(ModName, {Name, Arity}, ModInfo, Path, IndexMap)
+        end, FunIds).
+
+% @doc Check if a single function's spec has changed.
+-spec check_spec_changed(
+    atom(), ast:fun_with_arity(), cm_fun_deps:module_info(),
+    file:filename(), #{file:filename() => cm_index:file_index_entry()}
+) -> {true, cm_fun_deps:fun_id()} | false.
+check_spec_changed(ModName, {Name, Arity}, ModInfo, Path, IndexMap) ->
+    FunId = {ModName, Name, Arity},
+    Funs = ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}),
+    case maps:find(FunId, Funs) of
+        error -> false;
+        {ok, FunInfo} ->
+            NewSpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
+            case maps:find(Path, IndexMap) of
+                error ->
+                    % File not in index, treat spec as changed
+                    {true, FunId};
+                {ok, {_, _, _, OldFunIndex}} ->
+                    case maps:find({Name, Arity}, OldFunIndex) of
+                        error ->
+                            % New function, treat spec as changed
+                            {true, FunId};
+                        {ok, {failed, OldSpecHash}} ->
+                            % Previously failed - compare spec hashes
+                            case NewSpecHash =/= OldSpecHash of
+                                true -> {true, FunId};
+                                false -> false
+                            end;
+                        {ok, {_OldBodyHash, OldSpecHash}} ->
+                            case NewSpecHash =/= OldSpecHash of
+                                true -> {true, FunId};
+                                false -> false
+                            end
+                    end
+            end
+    end.
+
+% @doc Find callers of spec-changed functions, both same-module and cross-module.
+% Returns {LocalCallers, CrossFileEntries} where LocalCallers are {Name, Arity}
+% pairs in the same module, and CrossFileEntries are check_list entries for other files.
+-spec find_affected_callers(
+    [cm_fun_deps:fun_id()], cm_depgraph:fun_dep_graph(),
+    atom(), #{atom() => file:filename()}
+) -> {[ast:fun_with_arity()], check_list()}.
+find_affected_callers([], _FunDepGraph, _SourceMod, _ModToPath) ->
+    {[], []};
+find_affected_callers(SpecChangedFuns, FunDepGraph, SourceMod, ModToPath) ->
+    AllCallers = lists:flatmap(
+        fun(FunId) -> cm_depgraph:find_fun_callers(FunId, FunDepGraph) end,
+        SpecChangedFuns),
+    % Separate same-module callers from cross-module callers
+    {SameModCallers, CrossModCallers} = lists:partition(
+        fun({Mod, _, _}) -> Mod =:= SourceMod end, AllCallers),
+    LocalFuns = lists:uniq([{Name, Arity} || {_, Name, Arity} <- SameModCallers]),
+    % Group cross-module callers by module, then map to file paths
+    CallersByMod = lists:foldl(
+        fun({Mod, FName, FArity}, Acc) ->
+            Existing = maps:get(Mod, Acc, []),
+            maps:put(Mod, [{FName, FArity} | Existing], Acc)
+        end, ?assert_type(maps:new(), #{atom() => [ast:fun_with_arity()]}), CrossModCallers),
+    CrossEntries = lists:filtermap(
+        fun({Mod, FunsInMod}) ->
+            case maps:find(Mod, ModToPath) of
+                {ok, FilePath} ->
+                    UniqFuns = lists:uniq(?assert_type(FunsInMod, [ast:fun_with_arity()])),
+                    ?LOG_INFO("Need to recheck ~200p in ~p because called specs changed",
+                        UniqFuns, FilePath),
+                    {true, {FilePath, UniqFuns}};
+                error ->
+                    % Module not in our source list (external dep)
+                    false
+            end
+        end, maps:to_list(CallersByMod)),
+    {LocalFuns, CrossEntries}.
+
+% @doc Merge check entries, combining per-file function lists and deduplicating.
+-spec merge_check_entries(check_list()) -> check_list().
+merge_check_entries(Entries) ->
+    Merged = lists:foldl(
+        fun(Entry, Acc) -> merge_single_entry(Entry, Acc) end,
+        ?assert_type(maps:new(), #{file:filename() => all | [{atom(), arity()}]}),
+        Entries),
+    [{F, Fs} || {F, Fs} <- maps:to_list(Merged), Fs =:= all orelse Fs =/= []].
+
+% @doc Merge a single check entry into the accumulator map.
+-spec merge_single_entry(
+    check_entry(), #{file:filename() => all | [{atom(), arity()}]}
+) -> #{file:filename() => all | [{atom(), arity()}]}.
+merge_single_entry({File, Funs}, Acc) ->
+    case maps:find(File, Acc) of
+        error ->
+            maps:put(File, Funs, Acc);
+        {ok, all} ->
+            Acc;
+        {ok, _ExistingFuns} when Funs =:= all ->
+            maps:put(File, all, Acc);
+        {ok, ExistingFuns} ->
+            maps:put(File, lists:uniq(?assert_type(ExistingFuns, [{atom(), arity()}]) ++ ?assert_type(Funs, [{atom(), arity()}])), Acc)
+    end.
 
 -spec traverse_and_check(
-    [file:filename()], symtab:t(), symtab:t(), paths:search_path(), cmd_opts(), cm_index:index())
+    check_list(), symtab:t(), symtab:t(), paths:search_path(), cmd_opts(), cm_index:index())
     -> cm_index:index().
 traverse_and_check([], _, _, _, _, Index) ->
     Index;
-
-traverse_and_check([CurrentFile | RemainingFiles], Symtab, OverlaySymtab, SearchPath, Opts, Index) ->
-    {Forms, _ExpandedSymtab} = check_single_file(CurrentFile, Symtab, OverlaySymtab, SearchPath, Opts, Index),
-    NewIndex = cm_index:insert(CurrentFile, Forms, Index),
-    traverse_and_check(RemainingFiles, Symtab, OverlaySymtab, SearchPath, Opts, NewIndex).
+traverse_and_check([{CurrentFile, FunFilter} | Remaining], Symtab, OverlaySymtab, SearchPath, Opts, Index) ->
+    NewIndex = check_single_file(CurrentFile, FunFilter, Symtab, OverlaySymtab, SearchPath, Opts, Index),
+    traverse_and_check(Remaining, Symtab, OverlaySymtab, SearchPath, Opts, NewIndex).
 
 -spec check_single_file(
-    file:filename(), symtab:t(), symtab:t(), paths:search_path(), cmd_opts(), cm_index:index())
-    -> {ast:forms(), symtab:t()}.
-check_single_file(CurrentFile, Symtab, OverlaySymtab, SearchPath, Opts, _Index) ->
-    ?LOG_DEBUG("Checking ~s", CurrentFile),
-    Forms = parse_cache:parse(intern, CurrentFile),
+    file:filename(), all | [{atom(), arity()}], symtab:t(), symtab:t(),
+    paths:search_path(), cmd_opts(), cm_index:index())
+    -> cm_index:index().
+check_single_file(CurrentFile, FunFilter, Symtab, OverlaySymtab, SearchPath, Opts, Index) ->
     ModName = ast_utils:modname_from_path(CurrentFile),
-    Referenced = lists:filter(fun (M) -> M =/= ModName end, ast_utils:referenced_modules(Forms)),
-    ?LOG_DEBUG("Referenced from ~s: ~200p", CurrentFile, Referenced),
-    ExpandedSymtab = symtab:extend_symtab_with_module_list(Symtab, SearchPath, Referenced, OverlaySymtab),
-    do_type_check(CurrentFile, Forms, ExpandedSymtab, OverlaySymtab, Opts),
-    {Forms, ExpandedSymtab}.
+    Only = build_only_set(FunFilter, Opts#opts.type_check_only, ModName),
+    case {sets:is_empty(Only), Opts#opts.type_check_only} of
+        {true, [_|_]} ->
+            % -o specified but no functions match for this file, skip entirely
+            ?LOG_DEBUG("Skipping ~s: no functions match -o filter", CurrentFile),
+            Index;
+        _ ->
+            ?LOG_DEBUG("Checking ~s (filter: ~200p)", CurrentFile, FunFilter),
+            Forms = parse_cache:parse(intern, CurrentFile),
+            Referenced = [M || M <- ast_utils:referenced_modules(Forms), M =/= ModName],
+            ?LOG_DEBUG("Referenced from ~s: ~200p", CurrentFile, Referenced),
+            ExpandedSymtab = symtab:extend_symtab_with_module_list(Symtab, SearchPath, Referenced, OverlaySymtab),
+            FailedFuns = do_type_check(CurrentFile, Forms, Only, ExpandedSymtab, OverlaySymtab, Opts),
+            cm_index:insert(CurrentFile, Forms, FailedFuns, Index)
+    end.
 
--spec do_type_check(file:filename(), ast:forms(), symtab:t(), symtab:t(), cmd_opts()) -> ok.
-do_type_check(CurrentFile, Forms, ExpandedSymtab, OverlaySymtab, Opts) ->
-    Only = sets:from_list(Opts#opts.type_check_only, [{version, 2}]),
-    Ignore = sets:from_list(Opts#opts.type_check_ignore,[{version, 2}]),
+% @doc Run type check and return the list of functions that failed (empty in early-exit mode).
+-spec do_type_check(
+    file:filename(), ast:forms(), sets:set(string()), symtab:t(), symtab:t(), cmd_opts()
+) -> [{atom(), arity()}].
+do_type_check(CurrentFile, Forms, Only, ExpandedSymtab, OverlaySymtab, Opts) ->
     Sanity = perform_sanity_check(CurrentFile, Forms, Opts#opts.sanity),
-    ReportMode = Opts#opts.report_mode,
-    ReportTimeout = Opts#opts.report_timeout,
-    ExhaustivenessMode = Opts#opts.exhaustiveness_mode,
-    GradualTypingMode = Opts#opts.gradual_typing_mode,
-    Ctx = typing:new_ctx(ExpandedSymtab, OverlaySymtab, Sanity, ReportMode, ReportTimeout, ExhaustivenessMode, GradualTypingMode),
+    Ctx = typing:new_ctx(ExpandedSymtab, OverlaySymtab, Sanity,
+        Opts#opts.report_mode, Opts#opts.report_timeout,
+        Opts#opts.exhaustiveness_mode, Opts#opts.gradual_typing_mode),
     CliNoExhaustiveness = utils:parse_fun_ids(Opts#opts.no_exhaustiveness),
     CliNoRedundancy = utils:parse_fun_ids(Opts#opts.no_redundancy),
     case Opts#opts.no_type_checking of
         true ->
-            ?LOG_INFO("Not type checking ~p as requested", CurrentFile);
+            ?LOG_INFO("Not type checking ~p as requested", CurrentFile),
+            [];
         false ->
-            typing:check_forms(Ctx, CurrentFile, Forms, Only, Ignore, Opts#opts.check_exports, {CliNoExhaustiveness, CliNoRedundancy})
-    end,
-    ok.
+            typing:check_forms(Ctx, CurrentFile, Forms,
+                Only,
+                sets:from_list(Opts#opts.type_check_ignore, [{version, 2}]),
+                Opts#opts.check_exports,
+                {CliNoExhaustiveness, CliNoRedundancy})
+    end.
+
+% @doc Build the Only set from function filter and CLI --only flag.
+% Uses multi-level matching (module, module:name/arity, name/arity, name) consistent
+% with typing:should_check/6.
+-spec build_only_set(all | [{atom(), arity()}], [string()], atom()) -> sets:set(string()).
+build_only_set(all, CliOnly, _ModName) ->
+    sets:from_list(CliOnly, [{version, 2}]);
+build_only_set(FunFilter, [], _ModName) when is_list(FunFilter) ->
+    sets:from_list(
+        [utils:sformat("~w/~w", Name, Arity) || {Name, Arity} <- FunFilter],
+        [{version, 2}]);
+build_only_set(FunFilter, CliOnly, ModName) when is_list(FunFilter) ->
+    CliSet = sets:from_list(CliOnly, [{version, 2}]),
+    ModStr = utils:sformat("~w", ModName),
+    case sets:is_element(ModStr, CliSet) of
+        true ->
+            % Module-level match: all FunFilter functions are included
+            sets:from_list(
+                [utils:sformat("~w/~w", Name, Arity) || {Name, Arity} <- FunFilter],
+                [{version, 2}]);
+        false ->
+            % Per-function matching using same levels as typing:should_check/6
+            MatchingFuns = lists:filter(fun({Name, Arity}) ->
+                QRefStr = utils:sformat("~w:~w/~w", ModName, Name, Arity),
+                RefStr = utils:sformat("~w/~w", Name, Arity),
+                NameStr = utils:sformat("~w", Name),
+                sets:is_element(QRefStr, CliSet)
+                orelse sets:is_element(RefStr, CliSet)
+                orelse sets:is_element(NameStr, CliSet)
+            end, FunFilter),
+            sets:from_list(
+                [utils:sformat("~w/~w", N, A) || {N, A} <- MatchingFuns],
+                [{version, 2}])
+    end.
 
 -spec perform_sanity_check(file:filename(), ast:forms(), boolean()) -> {ok, ast_check:ty_map()} | error.
 perform_sanity_check(CurrentFile, Forms, DoCheck) ->

--- a/src/cm_check.erl
+++ b/src/cm_check.erl
@@ -67,7 +67,8 @@ compute_check_list(SourceList, Index, DepGraph, DepsChanged, Opts) ->
         case {DepsChanged, Opts#opts.force} of
             {false, false} ->
                 ?LOG_TRACE("No external dependency has changed"),
-                create_check_list(SourceList, Index, DepGraph, FunDepGraph);
+                create_check_list(SourceList, Index, DepGraph, FunDepGraph,
+                    Opts#opts.only_recheck_changed);
             {true, _} ->
                 ?LOG_DEBUG("Some external dependency has changed, rechecking everything"),
                 [{F, all} || F <- SourceList];
@@ -157,23 +158,25 @@ analyze_files(Files) ->
         end, Files).
 
 -spec create_check_list(
-    [file:filename()], cm_index:index(), cm_depgraph:dep_graph(), cm_depgraph:fun_dep_graph()
+    [file:filename()], cm_index:index(), cm_depgraph:dep_graph(), cm_depgraph:fun_dep_graph(),
+    boolean()
 ) -> check_list().
-create_check_list(SourceList, Index, DepGraph, FunDepGraph) ->
+create_check_list(SourceList, Index, DepGraph, FunDepGraph, OnlyRecheckChanged) ->
     ModToPath = maps:from_list(
         [{ast_utils:modname_from_path(P), P} || P <- SourceList]),
     CheckEntries = lists:foldl(
         fun(Path, Acc) ->
-            process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, Acc)
+            process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath,
+                OnlyRecheckChanged, Acc)
         end, [], SourceList),
     merge_check_entries(CheckEntries).
 
 % @doc Process a single source file and determine what needs rechecking.
 -spec process_source_file(
     file:filename(), cm_index:index(), cm_depgraph:dep_graph(),
-    cm_depgraph:fun_dep_graph(), #{atom() => file:filename()}, check_list()
+    cm_depgraph:fun_dep_graph(), #{atom() => file:filename()}, boolean(), check_list()
 ) -> check_list().
-process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, Acc) ->
+process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, OnlyRecheckChanged, Acc) ->
     case cm_index:has_file_changed(Path, Index) of
         false -> Acc;
         true ->
@@ -181,7 +184,8 @@ process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, Acc) ->
             Forms = parse_cache:parse(intern, Path),
             ModName = ast_utils:modname_from_path(Path),
             ModInfo = cm_fun_deps:analyze_module(ModName, Forms),
-            {ChangedFuns, DeclsChanged} = cm_index:changed_functions(Path, ModInfo, Index),
+            {ChangedFuns, DeclsChanged} =
+                cm_index:changed_functions(Path, ModInfo, Index, OnlyRecheckChanged),
             process_changed_file(Path, Forms, ModName, ModInfo, ChangedFuns,
                 DeclsChanged, Index, DepGraph, FunDepGraph, ModToPath, Acc)
     end.
@@ -276,7 +280,7 @@ check_spec_changed(ModName, {Name, Arity}, ModInfo, Path, IndexMap) ->
                         error ->
                             % New function, treat spec as changed
                             {true, FunId};
-                        {ok, {failed, OldSpecHash}} ->
+                        {ok, {failed, _OldBodyHash, OldSpecHash}} ->
                             % Previously failed - compare spec hashes
                             case NewSpecHash =/= OldSpecHash of
                                 true -> {true, FunId};

--- a/src/cm_check.erl
+++ b/src/cm_check.erl
@@ -1,11 +1,13 @@
 -module(cm_check).
 
 % @doc This module is responsible for orchestrating the execution of the type checks and
-% updating the index.
+% updating the index. Supports function-level incremental type checking.
 
 -export([
     perform_type_checks/4
 ]).
+
+-export_type([check_list/0]).
 
 -ifdef(TEST).
 -export([perform_sanity_check/3, perform_sanity_check/4]).
@@ -14,113 +16,431 @@
 -include("log.hrl").
 -include("etylizer_main.hrl").
 -include("parse.hrl").
+-include("etylizer.hrl").
+
+-type check_entry() :: {file:filename(), all | [{atom(), arity()}]}.
+-type check_list() :: [check_entry()].
 
 -spec perform_type_checks(
     paths:search_path(),
     [file:filename()],
     cm_depgraph:dep_graph(),
-    cmd_opts()) -> [file:filename()].
+    cmd_opts()) -> check_list().
 perform_type_checks(SearchPath, SourceList, DepGraph, Opts) ->
     IndexFile = paths:index_file_name(Opts),
     RebarLockFile = paths:rebar_lock_file(Opts),
     Index = cm_index:load_index(RebarLockFile, IndexFile, Opts#opts.mode),
-    ?LOG_DEBUG("All sources: ~p", SourceList),
-    {DepsChanged, NewIndex1} =
+    {DepsChanged, NewIndex0} =
         cm_index:has_external_dep_changed(RebarLockFile, Index),
-    CheckList =
-        case {DepsChanged, Opts#opts.force} of
-            {true, false} ->
-                ?LOG_DEBUG("Some external dependency has changed, rechecking everything"),
-                SourceList;
-            {false, true} ->
-                ?LOG_TRACE("Forced to recheck everything"),
-                SourceList;
-            _ ->
-                ?LOG_TRACE("No external dependency has changed"),
-                create_check_list(SourceList, NewIndex1, DepGraph)
-        end,
-    case CheckList of
-        [] -> ?LOG_DEBUG("Need to check 0 of ~p files", length(CheckList));
-        _ ->
-            ?LOG_DEBUG("Need to check ~p of ~p files: ~p",
-                length(CheckList), length(SourceList), CheckList)
+    NewIndex1 = case Opts#opts.no_deps of
+        true -> NewIndex0;
+        false -> cm_index:prune(NewIndex0, SourceList)
     end,
+    CheckList = compute_check_list(SourceList, NewIndex1, DepGraph, DepsChanged, Opts),
+    rebuild_dep_graphs_if_needed(CheckList, SearchPath, DepGraph, Opts),
+    _ = rebuild_fun_dep_graph(SourceList, CheckList, paths:fun_depgraph_file_name(Opts)),
+    run_checks_and_save(CheckList, SearchPath, Opts, NewIndex1, IndexFile).
+
+% @doc Run type checks and save the index.
+-spec run_checks_and_save(
+    check_list(), paths:search_path(), cmd_opts(), cm_index:index(), file:filename()
+) -> check_list().
+run_checks_and_save(CheckList, SearchPath, Opts, Index, IndexFile) ->
     OverlaySymtab = overlay_symtab(Opts),
-    NewIndex2 = traverse_and_check(CheckList,
-        symtab:std_symtab(SearchPath, OverlaySymtab, Opts#opts.gradual_typing_mode),
-        OverlaySymtab, SearchPath, Opts, NewIndex1),
-    cm_index:save_index(IndexFile, NewIndex2),
+    Symtab = symtab:std_symtab(SearchPath, OverlaySymtab, Opts#opts.gradual_typing_mode),
+    NewIndex = traverse_and_check(CheckList, Symtab,
+        OverlaySymtab, SearchPath, Opts, Index),
+    cm_index:save_index(IndexFile, NewIndex),
     CheckList.
 
--spec create_check_list([file:filename()], cm_index:index(), cm_depgraph:dep_graph()) -> [file:filename()].
-create_check_list(SourceList, Index, DepGraph) ->
-    CheckList = lists:foldl(
-                  fun(Path, FilesToCheck) ->
-                          case cm_index:has_file_changed(Path, Index) of
-                              true ->
-                                ?LOG_INFO("Need to check ~p because the file has changed.", Path),
-                                ChangedFile = [Path];
-                              false -> ChangedFile = []
-                          end,
-                          Forms = parse_cache:parse(intern, Path),
-                          case cm_index:has_exported_interface_changed(Path, Forms, Index) of
-                              true ->
-                                Deps = cm_depgraph:find_dependent_files(Path, DepGraph),
-                                case Deps of
-                                    [] -> ok;
-                                    _ ->
-                                        ?LOG_INFO("Need to check the following files because the " ++
-                                            "interface of ~p has changed: ~200p", Path, Deps)
-                                end;
-                              false -> Deps = []
-                          end,
-                          FilesToCheck ++ ChangedFile ++ Deps
-                  end, [], SourceList),
-    lists:uniq(CheckList).
+% @doc Determine which check list to use based on deps/force status.
+-spec compute_check_list(
+    [file:filename()], cm_index:index(), cm_depgraph:dep_graph(), boolean(), cmd_opts()
+) -> check_list().
+compute_check_list(SourceList, Index, DepGraph, DepsChanged, Opts) ->
+    FunDepGraphFile = paths:fun_depgraph_file_name(Opts),
+    FunDepGraph = case cm_depgraph:load_fun_depgraph(FunDepGraphFile) of
+        {ok, G} -> G;
+        stale -> ?assert_type(maps:new(), cm_depgraph:fun_dep_graph())
+    end,
+    CheckList =
+        case {DepsChanged, Opts#opts.force} of
+            {false, false} ->
+                ?LOG_TRACE("No external dependency has changed"),
+                create_check_list(SourceList, Index, DepGraph, FunDepGraph);
+            {true, _} ->
+                ?LOG_DEBUG("Some external dependency has changed, rechecking everything"),
+                [{F, all} || F <- SourceList];
+            {_, true} ->
+                ?LOG_TRACE("Forced to recheck everything"),
+                [{F, all} || F <- SourceList]
+        end,
+    log_check_list(CheckList, SourceList),
+    CheckList.
+
+% @doc Log check list summary.
+-spec log_check_list(check_list(), [file:filename()]) -> ok.
+log_check_list([], SourceList) ->
+    ?LOG_DEBUG("Need to check 0 of ~p files", length(SourceList)), ok;
+log_check_list(CheckList, SourceList) ->
+    ?LOG_DEBUG("Need to check ~p of ~p files: ~p",
+        length(CheckList), length(SourceList), CheckList), ok.
+
+% @doc Incrementally update and save the module-level dep graph for changed files.
+-spec rebuild_dep_graphs_if_needed(
+    check_list(), paths:search_path(), cm_depgraph:dep_graph(), cmd_opts()
+) -> ok.
+rebuild_dep_graphs_if_needed(CheckList, SearchPath, DepGraph, Opts) ->
+    ChangedFiles = [F || {F, _} <- CheckList],
+    DepGraphFile = paths:depgraph_file_name(Opts),
+    case ChangedFiles =/= [] andalso not Opts#opts.no_deps of
+        true ->
+            ?LOG_DEBUG("Incrementally updating dependency graph (~p changed files)",
+                length(ChangedFiles)),
+            % Remove old edges for changed files, then re-add from current AST
+            Pruned = lists:foldl(
+                fun(F, G) -> cm_depgraph:remove_dependent(F, G) end,
+                DepGraph, ChangedFiles),
+            Updated = lists:foldl(
+                fun(F, G) ->
+                    Forms = parse_cache:parse(intern, F),
+                    cm_depgraph:update_dep_graph(F, Forms, SearchPath, G)
+                end,
+                Pruned, ChangedFiles),
+            cm_depgraph:save_depgraph(DepGraphFile, Updated);
+        false -> ok
+    end.
+
+% @doc Rebuild function dep graph, incrementally if possible.
+-spec rebuild_fun_dep_graph([file:filename()], check_list(), file:filename()) -> cm_depgraph:fun_dep_graph().
+rebuild_fun_dep_graph(SourceList, CheckList, FunDepGraphFile) ->
+    ChangedFiles = [F || {F, _} <- CheckList],
+    case ChangedFiles of
+        [] ->
+            % Nothing changed, reuse existing graph
+            case cm_depgraph:load_fun_depgraph(FunDepGraphFile) of
+                {ok, G} -> G;
+                stale -> ?assert_type(maps:new(), cm_depgraph:fun_dep_graph())
+            end;
+        _ ->
+            case cm_depgraph:load_fun_depgraph(FunDepGraphFile) of
+                {ok, OldGraph} ->
+                    % Incremental: only re-analyze changed files
+                    ?LOG_DEBUG("Incrementally updating function dependency graph (~p changed files)",
+                        length(ChangedFiles)),
+                    ChangedMods = sets:from_list(
+                        [ast_utils:modname_from_path(F) || F <- ChangedFiles],
+                        [{version, 2}]),
+                    ChangedModInfos = analyze_files(ChangedFiles),
+                    Graph = cm_depgraph:update_fun_dep_graph(
+                        OldGraph, ChangedMods, ChangedModInfos),
+                    cm_depgraph:save_fun_depgraph(FunDepGraphFile, Graph),
+                    Graph;
+                stale ->
+                    % No existing graph, full rebuild from all files
+                    ?LOG_DEBUG("Building function dependency graph from scratch"),
+                    ModInfos = analyze_files(SourceList),
+                    Graph = cm_depgraph:build_fun_dep_graph(ModInfos),
+                    cm_depgraph:save_fun_depgraph(FunDepGraphFile, Graph),
+                    Graph
+            end
+    end.
+
+% @doc Parse and analyze a list of source files.
+-spec analyze_files([file:filename()]) -> [{file:filename(), cm_fun_deps:module_info()}].
+analyze_files(Files) ->
+    lists:map(
+        fun(Path) ->
+            Forms = parse_cache:parse(intern, Path),
+            ModName = ast_utils:modname_from_path(Path),
+            {Path, cm_fun_deps:analyze_module(ModName, Forms)}
+        end, Files).
+
+-spec create_check_list(
+    [file:filename()], cm_index:index(), cm_depgraph:dep_graph(), cm_depgraph:fun_dep_graph()
+) -> check_list().
+create_check_list(SourceList, Index, DepGraph, FunDepGraph) ->
+    ModToPath = maps:from_list(
+        [{ast_utils:modname_from_path(P), P} || P <- SourceList]),
+    CheckEntries = lists:foldl(
+        fun(Path, Acc) ->
+            process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, Acc)
+        end, [], SourceList),
+    merge_check_entries(CheckEntries).
+
+% @doc Process a single source file and determine what needs rechecking.
+-spec process_source_file(
+    file:filename(), cm_index:index(), cm_depgraph:dep_graph(),
+    cm_depgraph:fun_dep_graph(), #{atom() => file:filename()}, check_list()
+) -> check_list().
+process_source_file(Path, Index, DepGraph, FunDepGraph, ModToPath, Acc) ->
+    case cm_index:has_file_changed(Path, Index) of
+        false -> Acc;
+        true ->
+            ?LOG_DEBUG("Need to check ~p because the file has changed.", Path),
+            Forms = parse_cache:parse(intern, Path),
+            ModName = ast_utils:modname_from_path(Path),
+            ModInfo = cm_fun_deps:analyze_module(ModName, Forms),
+            {ChangedFuns, DeclsChanged} = cm_index:changed_functions(Path, ModInfo, Index),
+            process_changed_file(Path, Forms, ModName, ModInfo, ChangedFuns,
+                DeclsChanged, Index, DepGraph, FunDepGraph, ModToPath, Acc)
+    end.
+
+% @doc Handle a file that has changed, determining check entries.
+-spec process_changed_file(
+    file:filename(), ast:forms(), atom(), cm_fun_deps:module_info(),
+    all | [ast:fun_with_arity()], boolean(),
+    cm_index:index(), cm_depgraph:dep_graph(), cm_depgraph:fun_dep_graph(),
+    #{atom() => file:filename()}, check_list()
+) -> check_list().
+process_changed_file(Path, Forms, _ModName, _ModInfo, _ChangedFuns,
+        true, Index, DepGraph, _FunDepGraph, _ModToPath, Acc) ->
+    % Types/records/exports changed: recheck all in this file.
+    % Only recheck dependents if the exported interface actually changed
+    % (e.g. a local type change doesn't affect dependents).
+    Deps = case cm_index:has_exported_interface_changed(Path, Forms, Index) of
+        true ->
+            FoundDeps = cm_depgraph:find_dependent_files(Path, DepGraph),
+            case FoundDeps of
+                [] -> ok;
+                _ ->
+                    ?LOG_DEBUG("Need to check the following files because the " ++
+                        "interface of ~p has changed: ~200p", Path, FoundDeps)
+            end,
+            [{D, all} || D <- FoundDeps];
+        false -> []
+    end,
+    Acc ++ [{Path, all}] ++ Deps;
+process_changed_file(Path, _Forms, ModName, ModInfo, ChangedFuns,
+        false, Index, _DepGraph, FunDepGraph, ModToPath, Acc) ->
+    case ChangedFuns of
+        all ->
+            % All functions changed but decls didn't. Find callers of spec-changed funs.
+            AllFunIds = [FId || FId <- maps:keys(
+                ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}))],
+            SpecChangedFunIds = find_all_spec_changed_funs(AllFunIds, ModInfo, Path, Index),
+            {LocalCallers, CrossEntries} = find_affected_callers(
+                SpecChangedFunIds, FunDepGraph, ModName, ModToPath),
+            Acc ++ [{Path, all}] ++ [{Path, LocalCallers} || LocalCallers =/= []] ++ CrossEntries;
+        [] ->
+            % No functions changed (only whitespace/comments?)
+            Acc ++ [{Path, []}];
+        Funs ->
+            SpecChangedFuns = find_spec_changed_funs(ModName, Funs, ModInfo, Path, Index),
+            {LocalCallers, CrossEntries} = find_affected_callers(
+                SpecChangedFuns, FunDepGraph, ModName, ModToPath),
+            AllLocalFuns = lists:uniq(Funs ++ LocalCallers),
+            Acc ++ [{Path, AllLocalFuns}] ++ CrossEntries
+    end.
+
+% @doc Find functions whose specs changed from the set of changed functions.
+-spec find_spec_changed_funs(
+    atom(), [ast:fun_with_arity()], cm_fun_deps:module_info(),
+    file:filename(), cm_index:index()
+) -> [cm_fun_deps:fun_id()].
+find_spec_changed_funs(ModName, ChangedFuns, ModInfo, Path, {_, IndexMap}) ->
+    lists:filtermap(
+        fun(FA) ->
+            check_spec_changed(ModName, FA, ModInfo, Path, IndexMap)
+        end, ChangedFuns).
+
+% @doc Check all fun_ids for spec changes (used when ChangedFuns = all).
+-spec find_all_spec_changed_funs(
+    [cm_fun_deps:fun_id()], cm_fun_deps:module_info(),
+    file:filename(), cm_index:index()
+) -> [cm_fun_deps:fun_id()].
+find_all_spec_changed_funs(FunIds, ModInfo, Path, {_, IndexMap}) ->
+    lists:filtermap(
+        fun({ModName, Name, Arity}) ->
+            check_spec_changed(ModName, {Name, Arity}, ModInfo, Path, IndexMap)
+        end, FunIds).
+
+% @doc Check if a single function's spec has changed.
+-spec check_spec_changed(
+    atom(), ast:fun_with_arity(), cm_fun_deps:module_info(),
+    file:filename(), #{file:filename() => cm_index:file_index_entry()}
+) -> {true, cm_fun_deps:fun_id()} | false.
+check_spec_changed(ModName, {Name, Arity}, ModInfo, Path, IndexMap) ->
+    FunId = {ModName, Name, Arity},
+    Funs = ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}),
+    case maps:find(FunId, Funs) of
+        error -> false;
+        {ok, FunInfo} ->
+            NewSpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
+            case maps:find(Path, IndexMap) of
+                error ->
+                    % File not in index, treat spec as changed
+                    {true, FunId};
+                {ok, {_, _, _, OldFunIndex}} ->
+                    case maps:find({Name, Arity}, OldFunIndex) of
+                        error ->
+                            % New function, treat spec as changed
+                            {true, FunId};
+                        {ok, {failed, OldSpecHash}} ->
+                            % Previously failed - compare spec hashes
+                            case NewSpecHash =/= OldSpecHash of
+                                true -> {true, FunId};
+                                false -> false
+                            end;
+                        {ok, {_OldBodyHash, OldSpecHash}} ->
+                            case NewSpecHash =/= OldSpecHash of
+                                true -> {true, FunId};
+                                false -> false
+                            end
+                    end
+            end
+    end.
+
+% @doc Find callers of spec-changed functions, both same-module and cross-module.
+% Returns {LocalCallers, CrossFileEntries} where LocalCallers are {Name, Arity}
+% pairs in the same module, and CrossFileEntries are check_list entries for other files.
+-spec find_affected_callers(
+    [cm_fun_deps:fun_id()], cm_depgraph:fun_dep_graph(),
+    atom(), #{atom() => file:filename()}
+) -> {[ast:fun_with_arity()], check_list()}.
+find_affected_callers([], _FunDepGraph, _SourceMod, _ModToPath) ->
+    {[], []};
+find_affected_callers(SpecChangedFuns, FunDepGraph, SourceMod, ModToPath) ->
+    AllCallers = lists:flatmap(
+        fun(FunId) -> cm_depgraph:find_fun_callers(FunId, FunDepGraph) end,
+        SpecChangedFuns),
+    % Separate same-module callers from cross-module callers
+    {SameModCallers, CrossModCallers} = lists:partition(
+        fun({Mod, _, _}) -> Mod =:= SourceMod end, AllCallers),
+    LocalFuns = lists:uniq([{Name, Arity} || {_, Name, Arity} <- SameModCallers]),
+    % Group cross-module callers by module, then map to file paths
+    CallersByMod = lists:foldl(
+        fun({Mod, FName, FArity}, Acc) ->
+            Existing = maps:get(Mod, Acc, []),
+            maps:put(Mod, [{FName, FArity} | Existing], Acc)
+        end, ?assert_type(maps:new(), #{atom() => [ast:fun_with_arity()]}), CrossModCallers),
+    CrossEntries = lists:filtermap(
+        fun({Mod, FunsInMod}) ->
+            case maps:find(Mod, ModToPath) of
+                {ok, FilePath} ->
+                    UniqFuns = lists:uniq(?assert_type(FunsInMod, [ast:fun_with_arity()])),
+                    ?LOG_INFO("Need to recheck ~200p in ~p because called specs changed",
+                        UniqFuns, FilePath),
+                    {true, {FilePath, UniqFuns}};
+                error ->
+                    % Module not in our source list (external dep)
+                    false
+            end
+        end, maps:to_list(CallersByMod)),
+    {LocalFuns, CrossEntries}.
+
+% @doc Merge check entries, combining per-file function lists and deduplicating.
+-spec merge_check_entries(check_list()) -> check_list().
+merge_check_entries(Entries) ->
+    Merged = lists:foldl(
+        fun(Entry, Acc) -> merge_single_entry(Entry, Acc) end,
+        ?assert_type(maps:new(), #{file:filename() => all | [{atom(), arity()}]}),
+        Entries),
+    [{F, Fs} || {F, Fs} <- maps:to_list(Merged), Fs =:= all orelse Fs =/= []].
+
+% @doc Merge a single check entry into the accumulator map.
+-spec merge_single_entry(
+    check_entry(), #{file:filename() => all | [{atom(), arity()}]}
+) -> #{file:filename() => all | [{atom(), arity()}]}.
+merge_single_entry({File, Funs}, Acc) ->
+    case maps:find(File, Acc) of
+        error ->
+            maps:put(File, Funs, Acc);
+        {ok, all} ->
+            Acc;
+        {ok, _ExistingFuns} when Funs =:= all ->
+            maps:put(File, all, Acc);
+        {ok, ExistingFuns} ->
+            maps:put(File, lists:uniq(?assert_type(ExistingFuns, [{atom(), arity()}]) ++ ?assert_type(Funs, [{atom(), arity()}])), Acc)
+    end.
 
 -spec traverse_and_check(
-    [file:filename()], symtab:t(), symtab:t(), paths:search_path(), cmd_opts(), cm_index:index())
+    check_list(), symtab:t(), symtab:t(), paths:search_path(), cmd_opts(), cm_index:index())
     -> cm_index:index().
 traverse_and_check([], _, _, _, _, Index) ->
     Index;
-
-traverse_and_check([CurrentFile | RemainingFiles], Symtab, OverlaySymtab, SearchPath, Opts, Index) ->
-    {Forms, _ExpandedSymtab} = check_single_file(CurrentFile, Symtab, OverlaySymtab, SearchPath, Opts, Index),
-    NewIndex = cm_index:insert(CurrentFile, Forms, Index),
-    traverse_and_check(RemainingFiles, Symtab, OverlaySymtab, SearchPath, Opts, NewIndex).
+traverse_and_check([{CurrentFile, FunFilter} | Remaining], Symtab, OverlaySymtab, SearchPath, Opts, Index) ->
+    NewIndex = check_single_file(CurrentFile, FunFilter, Symtab, OverlaySymtab, SearchPath, Opts, Index),
+    traverse_and_check(Remaining, Symtab, OverlaySymtab, SearchPath, Opts, NewIndex).
 
 -spec check_single_file(
-    file:filename(), symtab:t(), symtab:t(), paths:search_path(), cmd_opts(), cm_index:index())
-    -> {ast:forms(), symtab:t()}.
-check_single_file(CurrentFile, Symtab, OverlaySymtab, SearchPath, Opts, _Index) ->
-    ?LOG_DEBUG("Checking ~s", CurrentFile),
-    Forms = parse_cache:parse(intern, CurrentFile),
+    file:filename(), all | [{atom(), arity()}], symtab:t(), symtab:t(),
+    paths:search_path(), cmd_opts(), cm_index:index())
+    -> cm_index:index().
+check_single_file(CurrentFile, FunFilter, Symtab, OverlaySymtab, SearchPath, Opts, Index) ->
     ModName = ast_utils:modname_from_path(CurrentFile),
-    Referenced = lists:filter(fun (M) -> M =/= ModName end, ast_utils:referenced_modules(Forms)),
-    ?LOG_DEBUG("Referenced from ~s: ~200p", CurrentFile, Referenced),
-    ExpandedSymtab = symtab:extend_symtab_with_module_list(Symtab, SearchPath, Referenced, OverlaySymtab),
-    do_type_check(CurrentFile, Forms, ExpandedSymtab, OverlaySymtab, Opts),
-    {Forms, ExpandedSymtab}.
+    Only = build_only_set(FunFilter, Opts#opts.type_check_only, ModName),
+    case {sets:is_empty(Only), Opts#opts.type_check_only} of
+        {true, [_|_]} ->
+            % -o specified but no functions match for this file, skip entirely
+            ?LOG_DEBUG("Skipping ~s: no functions match -o filter", CurrentFile),
+            Index;
+        _ ->
+            ?LOG_DEBUG("Checking ~s (filter: ~200p)", CurrentFile, FunFilter),
+            Forms = parse_cache:parse(intern, CurrentFile),
+            Referenced = [M || M <- ast_utils:referenced_modules(Forms), M =/= ModName],
+            ?LOG_DEBUG("Referenced from ~s: ~200p", CurrentFile, Referenced),
+            ExpandedSymtab = symtab:extend_symtab_with_module_list(Symtab, SearchPath, Referenced, OverlaySymtab),
+            FailedFuns = do_type_check(CurrentFile, Forms, Only, ExpandedSymtab, OverlaySymtab, Opts),
+            cm_index:insert(CurrentFile, Forms, FailedFuns, Index)
+    end.
 
--spec do_type_check(file:filename(), ast:forms(), symtab:t(), symtab:t(), cmd_opts()) -> ok.
-do_type_check(CurrentFile, Forms, ExpandedSymtab, OverlaySymtab, Opts) ->
-    Only = sets:from_list(Opts#opts.type_check_only, [{version, 2}]),
-    Ignore = sets:from_list(Opts#opts.type_check_ignore,[{version, 2}]),
+% @doc Run type check and return the list of functions that failed (empty in early-exit mode).
+-spec do_type_check(
+    file:filename(), ast:forms(), sets:set(string()), symtab:t(), symtab:t(), cmd_opts()
+) -> [{atom(), arity()}].
+do_type_check(CurrentFile, Forms, Only, ExpandedSymtab, OverlaySymtab, Opts) ->
     Sanity = perform_sanity_check(CurrentFile, Forms, Opts#opts.sanity),
-    ReportMode = Opts#opts.report_mode,
-    ReportTimeout = Opts#opts.report_timeout,
-    ExhaustivenessMode = Opts#opts.exhaustiveness_mode,
-    GradualTypingMode = Opts#opts.gradual_typing_mode,
-    Ctx = typing:new_ctx(ExpandedSymtab, OverlaySymtab, Sanity, ReportMode, ReportTimeout, ExhaustivenessMode, GradualTypingMode),
+    Ctx = typing:new_ctx(ExpandedSymtab, OverlaySymtab, Sanity,
+        Opts#opts.report_mode, Opts#opts.report_timeout,
+        Opts#opts.exhaustiveness_mode, Opts#opts.gradual_typing_mode),
     CliNoExhaustiveness = utils:parse_fun_ids(Opts#opts.no_exhaustiveness),
     CliNoRedundancy = utils:parse_fun_ids(Opts#opts.no_redundancy),
     case Opts#opts.no_type_checking of
         true ->
-            ?LOG_INFO("Not type checking ~p as requested", CurrentFile);
+            ?LOG_INFO("Not type checking ~p as requested", CurrentFile),
+            [];
         false ->
-            typing:check_forms(Ctx, CurrentFile, Forms, Only, Ignore, Opts#opts.check_exports, {CliNoExhaustiveness, CliNoRedundancy})
-    end,
-    ok.
+            typing:check_forms(Ctx, CurrentFile, Forms,
+                Only,
+                sets:from_list(Opts#opts.type_check_ignore, [{version, 2}]),
+                Opts#opts.check_exports,
+                {CliNoExhaustiveness, CliNoRedundancy})
+    end.
+
+% @doc Build the Only set from function filter and CLI --only flag.
+% Uses multi-level matching (module, module:name/arity, name/arity, name) consistent
+% with typing:should_check/6.
+-spec build_only_set(all | [{atom(), arity()}], [string()], atom()) -> sets:set(string()).
+build_only_set(all, CliOnly, _ModName) ->
+    sets:from_list(CliOnly, [{version, 2}]);
+build_only_set(FunFilter, [], _ModName) when is_list(FunFilter) ->
+    sets:from_list(
+        [utils:sformat("~w/~w", Name, Arity) || {Name, Arity} <- FunFilter],
+        [{version, 2}]);
+build_only_set(FunFilter, CliOnly, ModName) when is_list(FunFilter) ->
+    CliSet = sets:from_list(CliOnly, [{version, 2}]),
+    ModStr = utils:sformat("~w", ModName),
+    case sets:is_element(ModStr, CliSet) of
+        true ->
+            % Module-level match: all FunFilter functions are included
+            sets:from_list(
+                [utils:sformat("~w/~w", Name, Arity) || {Name, Arity} <- FunFilter],
+                [{version, 2}]);
+        false ->
+            % Per-function matching using same levels as typing:should_check/6
+            MatchingFuns = lists:filter(fun({Name, Arity}) ->
+                QRefStr = utils:sformat("~w:~w/~w", ModName, Name, Arity),
+                RefStr = utils:sformat("~w/~w", Name, Arity),
+                NameStr = utils:sformat("~w", Name),
+                sets:is_element(QRefStr, CliSet)
+                orelse sets:is_element(RefStr, CliSet)
+                orelse sets:is_element(NameStr, CliSet)
+            end, FunFilter),
+            sets:from_list(
+                [utils:sformat("~w/~w", N, A) || {N, A} <- MatchingFuns],
+                [{version, 2}])
+    end.
 
 -spec perform_sanity_check(file:filename(), ast:forms(), boolean()) -> {ok, ast_check:ty_map()} | error.
 perform_sanity_check(CurrentFile, Forms, DoCheck) ->

--- a/src/cm_depgraph.erl
+++ b/src/cm_depgraph.erl
@@ -13,18 +13,27 @@
     find_dependent_files/2,
     all_sources/1,
     build_dep_graph/2,
-    pretty_depgraph/1
+    update_dep_graph/4,
+    remove_dependent/2,
+    pretty_depgraph/1,
+    save_depgraph/2,
+    load_depgraph/2,
+    build_fun_dep_graph/1,
+    update_fun_dep_graph/3,
+    find_fun_callers/2,
+    save_fun_depgraph/2,
+    load_fun_depgraph/1
 ]).
 
--export_type([dep_graph/0]).
+-export_type([dep_graph/0, fun_dep_graph/0]).
 
 -ifdef(TEST).
 -export([
-    add_dependency/3,
-    update_dep_graph/4
+    add_dependency/3
 ]).
 -endif.
 
+-include("etylizer.hrl").
 
 -type dep_graph() :: {
     sets:set(file:filename()),
@@ -86,6 +95,21 @@ add_file(Path, {Srcs, DepFiles, DepMods}) ->
     NewSrcs = sets:add_element(PathNorm, Srcs),
     {NewSrcs, DepFiles, DepMods}.
 
+% @doc Remove a file from all reverse-dependency value sets.
+% Used for incremental updates: remove old edges before re-analyzing.
+-spec remove_dependent(file:filename(), dep_graph()) -> dep_graph().
+remove_dependent(Path, {Srcs, DepFiles, DepMods}) ->
+    PathNorm = utils:normalize_path(Path),
+    PathMod = ast_utils:modname_from_path(PathNorm),
+    NewDepFiles = maps:map(
+        fun(_, Deps) -> sets:del_element(PathNorm, Deps) end, DepFiles),
+    NewDepMods = maps:map(
+        fun(_, Deps) -> sets:del_element(PathMod, Deps) end, DepMods),
+    {Srcs, NewDepFiles, NewDepMods}.
+
+% Cache for type-reference lookups, keyed by source path.
+-type type_refs_cache() :: #{file:filename() => [ast:mod_name()]}.
+
 -spec update_dep_graph(
     file:filename(),
     ast:forms(),
@@ -95,32 +119,48 @@ add_file(Path, {Srcs, DepFiles, DepMods}) ->
 update_dep_graph(Path, Forms, SearchPath, DepGraph) ->
     Modules = ast_utils:referenced_modules(Forms),
     ?LOG_DEBUG("Modules referenced from ~p: ~p", Path, Modules),
-    traverse_module_list(Path, Modules, SearchPath, add_file(Path, DepGraph)).
+    {Result, _} = traverse_module_list(
+        Path, Modules, SearchPath, add_file(Path, DepGraph), maps:new()),
+    Result.
 
 -spec traverse_module_list(
     file:filename(),
     [atom()],
     paths:search_path(),
-    dep_graph()
-) -> dep_graph().
-traverse_module_list(_, [], _, DepGraph) ->
-    DepGraph;
-traverse_module_list(Path, [CurrentModule | RemainingModules], SearchPath, DepGraph) ->
+    dep_graph(),
+    type_refs_cache()
+) -> {dep_graph(), type_refs_cache()}.
+traverse_module_list(_, [], _, DepGraph, Cache) ->
+    {DepGraph, Cache};
+traverse_module_list(Path, [CurrentModule | RemainingModules], SearchPath, DepGraph, Cache) ->
     case find_source_for_module(CurrentModule, SearchPath) of
         false ->
-            traverse_module_list(Path, RemainingModules, SearchPath, DepGraph);
+            traverse_module_list(Path, RemainingModules, SearchPath, DepGraph, Cache);
         SourcePath ->
             NewDepGraph = add_dependency(SourcePath, Path, DepGraph),
-            Forms = parse_intern(SourcePath),
+            {TypeRefs, NewCache} = cached_type_refs(SourcePath, Cache),
             PathMod = ast_utils:modname_from_path(Path),
             AdditionalModules =
                 lists:filter(
                     fun (ModName) -> not has_rev_dep(ModName, PathMod, DepGraph) end,
-                    ast_utils:referenced_modules_via_types(Forms)
+                    TypeRefs
                 ),
             ?LOG_DEBUG("Additional modules for path ~s (current: ~w): ~200p", Path, CurrentModule, AdditionalModules),
             traverse_module_list(Path, RemainingModules ++ AdditionalModules,
-                SearchPath, NewDepGraph)
+                SearchPath, NewDepGraph, NewCache)
+    end.
+
+% @doc Returns referenced_modules_via_types for a source file, cached per path.
+-spec cached_type_refs(file:filename(), type_refs_cache()) ->
+    {[ast:mod_name()], type_refs_cache()}.
+cached_type_refs(SourcePath, Cache) ->
+    case maps:find(SourcePath, Cache) of
+        {ok, Result} ->
+            {Result, Cache};
+        error ->
+            Forms = parse_intern(SourcePath),
+            Result = ast_utils:referenced_modules_via_types(Forms),
+            {Result, maps:put(SourcePath, Result, Cache)}
     end.
 
 -spec find_source_for_module(atom(), paths:search_path()) -> false | file:filename().
@@ -135,21 +175,26 @@ find_source_for_module(Module, SearchPath) ->
 -spec build_dep_graph([file:filename()], paths:search_path()) -> dep_graph().
 build_dep_graph(Files, SearchPath) ->
     build_dep_graph(lists:map(fun utils:normalize_path/1, Files),
-        SearchPath, new(), sets:new([{version, 2}])).
+        SearchPath, new(), sets:new([{version, 2}]), maps:new()).
 
 -spec build_dep_graph(
         [file:filename()],
         paths:search_path(),
         dep_graph(),
-        sets:set(file:filename())
+        sets:set(file:filename()),
+        type_refs_cache()
     ) -> dep_graph().
-build_dep_graph(Worklist, SearchPath, DepGraph, AlreadyHandled) ->
+build_dep_graph(Worklist, SearchPath, DepGraph, AlreadyHandled, Cache) ->
     case Worklist of
         [] -> DepGraph;
         [File | Rest] ->
             ?LOG_DEBUG("Adding ~p to dependency graph", File),
             Forms = parse_intern(File),
-            {All, _, _} = NewDepGraph = update_dep_graph(File, Forms, SearchPath, DepGraph),
+            Modules = ast_utils:referenced_modules(Forms),
+            ?LOG_DEBUG("Modules referenced from ~p: ~p", File, Modules),
+            {NewDepGraph0, NewCache} = traverse_module_list(
+                File, Modules, SearchPath, add_file(File, DepGraph), Cache),
+            {All, _, _} = NewDepGraph = ?assert_type(NewDepGraph0, dep_graph()),
             NewAlreadyHandled = sets:add_element(File, AlreadyHandled),
             NewFiles = sets:subtract(
                 sets:subtract(All, NewAlreadyHandled),
@@ -159,9 +204,152 @@ build_dep_graph(Worklist, SearchPath, DepGraph, AlreadyHandled) ->
             build_dep_graph(
                 Rest ++ lists:map(fun utils:normalize_path/1, sets:to_list(NewFiles)),
                 SearchPath,
-                NewDepGraph, NewAlreadyHandled)
+                NewDepGraph, NewAlreadyHandled, NewCache)
     end.
 
 
+-define(DEPGRAPH_VERSION, 1).
+
+% @doc Save the dependency graph to disk.
+-spec save_depgraph(file:filename(), dep_graph()) -> ok.
+save_depgraph(Path, DepGraph) ->
+    filelib:ensure_dir(Path),
+    {Srcs, DepFiles, DepMods} = DepGraph,
+    Serializable = {sets:to_list(Srcs),
+        maps:map(fun(_, V) -> sets:to_list(V) end, DepFiles),
+        maps:map(fun(_, V) -> sets:to_list(V) end, DepMods)},
+    Formatted = lists:flatten(
+        io_lib:format("~p.~n", [{etylizer_depgraph, ?DEPGRAPH_VERSION, Serializable}])),
+    ?assert_pattern(ok, file:write_file(Path, Formatted)).
+
+% @doc Load the dependency graph from disk.
+-spec load_depgraph(file:filename(), [file:filename()]) -> {ok, dep_graph()} | stale.
+load_depgraph(Path, ExpectedSources) ->
+    case filelib:is_file(Path) of
+        false ->
+            ?LOG_DEBUG("No cached dependency graph at ~p", Path),
+            stale;
+        true ->
+            case file:consult(Path) of
+                {ok, [{etylizer_depgraph, ?DEPGRAPH_VERSION, {SrcList, DepFilesMap0, DepModsMap0}}]} ->
+                    Srcs = sets:from_list(?assert_type(SrcList, [file:filename()]), [{version, 2}]),
+                    ExpectedSet = sets:from_list(
+                        lists:map(fun utils:normalize_path/1, ExpectedSources),
+                        [{version, 2}]),
+                    DepFilesMap = ?assert_type(DepFilesMap0, #{file:filename() => [file:filename()]}),
+                    DepModsMap = ?assert_type(DepModsMap0, #{atom() => [atom()]}),
+                    case sets:is_equal(Srcs, ExpectedSet) of
+                        true ->
+                            ?LOG_TRACE("Loaded cached dependency graph from ~p", Path),
+                            DepFiles = maps:map(
+                                fun(_, V) -> sets:from_list(V, [{version, 2}]) end, DepFilesMap),
+                            DepMods = maps:map(
+                                fun(_, V) -> sets:from_list(V, [{version, 2}]) end, DepModsMap),
+                            {ok, {Srcs, DepFiles, DepMods}};
+                        false ->
+                            ?LOG_DEBUG("Cached dependency graph is stale (source set changed)"),
+                            stale
+                    end;
+                _ ->
+                    ?LOG_WARN("Cached dependency graph at ~p has unexpected format", Path),
+                    stale
+            end
+    end.
+
 -spec parse_intern(file:filename()) -> [ast:form()].
 parse_intern(P) -> parse_cache:parse(intern, P).
+
+%%% Function-level dependency graph
+
+% Reverse deps: fun_id -> set of callers of that function
+-type fun_dep_graph() :: #{cm_fun_deps:fun_id() => sets:set(cm_fun_deps:fun_id())}.
+
+% @doc Build function-level reverse dependency graph from module analyses.
+% If function f calls function g, we store g -> f (reverse dependency).
+-spec build_fun_dep_graph([{file:filename(), cm_fun_deps:module_info()}]) -> fun_dep_graph().
+build_fun_dep_graph(ModInfos) ->
+    lists:foldl(
+        fun(Entry, Graph) -> add_module_to_fun_dep_graph(Entry, Graph) end,
+        ?assert_type(maps:new(), fun_dep_graph()), ModInfos).
+
+% @doc Add a single module's function calls to the reverse dependency graph.
+-spec add_module_to_fun_dep_graph(
+    {file:filename(), cm_fun_deps:module_info()}, fun_dep_graph()) -> fun_dep_graph().
+add_module_to_fun_dep_graph({_File, ModInfo}, Graph) ->
+    Funs = ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}),
+    maps:fold(
+        fun(CallerId, FunInfo, G) ->
+            Calls = ?assert_type(maps:get(calls, FunInfo), [cm_fun_deps:fun_id()]),
+            lists:foldl(
+                fun(CalleeId, G2) ->
+                    Existing = maps:get(CalleeId, G2, sets:new([{version, 2}])),
+                    maps:put(CalleeId, sets:add_element(CallerId, Existing), G2)
+                end, G, Calls)
+        end, Graph, Funs).
+
+% @doc Incrementally update the function dep graph: remove all edges involving
+% changed modules, then add back edges from re-analyzed module infos.
+-spec update_fun_dep_graph(
+    fun_dep_graph(), sets:set(atom()),
+    [{file:filename(), cm_fun_deps:module_info()}]) -> fun_dep_graph().
+update_fun_dep_graph(Graph, ChangedMods, NewModInfos) ->
+    PrunedGraph = prune_fun_dep_graph(Graph, ChangedMods),
+    lists:foldl(
+        fun(Entry, G) -> add_module_to_fun_dep_graph(Entry, G) end,
+        PrunedGraph, NewModInfos).
+
+% @doc Remove all edges involving modules in the given set.
+-spec prune_fun_dep_graph(fun_dep_graph(), sets:set(atom())) -> fun_dep_graph().
+prune_fun_dep_graph(Graph, ChangedMods) ->
+    maps:filtermap(
+        fun({CalleeMod, _, _}, CallerSet) ->
+            case sets:is_element(CalleeMod, ChangedMods) of
+                true -> false;
+                false ->
+                    NewCallerSet = sets:filter(
+                        fun({CallerMod, _, _}) ->
+                            not sets:is_element(CallerMod, ChangedMods)
+                        end, CallerSet),
+                    {true, NewCallerSet}
+            end
+        end, Graph).
+
+% @doc Find all direct callers of a given function.
+-spec find_fun_callers(cm_fun_deps:fun_id(), fun_dep_graph()) -> [cm_fun_deps:fun_id()].
+find_fun_callers(FunId, Graph) ->
+    case maps:find(FunId, Graph) of
+        error -> [];
+        {ok, Callers} -> sets:to_list(Callers)
+    end.
+
+-define(FUN_DEPGRAPH_VERSION, 1).
+
+% @doc Save the function-level dependency graph to disk.
+-spec save_fun_depgraph(file:filename(), fun_dep_graph()) -> ok.
+save_fun_depgraph(Path, Graph) ->
+    filelib:ensure_dir(Path),
+    Serializable = maps:map(fun(_, V) -> sets:to_list(V) end, Graph),
+    Formatted = lists:flatten(
+        io_lib:format("~p.~n", [{etylizer_fun_depgraph, ?FUN_DEPGRAPH_VERSION, Serializable}])),
+    ?assert_pattern(ok, file:write_file(Path, Formatted)).
+
+% @doc Load the function-level dependency graph from disk.
+-spec load_fun_depgraph(file:filename()) -> {ok, fun_dep_graph()} | stale.
+load_fun_depgraph(Path) ->
+    case filelib:is_file(Path) of
+        false ->
+            ?LOG_DEBUG("No cached function dependency graph at ~p", Path),
+            stale;
+        true ->
+            case file:consult(Path) of
+                {ok, [{etylizer_fun_depgraph, ?FUN_DEPGRAPH_VERSION, SerMap0}]} ->
+                    ?LOG_TRACE("Loaded cached function dependency graph from ~p", Path),
+                    SerMap = ?assert_type(SerMap0, #{cm_fun_deps:fun_id() => [cm_fun_deps:fun_id()]}),
+                    Graph = maps:map(
+                        fun(_, V) -> sets:from_list(V, [{version, 2}]) end, SerMap),
+                    {ok, Graph};
+                _ ->
+                    ?LOG_WARN("Cached function dep graph at ~p has unexpected format", Path),
+                    stale
+            end
+    end.

--- a/src/cm_fun_deps.erl
+++ b/src/cm_fun_deps.erl
@@ -1,0 +1,174 @@
+-module(cm_fun_deps).
+
+% @doc This module handles function-level analysis for incremental type checking.
+% It extracts per-function info from parsed forms (body hash, spec hash, called functions,
+% referenced types) and supports building function-level dependency graphs.
+
+-export([
+    analyze_module/2,
+    extract_fun_refs/2,
+    extract_type_refs/2,
+    hash_fun_body/1,
+    hash_fun_spec/3,
+    hash_module_decls/1
+]).
+
+-export_type([
+    fun_id/0,
+    fun_info/0,
+    module_info/0
+]).
+
+-include("log.hrl").
+-include("etylizer.hrl").
+
+-type fun_id() :: {Module :: atom(), Name :: atom(), Arity :: arity()}.
+
+-type fun_info() :: #{
+    body_hash := string(),
+    spec_hash := string(),
+    calls := [fun_id()],
+    type_refs := [atom()]
+}.
+
+-type module_info() :: #{
+    decls_hash := string(),
+    funs := #{fun_id() => fun_info()}
+}.
+
+% @doc Extract function-level info from parsed forms.
+-spec analyze_module(atom(), ast:forms()) -> module_info().
+analyze_module(ModName, Forms) ->
+    DeclsHash = hash_module_decls(Forms),
+    FunDecls = [F || F = {function, _, _, _, _} <- Forms],
+    Funs = lists:foldl(
+        fun(FunDecl, Acc) ->
+            analyze_fun(ModName, FunDecl, Forms, Acc)
+        end, ?assert_type(maps:new(), #{fun_id() => fun_info()}), FunDecls),
+    ?assert_type(#{decls_hash => DeclsHash, funs => Funs}, module_info()).
+
+% @doc Analyze a single function declaration.
+-spec analyze_fun(atom(), ast:fun_decl(), ast:forms(), #{fun_id() => fun_info()}) ->
+    #{fun_id() => fun_info()}.
+analyze_fun(ModName, {function, _, Name, Arity, _Clauses} = FunDecl, Forms, Acc) ->
+    FunId = {ModName, Name, Arity},
+    Info = ?assert_type(#{
+        body_hash => hash_fun_body(FunDecl),
+        spec_hash => hash_fun_spec(Name, Arity, Forms),
+        calls => extract_fun_refs(ModName, FunDecl),
+        type_refs => extract_type_refs(FunDecl, Forms)
+    }, fun_info()),
+    maps:put(FunId, Info, Acc).
+
+% @doc Extract all function references from a function declaration.
+% Walks the function body collecting {ref, Name, Arity} and {qref, Mod, Name, Arity} patterns.
+-spec extract_fun_refs(atom(), ast:fun_decl()) -> [fun_id()].
+extract_fun_refs(ModName, {function, _, _, _, Clauses}) ->
+    Refs = utils:everything(
+        fun(T) ->
+            case T of
+                {call, _, {var, _, {ref, Name, Arity}}, _} when is_atom(Name), is_integer(Arity) ->
+                    {ok, {ModName, Name, Arity}};
+                {call, _, {var, _, {qref, Mod, Name, Arity}}, _} when is_atom(Mod), is_atom(Name), is_integer(Arity) ->
+                    {ok, {Mod, Name, Arity}};
+                {fun_ref, _, {ref, Name, Arity}} when is_atom(Name), is_integer(Arity) ->
+                    {ok, {ModName, Name, Arity}};
+                {fun_ref, _, {qref, Mod, Name, Arity}} when is_atom(Mod), is_atom(Name), is_integer(Arity) ->
+                    {ok, {Mod, Name, Arity}};
+                _ -> error
+            end
+        end, Clauses),
+    lists:uniq(Refs).
+
+% @doc Extract type references from a function declaration and its spec.
+-spec extract_type_refs(ast:fun_decl(), ast:forms()) -> [atom()].
+extract_type_refs({function, _, Name, Arity, Clauses}, Forms) ->
+    Spec = find_spec(Name, Arity, Forms),
+    BodyRefs = extract_type_names(Clauses),
+    SpecRefs = case Spec of
+        none -> [];
+        {ok, SpecForm} -> extract_type_names(SpecForm)
+    end,
+    lists:uniq(BodyRefs ++ SpecRefs).
+
+% @doc Hash a single function body (clauses only, locations and macro artifacts stripped).
+-spec hash_fun_body(ast:fun_decl()) -> string().
+hash_fun_body({function, _, _, _, Clauses}) ->
+    Stripped = normalize_for_hash(Clauses),
+    Written = ?assert_type(io_lib:write(Stripped), iodata()),
+    utils:hash_sha1(Written).
+
+% @doc Hash a single function spec. Returns "" if no spec exists.
+-spec hash_fun_spec(atom(), arity(), ast:forms()) -> string().
+hash_fun_spec(Name, Arity, Forms) ->
+    case find_spec(Name, Arity, Forms) of
+        none -> "";
+        {ok, SpecForm} ->
+            Stripped = ast_utils:remove_locs(SpecForm),
+            Written = ?assert_type(io_lib:write(Stripped), iodata()),
+            utils:hash_sha1(Written)
+    end.
+
+% @doc Hash module-level declarations (types, records, exports).
+-spec hash_module_decls(ast:forms()) -> string().
+hash_module_decls(Forms) ->
+    Decls = lists:filter(
+        fun(Form) ->
+            case Form of
+                {attribute, _, type, _, _} -> true;
+                {attribute, _, record, _} -> true;
+                {attribute, _, export, _} -> true;
+                {attribute, _, export_type, _} -> true;
+                {attribute, _, import, _} -> true;
+                _ -> false
+            end
+        end, Forms),
+    Stripped = ast_utils:remove_locs(Decls),
+    Written = ?assert_type(io_lib:write(Stripped), iodata()),
+    utils:hash_sha1(Written).
+
+% @doc Find the spec form for a function.
+-spec find_spec(atom(), arity(), ast:forms()) -> none | {ok, ast:fun_spec()}.
+find_spec(Name, Arity, Forms) ->
+    case lists:search(
+        fun(Form) ->
+            case Form of
+                {attribute, _, spec, N, A, _, _} -> N =:= Name andalso A =:= Arity;
+                _ -> false
+            end
+        end, Forms) of
+        {value, SpecForm} -> {ok, ?assert_type(SpecForm, ast:fun_spec())};
+        false -> none
+    end.
+
+% @doc Normalize AST for stable hashing: strip locations and replace ?FILE/?LINE
+% arguments in log:macro_log calls with constants. The ?FILE and ?LINE macros expand
+% to literal values that change when lines are added/removed elsewhere in the file,
+% causing false hash changes in unmodified functions.
+-spec normalize_for_hash(dynamic()) -> dynamic().
+normalize_for_hash(Term) ->
+    Normalized = utils:everywhere(fun normalize_macro_args/1, Term),
+    ast_utils:remove_locs(Normalized).
+
+% @doc Replace ?FILE and ?LINE arguments in log:macro_log/5 calls with constants.
+-spec normalize_macro_args(dynamic()) -> {ok, dynamic()} | error.
+normalize_macro_args({call, Loc, {var, VLoc, {qref, log, macro_log, 5}},
+                      [_File, _Line, Level, Fmt, Args]}) ->
+    {ok, {call, Loc, {var, VLoc, {qref, log, macro_log, 5}},
+          [{string, {loc, "", 0, 0}, ""},
+           {integer, {loc, "", 0, 0}, 0},
+           Level, Fmt, Args]}};
+normalize_macro_args(_) -> error.
+
+% @doc Extract type names referenced in a term (by traversing for ty_ref and ty_qref).
+-spec extract_type_names(term()) -> [atom()].
+extract_type_names(Term) ->
+    Refs = utils:everything(
+        fun(T) ->
+            case T of
+                {ty_ref, _, Name, _} when is_atom(Name) -> {ok, Name};
+                {named, _, {ty_ref, _, Name, _}, _} when is_atom(Name) -> {ok, Name};
+                _ -> error
+            end
+        end, Term),
+    lists:uniq(Refs).

--- a/src/cm_index.erl
+++ b/src/cm_index.erl
@@ -2,7 +2,7 @@
 
 % @doc This module maintains an index of files together with their hashes to enable
 % the detection of changes in the content or the exported interface of the
-% corresponding module.
+% corresponding module. Supports function-level granularity for incremental type checking.
 
 -export([
     load_index/3,
@@ -10,19 +10,30 @@
     has_file_changed/2,
     has_exported_interface_changed/3,
     has_external_dep_changed/2,
-    insert/3
+    insert/3,
+    insert/4,
+    insert_fun_index/5,
+    changed_functions/3,
+    prune/2
 ]).
 
--export_type([index/0]).
+-export_type([index/0, file_index_entry/0]).
 
 -include("log.hrl").
 -include("etylizer_main.hrl").
+-include("etylizer.hrl").
+
+% Per-function hashes: {atom(), arity()} => {BodyHash, SpecHash} | {failed, SpecHash}
+-type fun_index_entry() :: #{{atom(), arity()} => {string(), string()} | {failed, string()}}.
+
+% File index entry: {FileHash, InterfaceHash, DeclsHash, FunIndex}
+-type file_index_entry() :: {string(), string(), string(), fun_index_entry()}.
 
 -type index() :: {
     % OTP version and hash of rebar.lock
     {string(), string()},
-    % map .erl-file -> {FileHash, InterfaceHash}
-    #{file:filename() => {string(), string()}}
+    % map .erl-file -> file_index_entry()
+    #{file:filename() => file_index_entry()}
     }.
 
 % Format of index on disk:
@@ -32,7 +43,7 @@
 %    index()
 %}.
 
--define(INDEX_VERSION, 1).
+-define(INDEX_VERSION, 3).
 
 -spec empty_index(file:filename()) -> index().
 empty_index(RebarLockFile) ->
@@ -45,7 +56,10 @@ load_index(RebarLockFile, Path, Mode) ->
         fun(Msg) ->
             ?LOG_WARN(Msg),
             case Mode of
-                test_mode -> throw("bad index: " ++ Msg);
+                test_mode ->
+                    ?LOG_WARN("Deleting stale index at ~p", Path),
+                    file:delete(Path),
+                    empty_index(RebarLockFile);
                 prod_mode -> empty_index(RebarLockFile)
             end
         end,
@@ -54,7 +68,7 @@ load_index(RebarLockFile, Path, Mode) ->
             case file:consult(Path) of
                 {ok, [{etylizer_index, ?INDEX_VERSION, Index}]} ->
                     ?LOG_TRACE("Loading index from ~p", Path),
-                    Index;
+                    ?assert_type(Index, index());
                 {ok, []} ->
                     BadIndex(utils:sformat("Empty index at ~p", Path));
                 {ok, _} ->
@@ -72,21 +86,16 @@ load_index(RebarLockFile, Path, Mode) ->
 -spec save_index(file:filename(), index()) -> ok.
 save_index(Path, Index) ->
     filelib:ensure_dir(Path),
-    case file:write_file(Path, io_lib:format("~p.~n", [{etylizer_index, ?INDEX_VERSION, Index}])) of
-        ok ->
-            ?LOG_DEBUG("Stored index at ~p", Path),
-            ok;
-        {error, Reason} ->
-            ?ABORT("Error occurred while trying to save index. Reason: ~s", Reason)
-    end.
+    Formatted = lists:flatten(io_lib:format("~p.~n", [{etylizer_index, ?INDEX_VERSION, Index}])),
+    ?assert_pattern(ok, file:write_file(Path, ?assert_type(Formatted, string()))).
 
 -spec has_file_changed(file:filename(), index()) -> boolean().
 has_file_changed(Path, {_, Index}) ->
     case maps:find(Path, Index) of
         error ->
             true;
-        {ok, {OldFileHash, _}} ->
-            {ok, Content} = file:read_file(Path),
+        {ok, {OldFileHash, _, _, _}} ->
+            {ok, Content} = ?assert_type(file:read_file(Path), {ok, binary()}),
             NewHash = utils:hash_sha1(Content),
             NewHash =/= OldFileHash
     end.
@@ -96,28 +105,75 @@ has_exported_interface_changed(Path, Forms, {_, Index}) ->
     case maps:find(Path, Index) of
         error ->
             true;
-        {ok, {_, OldInterfaceHash}} ->
+        {ok, {_, OldInterfaceHash, _, _}} ->
             Interface = cm_module_interface:extract_interface_declaration(Forms),
             ?LOG_DEBUG("Interface of ~p: ~200p", Path, Interface),
-            NewHash = utils:hash_sha1(io_lib:write(Interface)),
+            Written = ?assert_type(io_lib:write(Interface), iodata()),
+            NewHash = utils:hash_sha1(Written),
             OldInterfaceHash =/= NewHash
+    end.
+
+% @doc Compute which functions in a file need rechecking.
+% Returns {all | [{atom(), arity()}], DeclsChanged :: boolean()}.
+-spec changed_functions(file:filename(), cm_fun_deps:module_info(), index()) ->
+    {all | [ast:fun_with_arity()], boolean()}.
+changed_functions(Path, ModInfo, {_, Index}) ->
+    NewDeclsHash = ?assert_type(maps:get(decls_hash, ModInfo), string()),
+    NewFuns = ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}),
+    case maps:find(Path, Index) of
+        error ->
+            % File not in index, everything is new
+            {all, true};
+        {ok, {_, _, OldDeclsHash, OldFunIndex}} ->
+            case NewDeclsHash =/= OldDeclsHash of
+                true ->
+                    % Types/records/exports changed, must recheck all
+                    ?LOG_DEBUG("Declarations changed in ~p, rechecking all functions", Path),
+                    {all, true};
+                false ->
+                    % Check each function individually
+                    ChangedFuns = maps:fold(
+                        fun({_Mod, Name, Arity}, FunInfo, Acc) ->
+                            NewBodyHash = ?assert_type(maps:get(body_hash, FunInfo), string()),
+                            NewSpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
+                            case maps:find({Name, Arity}, OldFunIndex) of
+                                error ->
+                                    % New function
+                                    [{Name, Arity} | Acc];
+                                {ok, {failed, _}} ->
+                                    % Previously failed, needs retry
+                                    [{Name, Arity} | Acc];
+                                {ok, {OldBodyHash, OldSpecHash}} ->
+                                    BodyChanged = NewBodyHash =/= OldBodyHash,
+                                    SpecChanged = NewSpecHash =/= OldSpecHash,
+                                    case {BodyChanged, SpecChanged} of
+                                        {false, false} -> Acc;
+                                        _ -> [{Name, Arity} | Acc]
+                                    end
+                            end
+                        end, [], NewFuns),
+                    {ChangedFuns, false}
+            end
+    end.
+
+-spec get_rebar_hash(file:filename()) -> string() | [].
+get_rebar_hash(RebarLockFile) ->
+    case utils:hash_file(RebarLockFile) of
+        {error, _} ->
+            case filelib:is_file(paths:rebar_config_from_lock_file(RebarLockFile)) of
+                true ->
+                    ?ABORT("Could not read rebar's lock file at ~p. Please build your project " ++
+                            "with rebar before using etylizer.", RebarLockFile);
+                false ->
+                    []
+            end;
+        H -> H
     end.
 
 -spec get_external_deps(file:filename()) -> {string(), string()}.
 get_external_deps(RebarLockFile) ->
     OtpVersion = erlang:system_info(otp_release),
-    RebarHash =
-        case utils:hash_file(RebarLockFile) of
-            {error, _} ->
-                case filelib:is_file(paths:rebar_config_from_lock_file(RebarLockFile)) of
-                    true ->
-                        ?ABORT("Could not read rebar's lock file at ~p. Please build your project " ++
-                                "with rebar before using etylizer.", RebarLockFile);
-                    false ->
-                        []
-                end;
-            H -> H
-        end,
+    RebarHash = get_rebar_hash(RebarLockFile),
     {OtpVersion, RebarHash}.
 
 -spec has_external_dep_changed(file:filename(), index()) -> {boolean(), index()}.
@@ -136,10 +192,55 @@ has_external_dep_changed(RebarLockFile, {{StoredOtpVersion, StoredRebarHash}, In
     NewIndex = {{OtpVersion, RebarHash}, Index},
     {Changed, NewIndex}.
 
+% @doc Backward-compatible insert without failed functions tracking.
 -spec insert(file:filename(), ast:forms(), index()) -> index().
-insert(Path, Forms, {DepVersions, Index}) ->
-    {ok, FileContent} = file:read_file(Path),
-    FileHash = utils:hash_sha1(FileContent),
+insert(Path, Forms, Index) ->
+    insert(Path, Forms, [], Index).
+
+% @doc Insert file index entry, excluding functions that failed type checking.
+% Failed functions are omitted from the fun index so they are re-checked on the next run.
+% If any functions failed, a dummy file hash is used to force re-processing of the file.
+-spec insert(file:filename(), ast:forms(), [{atom(), arity()}], index()) -> index().
+insert(Path, Forms, FailedFuns, Index) ->
+    ModName = ast_utils:modname_from_path(Path),
+    ModInfo = cm_fun_deps:analyze_module(ModName, Forms),
+    insert_fun_index(Path, Forms, ModInfo, FailedFuns, Index).
+
+% @doc Insert file index entry using pre-computed module info and forms.
+-spec insert_fun_index(file:filename(), ast:forms(), cm_fun_deps:module_info(),
+    [{atom(), arity()}], index()) -> index().
+insert_fun_index(Path, Forms, ModInfo, FailedFuns, {DepVersions, Index}) ->
+    {ok, FileContent} = ?assert_type(file:read_file(Path), {ok, binary()}),
     Interface = cm_module_interface:extract_interface_declaration(Forms),
-    InterfaceHash = utils:hash_sha1(io_lib:write(Interface)),
-    {DepVersions, maps:put(Path, {FileHash, InterfaceHash}, Index)}.
+    Written = ?assert_type(io_lib:write(Interface), iodata()),
+    InterfaceHash = utils:hash_sha1(Written),
+    DeclsHash = ?assert_type(maps:get(decls_hash, ModInfo), string()),
+    Funs = ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}),
+    FailedSet = sets:from_list(FailedFuns, [{version, 2}]),
+    FunIndex = maps:fold(
+        fun({_Mod, Name, Arity}, FunInfo, Acc) ->
+            case sets:is_element({Name, Arity}, FailedSet) of
+                true ->
+                    SpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
+                    maps:put({Name, Arity}, {failed, SpecHash}, Acc);
+                false ->
+                    BodyHash = ?assert_type(maps:get(body_hash, FunInfo), string()),
+                    SpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
+                    maps:put({Name, Arity}, {BodyHash, SpecHash}, Acc)
+            end
+        end, maps:new(), Funs),
+    % Use a dummy file hash when there are failures, so the file is re-processed next run
+    FileHash = case FailedFuns of
+        [] -> utils:hash_sha1(FileContent);
+        _ -> ""
+    end,
+    {DepVersions, maps:put(Path, {FileHash, InterfaceHash, DeclsHash, FunIndex}, Index)}.
+
+% @doc Remove index entries for files not in the given source list.
+-spec prune(index(), [file:filename()]) -> index().
+prune({DepVersions, Index}, SourceList) ->
+    SourceSet = sets:from_list(SourceList, [{version, 2}]),
+    PrunedIndex = maps:filter(
+        fun(Path, _) -> sets:is_element(Path, SourceSet) end,
+        Index),
+    {DepVersions, PrunedIndex}.

--- a/src/cm_index.erl
+++ b/src/cm_index.erl
@@ -13,7 +13,7 @@
     insert/3,
     insert/4,
     insert_fun_index/5,
-    changed_functions/3,
+    changed_functions/4,
     prune/2
 ]).
 
@@ -23,8 +23,8 @@
 -include("etylizer_main.hrl").
 -include("etylizer.hrl").
 
-% Per-function hashes: {atom(), arity()} => {BodyHash, SpecHash} | {failed, SpecHash}
--type fun_index_entry() :: #{{atom(), arity()} => {string(), string()} | {failed, string()}}.
+% Per-function hashes: {atom(), arity()} => {BodyHash, SpecHash} | {failed, BodyHash, SpecHash}
+-type fun_index_entry() :: #{{atom(), arity()} => {string(), string()} | {failed, string(), string()}}.
 
 % File index entry: {FileHash, InterfaceHash, DeclsHash, FunIndex}
 -type file_index_entry() :: {string(), string(), string(), fun_index_entry()}.
@@ -43,7 +43,7 @@
 %    index()
 %}.
 
--define(INDEX_VERSION, 3).
+-define(INDEX_VERSION, 4).
 
 -spec empty_index(file:filename()) -> index().
 empty_index(RebarLockFile) ->
@@ -115,9 +115,16 @@ has_exported_interface_changed(Path, Forms, {_, Index}) ->
 
 % @doc Compute which functions in a file need rechecking.
 % Returns {all | [{atom(), arity()}], DeclsChanged :: boolean()}.
--spec changed_functions(file:filename(), cm_fun_deps:module_info(), index()) ->
+% OnlyRecheckChanged=false (default): previously-failed functions are always
+% retried, even when body and spec are unchanged. This is the right behavior
+% for batch/CI runs — a transient or context-dependent failure should not be
+% baked into the index.
+% OnlyRecheckChanged=true: only retry failed functions when body or spec
+% changed. Used by watch-mode drivers (ety-watch) where re-running an
+% unchanged failed function on every save is noise.
+-spec changed_functions(file:filename(), cm_fun_deps:module_info(), index(), boolean()) ->
     {all | [ast:fun_with_arity()], boolean()}.
-changed_functions(Path, ModInfo, {_, Index}) ->
+changed_functions(Path, ModInfo, {_, Index}, OnlyRecheckChanged) ->
     NewDeclsHash = ?assert_type(maps:get(decls_hash, ModInfo), string()),
     NewFuns = ?assert_type(maps:get(funs, ModInfo), #{cm_fun_deps:fun_id() => cm_fun_deps:fun_info()}),
     case maps:find(Path, Index) of
@@ -140,9 +147,13 @@ changed_functions(Path, ModInfo, {_, Index}) ->
                                 error ->
                                     % New function
                                     [{Name, Arity} | Acc];
-                                {ok, {failed, _}} ->
-                                    % Previously failed, needs retry
-                                    [{Name, Arity} | Acc];
+                                {ok, {failed, OldBodyHash, OldSpecHash}} ->
+                                    BodyChanged = NewBodyHash =/= OldBodyHash,
+                                    SpecChanged = NewSpecHash =/= OldSpecHash,
+                                    case {OnlyRecheckChanged, BodyChanged, SpecChanged} of
+                                        {true, false, false} -> Acc;
+                                        _ -> [{Name, Arity} | Acc]
+                                    end;
                                 {ok, {OldBodyHash, OldSpecHash}} ->
                                     BodyChanged = NewBodyHash =/= OldBodyHash,
                                     SpecChanged = NewSpecHash =/= OldSpecHash,
@@ -219,13 +230,12 @@ insert_fun_index(Path, Forms, ModInfo, FailedFuns, {DepVersions, Index}) ->
     FailedSet = sets:from_list(FailedFuns, [{version, 2}]),
     FunIndex = maps:fold(
         fun({_Mod, Name, Arity}, FunInfo, Acc) ->
+            BodyHash = ?assert_type(maps:get(body_hash, FunInfo), string()),
+            SpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
             case sets:is_element({Name, Arity}, FailedSet) of
                 true ->
-                    SpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
-                    maps:put({Name, Arity}, {failed, SpecHash}, Acc);
+                    maps:put({Name, Arity}, {failed, BodyHash, SpecHash}, Acc);
                 false ->
-                    BodyHash = ?assert_type(maps:get(body_hash, FunInfo), string()),
-                    SpecHash = ?assert_type(maps:get(spec_hash, FunInfo), string()),
                     maps:put({Name, Arity}, {BodyHash, SpecHash}, Acc)
             end
         end, maps:new(), Funs),

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -29,7 +29,9 @@
           % Local var bindings known at constraint-gen time
           % e.g. function args from the spec, plus any other refs we want exp_constrs_tyof to resolve
           % directly to a closed type.
-          env = #{} :: #{ ast:any_ref() => ast:ty() }
+          env = #{} :: #{ ast:any_ref() => ast:ty() },
+          % true when generating constraints inside a guard expression
+          in_guard = false :: boolean()
         }).
 -type ctx() :: #ctx{}.
 
@@ -380,6 +382,33 @@ exp_constrs(Ctx, E, T) ->
             sets:add_element(ResultC, Cs2);
         {nil, L} ->
             utils:single({csubty, mk_locs("result of nil", L), {empty_list}, T});
+        {op, L, Op, Lhs, Rhs} when Op =:= '=='; Op =:= '=:=';
+                                     Op =:= '/='; Op =:= '=/=';
+                                     Op =:= '>'; Op =:= '<';
+                                     Op =:= '>='; Op =:= '=<' ->
+            % For comparison/equality operators, skip the function type machinery entirely.
+            % Their type is fun((any(), any()) -> boolean()), so the only useful
+            % constraint is that the result type is boolean(). The refinement
+            % (narrowing variables) is handled separately by guard_test_env/refine_eq_env
+            % and comparison_refine_env.
+            Alpha1 = fresh_tyvar(Ctx),
+            Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
+            Alpha2 = fresh_tyvar(Ctx),
+            Cs2 = exp_constrs(Ctx, Rhs, Alpha2),
+            BoolCs = utils:single({csubty, mk_locs("comparison result", L), {predef_alias, boolean}, T}),
+            sets:union([Cs1, Cs2, BoolCs]);
+        {op, L, Op, Lhs, Rhs} when (Op =:= 'andalso' orelse Op =:= 'orelse'),
+                                     Ctx#ctx.in_guard ->
+            % In guard context, andalso/orelse result is always boolean.
+            % Skip the intersection function type (fun((false,any())->false) /\ fun((true,a)->a))
+            % and just constrain the result to boolean(). Guard sub-expressions already
+            % produce boolean from their own semantics.
+            Alpha1 = fresh_tyvar(Ctx),
+            Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
+            Alpha2 = fresh_tyvar(Ctx),
+            Cs2 = exp_constrs(Ctx, Rhs, Alpha2),
+            BoolCs = utils:single({csubty, mk_locs("boolean shortcircuit", L), {predef_alias, boolean}, T}),
+            sets:union([Cs1, Cs2, BoolCs]);
         {op, L, Op, Lhs, Rhs} ->
             Alpha1 = fresh_tyvar(Ctx),
             Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
@@ -743,18 +772,53 @@ var_funcall_constrs(Ctx, L, Var, Args, T) ->
 
 -spec funcall_constrs_with_tyscm(ctx(), ast:loc(), ast:exp_var(), ast:ty_scheme(), [ast:exp()], ast:ty()) -> constr:constrs().
 funcall_constrs_with_tyscm(Ctx, L, Var, TyScm, Args, T) ->
-    case try_spec_call_with_tyscm(Ctx, L, TyScm, Args) of
-        {ok, {ResTy, ArgCs}} ->
-            FunName = pretty:render_var(Var),
-            ResConstr =
-                {csubty,
-                    mk_locs(utils:sformat("result of calling ~s", FunName), L),
-                    ResTy,
-                    T},
-            sets:add_element(ResConstr, ArgCs);
-        error ->
-            gen_funcall_constrs(Ctx, L, Var, Args, T)
+    case Ctx#ctx.in_guard of
+        true ->
+            {Mono, _, _} = typing_common:mono_ty(L, TyScm, none,
+                fun(_, none) -> {fresh_ty_varname(Ctx), none} end,
+                Ctx#ctx.symtab),
+            guard_funcall_constrs(Ctx, L, Var, Mono, Args, T);
+        false ->
+            case try_spec_call_with_tyscm(Ctx, L, TyScm, Args) of
+                {ok, {ResTy, ArgCs}} ->
+                    FunName = pretty:render_var(Var),
+                    ResConstr =
+                        {csubty,
+                            mk_locs(utils:sformat("result of calling ~s", FunName), L),
+                            ResTy,
+                            T},
+                    sets:add_element(ResConstr, ArgCs);
+                error ->
+                    gen_funcall_constrs(Ctx, L, Var, Args, T)
+            end
     end.
+
+% In guard context, BIF calls are total: exceptions cause guard failure.
+% We skip the domain check (don't constrain args against parameter types)
+% and use the union of return types as the result. This avoids expensive
+% intersection function type subtyping in tally.
+-spec guard_funcall_constrs(ctx(), ast:loc(), ast:exp_var(), ast:ty(), [ast:exp()], ast:ty()) -> constr:constrs().
+guard_funcall_constrs(Ctx, L, Var, Mono, Args, T) ->
+    % Extract return types from all overloads
+    ReturnTys = case Mono of
+        {fun_full, _, ResTy} -> [ResTy];
+        {intersection, FunTys} ->
+            [ResTy || {fun_full, _, ResTy} <- FunTys]
+    end,
+    ResultTy = ast_lib:mk_union(ReturnTys),
+    FunName = pretty:render_var(Var),
+    ResConstr = {csubty, mk_locs(utils:sformat("result of calling ~s", FunName), L), ResultTy, T},
+    % Typecheck argument expressions (generates their own constraints)
+    % but don't constrain arg types against the function's parameter types.
+    ArgCs = lists:foldl(
+        fun(Arg, AccCs) ->
+            Alpha = fresh_tyvar(Ctx),
+            ThisCs = exp_constrs(Ctx, Arg, Alpha),
+            sets:union(AccCs, ThisCs)
+        end,
+        sets:new([{version, 2}]),
+        Args),
+    sets:add_element(ResConstr, ArgCs).
 
 % Helper: instantiate the type scheme, generate arg constraints, and return the
 % spec'd result type directly. Used both by funcall_constrs_with_tyscm (which
@@ -1120,10 +1184,11 @@ receive_clause_constrs(Ctx, {case_clause, L, Pat, Guards, Exps}, T) ->
     % Unguarded variables remain dynamic().
     VarEnv = maps:merge(DynamicPatEnv, GuardEnv),
     % Generate guard constraints to evaluate to boolean()
+    GuardCtx = Ctx#ctx{in_guard = true},
     GuardCs = sets:union(
         lists:map(
             fun(Guard) ->
-                exps_constrs(Ctx, L, Guard, {predef_alias, boolean})
+                exps_constrs(GuardCtx, L, Guard, {predef_alias, boolean})
             end,
             Guards)),
     % Generate body constraints
@@ -1244,11 +1309,12 @@ case_clause_constrs(Ctx, TyScrut, Scrut, NeedsUnmatchedCheck, LowersBefore,
     BodyCs = exps_constrs(BodyCtx, L, Exps, ExpectedTy),
     InnerCs = BodyCs,
 
+    GuardCtx = Ctx#ctx{in_guard = true},
     CGuards =
         sets:union(
           lists:map(
             fun(Guard) ->
-                    GuardCs = exps_constrs(Ctx, L, Guard, {predef_alias, boolean}),
+                    GuardCs = exps_constrs(GuardCtx, L, Guard, {predef_alias, boolean}),
                     GuardCs
             end,
             Guards)),
@@ -1290,11 +1356,12 @@ catch_clause_constrs(Ctx, {catch_clause, L, ExcType, Pat, Stack, Guards, Body}, 
     InnerCs = sets:union(BodyCs, InnerCs0),
 
     % Generate guard constraints (guards must be boolean)
+    GuardCtx = Ctx#ctx{in_guard = true},
     CGuards =
         sets:union(
           lists:map(
             fun(Guard) ->
-                    exps_constrs(Ctx, L, Guard, {predef_alias, boolean})
+                    exps_constrs(GuardCtx, L, Guard, {predef_alias, boolean})
             end,
             Guards)),
 

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -29,7 +29,9 @@
           % Local var bindings known at constraint-gen time
           % e.g. function args from the spec, plus any other refs we want exp_constrs_tyof to resolve
           % directly to a closed type.
-          env = #{} :: #{ ast:any_ref() => ast:ty() }
+          env = #{} :: #{ ast:any_ref() => ast:ty() },
+          % true when generating constraints inside a guard expression
+          in_guard = false :: boolean()
         }).
 -type ctx() :: #ctx{}.
 
@@ -376,6 +378,33 @@ exp_constrs(Ctx, E, T) ->
             sets:add_element(ResultC, Cs2);
         {nil, L} ->
             utils:single({csubty, mk_locs("result of nil", L), {empty_list}, T});
+        {op, L, Op, Lhs, Rhs} when Op =:= '=='; Op =:= '=:=';
+                                     Op =:= '/='; Op =:= '=/=';
+                                     Op =:= '>'; Op =:= '<';
+                                     Op =:= '>='; Op =:= '=<' ->
+            % For comparison/equality operators, skip the function type machinery entirely.
+            % Their type is fun((any(), any()) -> boolean()), so the only useful
+            % constraint is that the result type is boolean(). The refinement
+            % (narrowing variables) is handled separately by guard_test_env/refine_eq_env
+            % and comparison_refine_env.
+            Alpha1 = fresh_tyvar(Ctx),
+            Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
+            Alpha2 = fresh_tyvar(Ctx),
+            Cs2 = exp_constrs(Ctx, Rhs, Alpha2),
+            BoolCs = utils:single({csubty, mk_locs("comparison result", L), {predef_alias, boolean}, T}),
+            sets:union([Cs1, Cs2, BoolCs]);
+        {op, L, Op, Lhs, Rhs} when (Op =:= 'andalso' orelse Op =:= 'orelse'),
+                                     Ctx#ctx.in_guard ->
+            % In guard context, andalso/orelse result is always boolean.
+            % Skip the intersection function type (fun((false,any())->false) /\ fun((true,a)->a))
+            % and just constrain the result to boolean(). Guard sub-expressions already
+            % produce boolean from their own semantics.
+            Alpha1 = fresh_tyvar(Ctx),
+            Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
+            Alpha2 = fresh_tyvar(Ctx),
+            Cs2 = exp_constrs(Ctx, Rhs, Alpha2),
+            BoolCs = utils:single({csubty, mk_locs("boolean shortcircuit", L), {predef_alias, boolean}, T}),
+            sets:union([Cs1, Cs2, BoolCs]);
         {op, L, Op, Lhs, Rhs} ->
             Alpha1 = fresh_tyvar(Ctx),
             Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
@@ -736,18 +765,53 @@ var_funcall_constrs(Ctx, L, Var, Args, T) ->
 
 -spec funcall_constrs_with_tyscm(ctx(), ast:loc(), ast:exp_var(), ast:ty_scheme(), [ast:exp()], ast:ty()) -> constr:constrs().
 funcall_constrs_with_tyscm(Ctx, L, Var, TyScm, Args, T) ->
-    case try_spec_call_with_tyscm(Ctx, L, TyScm, Args) of
-        {ok, {ResTy, ArgCs}} ->
-            FunName = pretty:render_var(Var),
-            ResConstr =
-                {csubty,
-                    mk_locs(utils:sformat("result of calling ~s", FunName), L),
-                    ResTy,
-                    T},
-            sets:add_element(ResConstr, ArgCs);
-        error ->
-            gen_funcall_constrs(Ctx, L, Var, Args, T)
+    case Ctx#ctx.in_guard of
+        true ->
+            {Mono, _, _} = typing_common:mono_ty(L, TyScm, none,
+                fun(_, none) -> {fresh_ty_varname(Ctx), none} end,
+                Ctx#ctx.symtab),
+            guard_funcall_constrs(Ctx, L, Var, Mono, Args, T);
+        false ->
+            case try_spec_call_with_tyscm(Ctx, L, TyScm, Args) of
+                {ok, {ResTy, ArgCs}} ->
+                    FunName = pretty:render_var(Var),
+                    ResConstr =
+                        {csubty,
+                            mk_locs(utils:sformat("result of calling ~s", FunName), L),
+                            ResTy,
+                            T},
+                    sets:add_element(ResConstr, ArgCs);
+                error ->
+                    gen_funcall_constrs(Ctx, L, Var, Args, T)
+            end
     end.
+
+% In guard context, BIF calls are total: exceptions cause guard failure.
+% We skip the domain check (don't constrain args against parameter types)
+% and use the union of return types as the result. This avoids expensive
+% intersection function type subtyping in tally.
+-spec guard_funcall_constrs(ctx(), ast:loc(), ast:exp_var(), ast:ty(), [ast:exp()], ast:ty()) -> constr:constrs().
+guard_funcall_constrs(Ctx, L, Var, Mono, Args, T) ->
+    % Extract return types from all overloads
+    ReturnTys = case Mono of
+        {fun_full, _, ResTy} -> [ResTy];
+        {intersection, FunTys} ->
+            [ResTy || {fun_full, _, ResTy} <- FunTys]
+    end,
+    ResultTy = ast_lib:mk_union(ReturnTys),
+    FunName = pretty:render_var(Var),
+    ResConstr = {csubty, mk_locs(utils:sformat("result of calling ~s", FunName), L), ResultTy, T},
+    % Typecheck argument expressions (generates their own constraints)
+    % but don't constrain arg types against the function's parameter types.
+    ArgCs = lists:foldl(
+        fun(Arg, AccCs) ->
+            Alpha = fresh_tyvar(Ctx),
+            ThisCs = exp_constrs(Ctx, Arg, Alpha),
+            sets:union(AccCs, ThisCs)
+        end,
+        sets:new([{version, 2}]),
+        Args),
+    sets:add_element(ResConstr, ArgCs).
 
 % Helper: instantiate the type scheme, generate arg constraints, and return the
 % spec'd result type directly. Used both by funcall_constrs_with_tyscm (which
@@ -1113,10 +1177,11 @@ receive_clause_constrs(Ctx, {case_clause, L, Pat, Guards, Exps}, T) ->
     % Unguarded variables remain dynamic().
     VarEnv = maps:merge(DynamicPatEnv, GuardEnv),
     % Generate guard constraints to evaluate to boolean()
+    GuardCtx = Ctx#ctx{in_guard = true},
     GuardCs = sets:union(
         lists:map(
             fun(Guard) ->
-                exps_constrs(Ctx, L, Guard, {predef_alias, boolean})
+                exps_constrs(GuardCtx, L, Guard, {predef_alias, boolean})
             end,
             Guards)),
     % Generate body constraints
@@ -1206,11 +1271,12 @@ case_clause_constrs(Ctx, TyScrut, Scrut, NeedsUnmatchedCheck, LowersBefore,
     BodyCs = exps_constrs(BodyCtx, L, Exps, ExpectedTy),
     InnerCs = BodyCs,
 
+    GuardCtx = Ctx#ctx{in_guard = true},
     CGuards =
         sets:union(
           lists:map(
             fun(Guard) ->
-                    GuardCs = exps_constrs(Ctx, L, Guard, {predef_alias, boolean}),
+                    GuardCs = exps_constrs(GuardCtx, L, Guard, {predef_alias, boolean}),
                     GuardCs
             end,
             Guards)),
@@ -1252,11 +1318,12 @@ catch_clause_constrs(Ctx, {catch_clause, L, ExcType, Pat, Stack, Guards, Body}, 
     InnerCs = sets:union(BodyCs, InnerCs0),
 
     % Generate guard constraints (guards must be boolean)
+    GuardCtx = Ctx#ctx{in_guard = true},
     CGuards =
         sets:union(
           lists:map(
             fun(Guard) ->
-                    exps_constrs(Ctx, L, Guard, {predef_alias, boolean})
+                    exps_constrs(GuardCtx, L, Guard, {predef_alias, boolean})
             end,
             Guards)),
 

--- a/src/erlang_types/dnf_ty_tuple.erl
+++ b/src/erlang_types/dnf_ty_tuple.erl
@@ -49,6 +49,7 @@ phi(BigS, [Ty | N], ST) ->
     phi_fold_components(BigS, ty_tuple:components(Ty), 1, {true, ST1}, N)
   end.
 
+-spec phi_fold_components([ty:type()], [ty:type()], integer(), {boolean(), S}, [?ATOM:type()]) -> {boolean(), S} when S :: is_empty_cache().
 phi_fold_components(_BigS, [], _Idx, Acc, _N) -> Acc;
 phi_fold_components(BigS, [NComp | Rest], Idx, Acc, N) ->
     Acc1 = phi_solve(Idx, NComp, Acc, N, BigS),
@@ -123,6 +124,8 @@ phi_norm_impl(BigS, [Ty | N], Fixed, ST) ->
       {constraint_set:join(R1, R4, Fixed), ST4}
   end.
 
+-spec phi_norm_fold_components([ty_node:type()], [ty_node:type()], integer(), {set_of_constraint_sets(), S}, [?ATOM:type()], monomorphic_variables()) ->
+    {set_of_constraint_sets(), S} when S :: normalize_cache().
 phi_norm_fold_components(_BigS, [], _Idx, Acc, _N, _Fixed) -> Acc;
 %% Short-circuit on accumulator = [] (meet absorbs to [] from here on).
 phi_norm_fold_components(_BigS, _Rest, _Idx, {[], ST} = Acc, _N, _Fixed) -> Acc;
@@ -140,8 +143,10 @@ phi_norm_solve(Index, NComponent, {Result, ST00}, N, BigS, Fixed) ->
     {Res01, ST01} = phi_norm(NewBigS, N, Fixed, ST00),
     {constraint_set:meet(Result, Res01, Fixed), ST01}.
 
-replace_at(1, [H | T], NComp) -> [ty_node:difference(H, NComp) | T];
-replace_at(N, [H | T], NComp) when N > 1 -> [H | replace_at(N - 1, T, NComp)].
+-spec replace_at(integer(), [ty_node:type()], ty_node:type()) -> [ty_node:type()].
+replace_at(_, [], _NComp) -> [];
+replace_at(N, [H | T], NComp) when N =< 1 -> [ty_node:difference(H, NComp) | T];
+replace_at(N, [H | T], NComp) -> [H | replace_at(N - 1, T, NComp)].
 
 -spec all_variables_line([T], [T], ?LEAF:type(), all_variables_cache()) -> 
     sets:set(variable()) when T :: ?ATOM:type().

--- a/src/etylizer_main.erl
+++ b/src/etylizer_main.erl
@@ -231,7 +231,7 @@ dump_transformed_ast(Opts) ->
         end, FunDecls)
     end, Opts#opts.files).
 
--spec doWork(#opts{}) -> [file:filename()].
+-spec doWork(#opts{}) -> cm_check:check_list().
 doWork(Opts) ->
     global_state:with_new_state(fun() ->
       ?LOG_TRACE("Initializing ETS tables"),
@@ -255,18 +255,26 @@ doWork(Opts) ->
           end,
           SourceList = paths:generate_input_file_list(Opts),
           SearchPath = paths:compute_search_path(Opts),
+          DepGraphFile = paths:depgraph_file_name(Opts),
           DepGraph =
               case Opts#opts.no_deps of
                   true ->
                       % only typecheck the files given
                       cm_depgraph:new(SourceList);
                   false ->
-                      ?LOG_DEBUG("Entry points: ~p, now building dependency graph", SourceList),
-                      G = cm_depgraph:build_dep_graph(
-                          SourceList,
-                          SearchPath),
-                      ?LOG_DEBUG("Reverse dependency graph: ~p", cm_depgraph:pretty_depgraph(G)),
-                      G
+                      case Opts#opts.force of
+                          true ->
+                              ?LOG_DEBUG("Force flag set, rebuilding dependency graph"),
+                              build_and_save_depgraph(SourceList, SearchPath, DepGraphFile);
+                          false ->
+                              case cm_depgraph:load_depgraph(DepGraphFile, SourceList) of
+                                  {ok, CachedGraph} ->
+                                      ?LOG_DEBUG("Using cached dependency graph"),
+                                      CachedGraph;
+                                  stale ->
+                                      build_and_save_depgraph(SourceList, SearchPath, DepGraphFile)
+                              end
+                      end
               end,
           case Opts#opts.dump_transformed of
               true ->
@@ -278,9 +286,19 @@ doWork(Opts) ->
           end
       after
           parse_cache:cleanup(),
-          stdtypes:cleanup()
+          stdtypes:cleanup(),
+          paths:clear_module_cache()
       end
                                 end).
+
+-spec build_and_save_depgraph([file:filename()], paths:search_path(), file:filename()) ->
+    cm_depgraph:dep_graph().
+build_and_save_depgraph(SourceList, SearchPath, DepGraphFile) ->
+    ?LOG_DEBUG("Entry points: ~p, now building dependency graph", SourceList),
+    G = cm_depgraph:build_dep_graph(SourceList, SearchPath),
+    ?LOG_DEBUG("Reverse dependency graph: ~p", cm_depgraph:pretty_depgraph(G)),
+    cm_depgraph:save_depgraph(DepGraphFile, G),
+    G.
 
 -spec main([string()]) -> ok.
 main(Args) ->

--- a/src/etylizer_main.erl
+++ b/src/etylizer_main.erl
@@ -230,7 +230,7 @@ dump_transformed_ast(Opts) ->
         end, FunDecls)
     end, Opts#opts.files).
 
--spec doWork(#opts{}) -> [file:filename()].
+-spec doWork(#opts{}) -> cm_check:check_list().
 doWork(Opts) ->
     global_state:with_new_state(fun() ->
       ?LOG_TRACE("Initializing ETS tables"),
@@ -258,18 +258,26 @@ doWork(Opts) ->
           end,
           SourceList = paths:generate_input_file_list(Opts),
           SearchPath = paths:compute_search_path(Opts),
+          DepGraphFile = paths:depgraph_file_name(Opts),
           DepGraph =
               case Opts#opts.no_deps of
                   true ->
                       % only typecheck the files given
                       cm_depgraph:new(SourceList);
                   false ->
-                      ?LOG_DEBUG("Entry points: ~p, now building dependency graph", SourceList),
-                      G = cm_depgraph:build_dep_graph(
-                          SourceList,
-                          SearchPath),
-                      ?LOG_DEBUG("Reverse dependency graph: ~p", cm_depgraph:pretty_depgraph(G)),
-                      G
+                      case Opts#opts.force of
+                          true ->
+                              ?LOG_DEBUG("Force flag set, rebuilding dependency graph"),
+                              build_and_save_depgraph(SourceList, SearchPath, DepGraphFile);
+                          false ->
+                              case cm_depgraph:load_depgraph(DepGraphFile, SourceList) of
+                                  {ok, CachedGraph} ->
+                                      ?LOG_DEBUG("Using cached dependency graph"),
+                                      CachedGraph;
+                                  stale ->
+                                      build_and_save_depgraph(SourceList, SearchPath, DepGraphFile)
+                              end
+                      end
               end,
           case Opts#opts.dump_transformed of
               true ->
@@ -286,9 +294,19 @@ doWork(Opts) ->
           end,
           metrics:cleanup(),
           parse_cache:cleanup(),
-          stdtypes:cleanup()
+          stdtypes:cleanup(),
+          paths:clear_module_cache()
       end
                                 end).
+
+-spec build_and_save_depgraph([file:filename()], paths:search_path(), file:filename()) ->
+    cm_depgraph:dep_graph().
+build_and_save_depgraph(SourceList, SearchPath, DepGraphFile) ->
+    ?LOG_DEBUG("Entry points: ~p, now building dependency graph", SourceList),
+    G = cm_depgraph:build_dep_graph(SourceList, SearchPath),
+    ?LOG_DEBUG("Reverse dependency graph: ~p", cm_depgraph:pretty_depgraph(G)),
+    cm_depgraph:save_depgraph(DepGraphFile, G),
+    G.
 
 -spec main([string()]) -> ok.
 main(Args) ->

--- a/src/etylizer_main.erl
+++ b/src/etylizer_main.erl
@@ -119,6 +119,10 @@ cmd_spec() ->
               help => "Disable exhaustiveness checking for a function (name/arity). May be given multiple times."},
             #{name => no_redundancy, long => "-no-redundancy", action => append, default => [],
               help => "Disable redundancy checking for a function (name/arity). May be given multiple times."},
+            #{name => only_recheck_changed, long => "-only-recheck-changed", type => boolean, default => false,
+              help => "Skip rechecking previously-failed functions whose body and spec are unchanged. "
+                      "Default behavior is to always retry failed functions. Intended for watch-mode "
+                      "drivers (e.g. ety-watch) where re-running an unchanged failed function is noise."},
             #{name => verbose, short => $v, long => "-verbose", type => boolean, default => false,
               help => "Verbose output (e.g. preprocessor warnings)"},
             #{name => metrics_file, long => "-metrics-file",
@@ -167,6 +171,7 @@ parse_args(Args) ->
         load_end = maps:get(load_end, ArgMap),
         no_exhaustiveness = maps:get(no_exhaustiveness, ArgMap),
         no_redundancy = maps:get(no_redundancy, ArgMap),
+        only_recheck_changed = maps:get(only_recheck_changed, ArgMap),
         files = maps:get(files, ArgMap),
         type_overlay = maps:get(type_overlay, ArgMap, []),
         verbose = maps:get(verbose, ArgMap, false),

--- a/src/etylizer_main.hrl
+++ b/src/etylizer_main.hrl
@@ -31,6 +31,7 @@
                metrics_file = undefined :: undefined | string(),
                no_exhaustiveness = [] :: [string()],
                no_redundancy = [] :: [string()],
+               only_recheck_changed = false :: boolean(),
                mode = prod_mode :: opts_mode() % only used internally
             }).
 

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -5,8 +5,12 @@
 -export([
     compute_search_path/1,
     generate_input_file_list/1,
+    depgraph_file_name/1,
+    fun_depgraph_file_name/1,
+    std_symtab_file_name/1,
     index_file_name/1,
     find_module_path/2,
+    clear_module_cache/0,
     rebar_lock_file/1,
     rebar_config_from_lock_file/1
 ]).
@@ -210,6 +214,21 @@ index_file_name(Opts) ->
     D = etylizer_dir(Opts),
     filename:join(D, "index").
 
+-spec depgraph_file_name(cmd_opts()) -> file:filename().
+depgraph_file_name(Opts) ->
+    D = etylizer_dir(Opts),
+    filename:join(D, "depgraph").
+
+-spec fun_depgraph_file_name(cmd_opts()) -> file:filename().
+fun_depgraph_file_name(Opts) ->
+    D = etylizer_dir(Opts),
+    filename:join(D, "fun_depgraph").
+
+-spec std_symtab_file_name(cmd_opts()) -> file:filename().
+std_symtab_file_name(Opts) ->
+    D = etylizer_dir(Opts),
+    filename:join(D, "std_symtab.config").
+
 -spec rebar_lock_file(cmd_opts()) -> file:filename().
 rebar_lock_file(Opts) ->
     RootDir = root_dir(Opts),
@@ -221,18 +240,27 @@ rebar_config_from_lock_file(F) ->
 
 -define(TABLE, mod_table).
 
+% @doc Clear the module path cache. Must be called between independent runs
+% to avoid stale path entries (e.g., paths pointing to deleted temp directories).
+-spec clear_module_cache() -> ok.
+clear_module_cache() ->
+    case ets:whereis(?TABLE) of
+        undefined -> ok;
+        _ -> ets:delete(?TABLE)
+    end,
+    ok.
+
 -spec find_module_path(search_path(), atom()) -> search_path_entry().
 find_module_path(SearchPath, Module) ->
     case ets:whereis(?TABLE) of
         undefined -> ets:new(?TABLE, [set, named_table, {keypos, 1}]);
         _ -> ok
     end,
-    Key = {SearchPath, Module},
-    case ets:lookup(?TABLE, Key) of
+    case ets:lookup(?TABLE, Module) of
         [{_, Result}] -> ?assert_type(Result, search_path_entry());
         [] ->
             X = really_find_module_path(SearchPath, Module),
-            true = ets:insert(?TABLE, {Key, X}),
+            true = ets:insert(?TABLE, {Module, X}),
             X;
         Y -> ?ABORT("Unexpected entry in mod_table: ~p", Y)
     end.

--- a/src/typing.erl
+++ b/src/typing.erl
@@ -51,11 +51,11 @@ resolve_disabled_funs(Feature, Forms) ->
     end.
 
 % Checks all forms of a module
--spec check_forms(ctx(), string(), ast:forms(), sets:set(string()), sets:set(string()), boolean()) -> ok.
+-spec check_forms(ctx(), string(), ast:forms(), sets:set(string()), sets:set(string()), boolean()) -> [{atom(), arity()}].
 check_forms(Ctx, FileName, Forms, Only, Ignore, CheckExports) ->
     check_forms(Ctx, FileName, Forms, Only, Ignore, CheckExports, {sets:new(), sets:new()}).
 
--spec check_forms(ctx(), string(), ast:forms(), sets:set(string()), sets:set(string()), boolean(), {sets:set({atom(), arity()}), sets:set({atom(), arity()})}) -> ok.
+-spec check_forms(ctx(), string(), ast:forms(), sets:set(string()), sets:set(string()), boolean(), {sets:set({atom(), arity()}), sets:set({atom(), arity()})}) -> [{atom(), arity()}].
 check_forms(Ctx, FileName, Forms, Only, Ignore, CheckExports, {CliNoExhaustiveness, CliNoRedundancy}) ->
     case CheckExports orelse Ctx#ctx.gradual_typing_mode =:= infer of
         true ->
@@ -164,19 +164,20 @@ check_forms(Ctx, FileName, Forms, Only, Ignore, CheckExports, {CliNoExhaustivene
                         end;
                     [E | RestEnvs] ->
                         case ReportMode of
-                            early_exit -> 
+                            early_exit ->
                                 case typing_check:check_all(ExtCtx, FileName, E, FunsWithSpec) of
-                                    ok -> ok; % we are done
+                                    ok -> []; % we are done
                                     {error, Msg} -> Loop(RestEnvs, [{E, Msg} | Errs])
                                 end;
-                            report -> 
+                            report ->
                                 typing_check:check_all_report(ExtCtx, FileName, E, FunsWithSpec)
                         end
                 end
         end,
-    Loop(InferredTyEnvs, []),
+    FailedFuns = Loop(InferredTyEnvs, []),
     ?LOG_INFO("Checking ~w functions in ~s against their specs finished successfully",
-              length(FunsWithSpec), FileName).
+              length(FunsWithSpec), FileName),
+    FailedFuns.
 
 -spec should_check(string(), string(), string(), string(), sets:set(string()), sets:set(string())) -> boolean().
 should_check(QRefStr, RefStr, NameStr, ModStr, Only, Ignore) ->

--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -17,37 +17,43 @@
 -include("typing.hrl").
 
 % Checks all functions against their specs, only print a report.
+% Returns the list of functions that failed type checking.
 -spec check_all_report(
         ctx(), string(), symtab:fun_env(), [{ast:fun_decl(), ast:ty_scheme()}]
-       ) -> ok.
+       ) -> [{atom(), arity()}].
 check_all_report(Ctx, FileName, Env, Decls) ->
     ?LOG_NOTE("Checking ~w functions in ~s against their specs", length(Decls), FileName),
     ExtSymtab = symtab:extend_symtab_with_fun_env(Env, Ctx#ctx.symtab),
     ExtCtx = Ctx#ctx { symtab = ExtSymtab },
     F = fun(FN) -> filename:basename(filename:rootname(FN)) end,
-    lists:foreach(
-        fun({Decl, Ty}) -> 
+    lists:filtermap(
+        fun({Decl, Ty}) ->
             {function, _, Name, Arity, _} = Decl,
             T0 = erlang:system_time(millisecond),
             try check_report(ExtCtx, Decl, Ty) of
-                success -> 
-                    io:format(user,"Ok: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, ?TIME(T0)]);
-                timeout -> 
-                    io:format(user,"Timeout: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, ?TIME(T0)])
-            catch 
-                throw:{etylizer, ty_error, Msg} -> 
-                    io:format(user,"Error: ~s:~w/~w (~p ms)~n  ~s~n", [F(FileName), Name, Arity, ?TIME(T0), Msg]);
-                throw:{etylizer, unsupported, Msg} -> 
-                    io:format(user,"Unsupported: ~s:~w/~w~n  ~s~n", [F(FileName), Name, Arity, Msg]);
+                success ->
+                    io:format(user,"Ok: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, ?TIME(T0)]),
+                    false;
+                timeout ->
+                    io:format(user,"Timeout: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, ?TIME(T0)]),
+                    {true, {Name, Arity}}
+            catch
+                throw:{etylizer, ty_error, Msg} ->
+                    io:format(user,"Error: ~s:~w/~w (~p ms)~n  ~s~n", [F(FileName), Name, Arity, ?TIME(T0), Msg]),
+                    {true, {Name, Arity}};
+                throw:{etylizer, unsupported, Msg} ->
+                    io:format(user,"Unsupported: ~s:~w/~w~n  ~s~n", [F(FileName), Name, Arity, Msg]),
+                    {true, {Name, Arity}};
                 throw:{etylizer, Type, _Msg} ->
-                    io:format(user,"Error: (~p) ~s:~w/~w (~p ms)~n", [Type, F(FileName), Name, Arity, ?TIME(T0)]);
+                    io:format(user,"Error: (~p) ~s:~w/~w (~p ms)~n", [Type, F(FileName), Name, Arity, ?TIME(T0)]),
+                    {true, {Name, Arity}};
                 _:T ->
-                    io:format(user,"Other: (~p) ~s:~w/~w (~p ms)~n", [{T}, F(FileName), Name, Arity, ?TIME(T0)])
+                    io:format(user,"Other: (~p) ~s:~w/~w (~p ms)~n", [{T}, F(FileName), Name, Arity, ?TIME(T0)]),
+                    {true, {Name, Arity}}
             end
         end,
         Decls
-    ),
-    ok.
+    ).
 
 % Checks a function against its spec, skips timeouts and does not report errors.
 -spec check_report(ctx(), ast:fun_decl(), ast:ty_scheme()) -> success | timeout.

--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -18,15 +18,16 @@
 -include("metrics.hrl").
 
 % Checks all functions against their specs, only print a report.
+% Returns the list of functions that failed type checking.
 -spec check_all_report(
         ctx(), string(), symtab:fun_env(), [{ast:fun_decl(), ast:ty_scheme()}]
-       ) -> ok.
+       ) -> [{atom(), arity()}].
 check_all_report(Ctx, FileName, Env, Decls) ->
     ?LOG_NOTE("Checking ~w functions in ~s against their specs", length(Decls), FileName),
     ExtSymtab = symtab:extend_symtab_with_fun_env(Env, Ctx#ctx.symtab),
     ExtCtx = Ctx#ctx { symtab = ExtSymtab },
     F = fun(FN) -> filename:basename(filename:rootname(FN)) end,
-    lists:foreach(
+    lists:filtermap(
         fun({Decl, Ty}) ->
             {function, _, Name, Arity, _} = Decl,
             ?METRIC_SET_FUN(list_to_atom(utils:sformat("~s:~w/~w", [F(FileName), Name, Arity]))),
@@ -35,31 +36,36 @@ check_all_report(Ctx, FileName, Env, Decls) ->
                 success ->
                     Time = ?TIME(T0),
                     ?METRIC(typecheck_time, {list_to_atom(utils:sformat("~s:~w/~w", [F(FileName), Name, Arity])), Time, ok}),
-                    io:format(user,"Ok: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, Time]);
+                    io:format(user,"Ok: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, Time]),
+                    false;
                 timeout ->
                     Time = ?TIME(T0),
                     ?METRIC(typecheck_time, {list_to_atom(utils:sformat("~s:~w/~w", [F(FileName), Name, Arity])), Time, timeout}),
-                    io:format(user,"Timeout: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, Time])
+                    io:format(user,"Timeout: ~s:~w/~w (~p ms)~n", [F(FileName), Name, Arity, Time]),
+                    {true, {Name, Arity}}
             catch
                 throw:{etylizer, ty_error, Msg} ->
                     Time = ?TIME(T0),
                     ?METRIC(typecheck_time, {list_to_atom(utils:sformat("~s:~w/~w", [F(FileName), Name, Arity])), Time, error}),
-                    io:format(user,"Error: ~s:~w/~w (~p ms)~n  ~s~n", [F(FileName), Name, Arity, Time, Msg]);
+                    io:format(user,"Error: ~s:~w/~w (~p ms)~n  ~s~n", [F(FileName), Name, Arity, Time, Msg]),
+                    {true, {Name, Arity}};
                 throw:{etylizer, unsupported, Msg} ->
-                    io:format(user,"Unsupported: ~s:~w/~w~n  ~s~n", [F(FileName), Name, Arity, Msg]);
+                    io:format(user,"Unsupported: ~s:~w/~w~n  ~s~n", [F(FileName), Name, Arity, Msg]),
+                    {true, {Name, Arity}};
                 throw:{etylizer, Type, _Msg} ->
                     Time = ?TIME(T0),
                     ?METRIC(typecheck_time, {list_to_atom(utils:sformat("~s:~w/~w", [F(FileName), Name, Arity])), Time, error}),
-                    io:format(user,"Error: (~p) ~s:~w/~w (~p ms)~n", [Type, F(FileName), Name, Arity, Time]);
+                    io:format(user,"Error: (~p) ~s:~w/~w (~p ms)~n", [Type, F(FileName), Name, Arity, Time]),
+                    {true, {Name, Arity}};
                 _:T ->
                     Time = ?TIME(T0),
                     ?METRIC(typecheck_time, {list_to_atom(utils:sformat("~s:~w/~w", [F(FileName), Name, Arity])), Time, error}),
-                    io:format(user,"Other: (~p) ~s:~w/~w (~p ms)~n", [{T}, F(FileName), Name, Arity, Time])
+                    io:format(user,"Other: (~p) ~s:~w/~w (~p ms)~n", [{T}, F(FileName), Name, Arity, Time]),
+                    {true, {Name, Arity}}
             end
         end,
         Decls
-    ),
-    ok.
+    ).
 
 % Checks a function against its spec, skips timeouts and does not report errors.
 -spec check_report(ctx(), ast:fun_decl(), ast:ty_scheme()) -> success | timeout.

--- a/src/varenv.erl
+++ b/src/varenv.erl
@@ -45,7 +45,7 @@ insert_if_absent(Key, Val, {What, Map}) ->
 
 -spec range(t(_K, V)) -> [V].
 range({_, Map}) ->
-    lists:map(fun({_, V}) -> V end, maps:to_list(Map)).
+    lists:map(fun({_, V}) -> V end, lists:sort(maps:to_list(Map))).
 
 % Looks up a variable, undefined variables cause an error.
 -spec lookup(ast:loc(), K, t(K, V)) -> V.

--- a/test/cm_recompile_tests.erl
+++ b/test/cm_recompile_tests.erl
@@ -56,15 +56,16 @@ get_files_with_version(Dir, Version) ->
         end,
         Files).
 
--type tycheck_mode() :: tycheck | dont_tycheck.
+-type tycheck_mode() :: tycheck | dont_tycheck | report.
 
--spec run_typechecker(file:name(), tycheck_mode()) -> [file:name()].
+-spec run_typechecker(file:name(), tycheck_mode()) -> cm_check:check_list().
 run_typechecker(SrcDir, Mode) ->
     Opts = #opts{
         files = [filename:join(SrcDir, "main.erl")],
         project_root = SrcDir,
         mode = test_mode,
-        no_type_checking = (Mode =:= dont_tycheck)
+        no_type_checking = (Mode =:= dont_tycheck),
+        report_mode = case Mode of report -> report; _ -> early_exit end
     },
     etylizer_main:doWork(Opts).
 
@@ -94,7 +95,8 @@ test_recompile_version(TargetDir, Dir, Version, RebarLockContent, ExpectedChange
     file:write_file(filename:join(TargetDir, "rebar.lock"), RebarLockContent),
     RealChanges =
         try
-            run_typechecker(TargetDir, Mode)
+            CheckList = run_typechecker(TargetDir, Mode),
+            [F || {F, _} <- CheckList]
         catch throw:{etylizer, ty_error, _}:_ -> type_error
         end,
     ExpectedChangesSorted =
@@ -158,10 +160,85 @@ test_rebar_changes() ->
                 tycheck)
         end).
 
+% @doc Normalize a check_list to {BaseName, FunFilter} pairs for comparison.
+-spec normalize_check_list(cm_check:check_list()) -> [{string(), all | [{atom(), arity()}]}].
+normalize_check_list(CheckList) ->
+    Normalized = [{filename:basename(F), Funs} || {F, Funs} <- CheckList],
+    lists:sort(Normalized).
+
+% @doc Compare a detailed expected result against the actual check list.
+% Expected is either type_error, a list of filenames (file-level), or
+% a list of {filename, all | [{atom(), arity()}]} tuples (function-level).
+-type detailed_expected() :: type_error | [{string(), all | [{atom(), arity()}]}].
+-type detailed_changes_map() :: #{integer() => detailed_expected()}.
+
+-spec test_recompile_version_detailed(
+    file:name(), file:name(), integer(), string(), detailed_expected(), tycheck_mode()
+) -> ok.
+test_recompile_version_detailed(TargetDir, Dir, Version, RebarLockContent, ExpectedChanges, Mode) ->
+    ?LOG_NOTE("Testing code version ~p in ~p (detailed)", Version, Dir),
+    % cleanup of previous source files
+    {ok, ExistingFiles} = file:list_dir(TargetDir),
+    lists:foreach(
+        fun(F) ->
+            case filename:extension(F) =:= ".erl" andalso filelib:is_regular(F) of
+                true -> file:delete(F);
+                false -> ok
+            end
+        end, ExistingFiles),
+    % Copy new source files
+    Files = get_files_with_version(Dir, Version),
+    lists:foreach(fun({SrcFile,TargetFile}) ->
+            From = filename:join(Dir, SrcFile),
+            To = filename:join(TargetDir,TargetFile),
+            ?LOG_INFO("Copying ~p to ~p", From, To),
+            file:copy(From, To)
+        end, Files),
+    utils:mkdirs(filename:join(TargetDir, "_build/default/lib")),
+    file:write_file(filename:join(TargetDir, "rebar.lock"), RebarLockContent),
+    RealChanges =
+        try
+            run_typechecker(TargetDir, Mode)
+        catch throw:{etylizer, ty_error, _}:_ -> type_error
+        end,
+    case {ExpectedChanges, RealChanges} of
+        {type_error, type_error} -> ok;
+        {type_error, _} ->
+            erlang:error({expected_type_error, got, RealChanges});
+        {_, type_error} ->
+            erlang:error({expected_check_list, got, type_error});
+        _ ->
+            RealNormalized = normalize_check_list(RealChanges),
+            ExpectedSorted = lists:sort(
+                [{F, sort_fun_filter(Funs)} || {F, Funs} <- ExpectedChanges]),
+            RealSorted = [{F, sort_fun_filter(Funs)} || {F, Funs} <- RealNormalized],
+            ?assertEqual(ExpectedSorted, RealSorted)
+    end,
+    ?LOG_NOTE("Test successful for code version ~p in ~p (detailed)", Version, Dir).
+
+% @doc Sort function filter for deterministic comparison.
+-spec sort_fun_filter(all | [{atom(), arity()}]) -> all | [{atom(), arity()}].
+sort_fun_filter(all) -> all;
+sort_fun_filter(Funs) -> lists:sort(Funs).
+
+-spec test_recompile_detailed(file:name(), detailed_changes_map(), tycheck_mode()) -> ok.
+test_recompile_detailed(Dir, VersionMap, Mode) ->
+    Versions = lists:sort(maps:keys(VersionMap)),
+    tmp:with_tmp_dir(Dir, "root", delete,
+        fun(TargetDir) ->
+            lists:foreach(
+                fun(V) ->
+                    test_recompile_version_detailed(TargetDir,
+                        filename:join("test_files/recompilation/", Dir),
+                        V,
+                        "rebar.lock_1",
+                        maps:get(V, VersionMap),
+                        Mode)
+                end, Versions)
+        end).
+
 file_changes_test_() ->
-    [ 
-     % TODO building the std_symtab takes longer than 5 seconds and causes timeouts;
-     % why is symtab rebuilt everytime?
+    [
      ?_timeout(?_test(test_recompile("simple", #{1 => ["main.erl"], 2 => []}))),
      ?_timeout(?_test(test_recompile("file_changes",
         #{1 => ["bar.erl", "foo.erl", "main.erl"], 2 => ["foo.erl"]}))),
@@ -191,3 +268,67 @@ file_changes_test_() ->
      ?_timeout(?_test(test_rebar_changes()))
     ].
 
+% @doc Test function-level incremental rechecking after fixing a type error.
+% Module foo has 3 functions: safe1, safe2, broken. V1: all OK. V2: broken has type error.
+% V3: broken fixed. Only broken/0 should be rechecked in V3.
+fun_level_fix_then_recheck_test_() ->
+    [?_timeout(?_test(test_recompile_detailed("fix_then_recheck", #{
+        1 => [{"foo.erl", all}, {"main.erl", all}],
+        2 => type_error,
+        3 => [{"foo.erl", [{broken, 0}]}]
+    }, tycheck)))].
+
+% @doc Test that changing only a function body does not trigger rechecking of dependents.
+% foo has f1 (calls f2) and f2. bar has b1 (calls foo:f1). Changing f2's body (not spec)
+% should only recheck f2, not f1 or b1.
+fun_level_body_change_test_() ->
+    [?_timeout(?_test(test_recompile_detailed("body_change_no_recheck", #{
+        1 => [{"bar.erl", all}, {"foo.erl", all}, {"main.erl", all}],
+        2 => [{"foo.erl", [{f2, 0}]}]
+    }, tycheck)))].
+
+% @doc Test that changing a function's spec triggers rechecking of its dependents.
+% foo has f1. bar has b1 (calls foo:f1) and b2 (independent). Changing f1's spec
+% should recheck f1 and b1, but not b2 or main.
+fun_level_spec_change_test_() ->
+    [?_timeout(?_test(test_recompile_detailed("spec_change_recheck", #{
+        1 => [{"bar.erl", all}, {"foo.erl", all}, {"main.erl", all}],
+        2 => [{"foo.erl", [{f1, 0}]}, {"bar.erl", [{b1, 0}]}]
+    }, dont_tycheck)))].
+
+% @doc Test that a persistent type error is still detected on re-run.
+% foo has broken/0 which returns integer() instead of boolean(). Both runs
+% should produce a type error (the index is not saved after a type error,
+% so the second run rechecks everything and still fails).
+persistent_type_error_test_() ->
+    [?_timeout(?_test(test_recompile("persistent_type_error",
+        #{1 => type_error, 2 => type_error})))].
+
+% @doc Test that a failed function does not cause false caller propagation.
+% foo:broken/0 has a type error (report mode). On re-run, broken/0 is retried
+% but its spec_hash is unchanged, so bar:b1/0 (its caller) is NOT rechecked.
+failed_no_caller_recheck_test_() ->
+    [?_timeout(?_test(test_recompile_detailed("failed_no_caller_recheck", #{
+        1 => [{"bar.erl", all}, {"foo.erl", all}, {"main.erl", all}],
+        2 => [{"foo.erl", [{broken, 0}]}]
+    }, report)))].
+
+% @doc Test that modifying one function's body (adding lines) does not cause
+% other functions in the same file to be rechecked due to unstable hashes.
+% foo has f1, f2, f3. V2 changes only f1's body (adds lines, shifting f2/f3 line numbers).
+% Only f1/0 should be rechecked - f2, f3, and cross-module caller bar:b1 should not.
+body_change_hash_stable_test_() ->
+    [?_timeout(?_test(test_recompile_detailed("body_change_hash_stable", #{
+        1 => [{"bar.erl", all}, {"foo.erl", all}, {"main.erl", all}],
+        2 => [{"foo.erl", [{f1, 0}]}]
+    }, tycheck)))].
+
+% @doc Test that report mode re-detects type errors on re-run.
+% In report mode, type errors don't throw - the index is saved. Without the fix,
+% the second run would find nothing to check (empty check list). With the fix,
+% the failed function is excluded from the index and re-checked on the next run.
+report_mode_redetect_test_() ->
+    [?_timeout(?_test(test_recompile_detailed("report_mode_redetect", #{
+        1 => [{"foo.erl", all}, {"main.erl", all}],
+        2 => [{"foo.erl", [{broken, 0}]}]
+    }, report)))].

--- a/test/hash_stability_tests.erl
+++ b/test/hash_stability_tests.erl
@@ -1,0 +1,65 @@
+-module(hash_stability_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("log.hrl").
+-include("parse.hrl").
+
+% @doc Parse a file through the full pipeline (parse + AST transform) without parse cache.
+-spec parse_to_internal(file:filename()) -> ast:forms().
+parse_to_internal(File) ->
+    RawForms = parse:parse_file_or_die(File, #parse_opts{includes = ["src"]}),
+    ast_transform:trans(File, RawForms, full).
+
+% @doc Compute per-function body and spec hashes for all functions in a file.
+-spec compute_hashes(ast:forms()) -> #{{atom(), arity()} => {string(), string()}}.
+compute_hashes(Forms) ->
+    FunDecls = [F || F = {function, _, _, _, _} <- Forms],
+    lists:foldl(fun({function, _, Name, Arity, _} = FunDecl, Acc) ->
+        BodyHash = cm_fun_deps:hash_fun_body(FunDecl),
+        SpecHash = cm_fun_deps:hash_fun_spec(Name, Arity, Forms),
+        maps:put({Name, Arity}, {BodyHash, SpecHash}, Acc)
+    end, #{}, FunDecls).
+
+% @doc Compare hashes between two versions of a file and return functions with changed hashes.
+-spec changed_funs(file:filename(), file:filename()) -> [{atom(), arity(), body | spec | both}].
+changed_funs(V1File, V2File) ->
+    V1Forms = parse_to_internal(V1File),
+    V2Forms = parse_to_internal(V2File),
+    V1Hashes = compute_hashes(V1Forms),
+    V2Hashes = compute_hashes(V2Forms),
+    AllKeys = lists:usort(maps:keys(V1Hashes) ++ maps:keys(V2Hashes)),
+    lists:filtermap(fun(Key) ->
+        {Name, Arity} = Key,
+        V1Entry = maps:get(Key, V1Hashes, {"", ""}),
+        V2Entry = maps:get(Key, V2Hashes, {"", ""}),
+        {V1Body, V1Spec} = V1Entry,
+        {V2Body, V2Spec} = V2Entry,
+        BodyChanged = V1Body =/= V2Body,
+        SpecChanged = V1Spec =/= V2Spec,
+        case {BodyChanged, SpecChanged} of
+            {false, false} -> false;
+            {true, false} -> {true, {Name, Arity, body}};
+            {false, true} -> {true, {Name, Arity, spec}};
+            {true, true} -> {true, {Name, Arity, both}}
+        end
+    end, AllKeys).
+
+% Test: modifying f1's body (adding lines) must not change f2/f3's body hashes.
+% The log macros expand ?FILE and ?LINE to literal values that shift when lines
+% are added/removed above. hash_fun_body normalizes these for stable hashing.
+line_macro_hash_stability_test() ->
+    Changed = changed_funs(
+        "test_files/recompilation/body_change_hash_stable/foo_V1.erl",
+        "test_files/recompilation/body_change_hash_stable/foo_V2.erl"),
+    % Only f1 should have changed body hash, not f2 and f3
+    ?assertEqual([{f1, 0, body}], Changed).
+
+% Test: parsing the same file twice must produce identical body hashes.
+% ast_transform:rewrite_dispatched_clauses generates $dispatch variables for
+% multi-clause functions. These variable names must be deterministic — if they
+% use erlang:unique_integer, hashes differ between separate parse invocations.
+dispatch_var_hash_stability_test() ->
+    File = "test_files/recompilation/dispatch_hash_stable/foo.erl",
+    Hashes1 = compute_hashes(parse_to_internal(File)),
+    Hashes2 = compute_hashes(parse_to_internal(File)),
+    ?assertEqual(Hashes1, Hashes2).

--- a/test/index_tests.erl
+++ b/test/index_tests.erl
@@ -7,7 +7,7 @@ has_file_changed_test() ->
     TestFilePath = "./test_files/index/test/module.erl",
     RawForms = parse:parse_file_or_die(TestFilePath),
     Forms = ast_transform:trans(TestFilePath, RawForms),
-    Index = cm_index:insert(TestFilePath, Forms, {{"", ""}, maps:new()}),
+    Index = cm_index:insert(TestFilePath, Forms, [], {{"", ""}, maps:new()}),
     swap_test_files(),
     true = cm_index:has_file_changed(TestFilePath, Index),
     clean_up_test_file().
@@ -17,7 +17,7 @@ has_exported_interface_changed_test() ->
     TestFilePath = "./test_files/index/test/module.erl",
     RawForms = parse:parse_file_or_die(TestFilePath),
     Forms = ast_transform:trans(TestFilePath, RawForms),
-    Index = cm_index:insert(TestFilePath, Forms, {{"", ""}, maps:new()}),
+    Index = cm_index:insert(TestFilePath, Forms, [], {{"", ""}, maps:new()}),
     swap_test_files(),
     ChangedRawForms = parse:parse_file_or_die(TestFilePath),
     ChangedForms = ast_transform:trans(TestFilePath, ChangedRawForms),

--- a/test_files/recompilation/body_change_hash_stable/bar_V1+2.erl
+++ b/test_files/recompilation/body_change_hash_stable/bar_V1+2.erl
@@ -1,0 +1,6 @@
+-module(bar).
+
+-export([b1/0]).
+
+-spec b1() -> integer().
+b1() -> foo:f3().

--- a/test_files/recompilation/body_change_hash_stable/foo_V1.erl
+++ b/test_files/recompilation/body_change_hash_stable/foo_V1.erl
@@ -1,0 +1,12 @@
+-module(foo).
+
+-export([f1/0, f2/0, f3/0]).
+
+-spec f1() -> integer().
+f1() -> 1.
+
+-spec f2() -> integer().
+f2() -> 2.
+
+-spec f3() -> integer().
+f3() -> 3.

--- a/test_files/recompilation/body_change_hash_stable/foo_V2.erl
+++ b/test_files/recompilation/body_change_hash_stable/foo_V2.erl
@@ -1,0 +1,14 @@
+-module(foo).
+
+-export([f1/0, f2/0, f3/0]).
+
+-spec f1() -> integer().
+f1() ->
+    X = 1,
+    X + 1.
+
+-spec f2() -> integer().
+f2() -> 2.
+
+-spec f3() -> integer().
+f3() -> 3.

--- a/test_files/recompilation/body_change_hash_stable/main_V1+2.erl
+++ b/test_files/recompilation/body_change_hash_stable/main_V1+2.erl
@@ -1,0 +1,6 @@
+-module(main).
+
+-export([main/0]).
+
+-spec main() -> integer().
+main() -> foo:f2() + bar:b1().

--- a/test_files/recompilation/body_change_no_recheck/bar_V1+2.erl
+++ b/test_files/recompilation/body_change_no_recheck/bar_V1+2.erl
@@ -1,0 +1,6 @@
+-module(bar).
+
+-export([b1/0]).
+
+-spec b1() -> boolean().
+b1() -> foo:f1().

--- a/test_files/recompilation/body_change_no_recheck/foo_V1.erl
+++ b/test_files/recompilation/body_change_no_recheck/foo_V1.erl
@@ -1,0 +1,9 @@
+-module(foo).
+
+-export([f1/0, f2/0]).
+
+-spec f2() -> boolean().
+f2() -> true.
+
+-spec f1() -> boolean().
+f1() -> f2().

--- a/test_files/recompilation/body_change_no_recheck/foo_V2.erl
+++ b/test_files/recompilation/body_change_no_recheck/foo_V2.erl
@@ -1,0 +1,9 @@
+-module(foo).
+
+-export([f1/0, f2/0]).
+
+-spec f2() -> boolean().
+f2() -> false.
+
+-spec f1() -> boolean().
+f1() -> f2().

--- a/test_files/recompilation/body_change_no_recheck/main_V1+2.erl
+++ b/test_files/recompilation/body_change_no_recheck/main_V1+2.erl
@@ -1,0 +1,6 @@
+-module(main).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() -> foo:f1() and bar:b1().

--- a/test_files/recompilation/dispatch_hash_stable/foo.erl
+++ b/test_files/recompilation/dispatch_hash_stable/foo.erl
@@ -1,0 +1,11 @@
+-module(foo).
+-export([f/2, g/0]).
+
+% Multi-clause function with arity >= 2, one direct position and one complex position.
+% This triggers ast_transform:rewrite_dispatched_clauses which generates $dispatch variables.
+-spec f(integer(), {a, integer()} | {b, integer()}) -> integer().
+f(X, {a, Y}) -> X + Y;
+f(X, {b, Y}) -> X - Y.
+
+-spec g() -> integer().
+g() -> 42.

--- a/test_files/recompilation/failed_no_caller_recheck/bar_V1+2.erl
+++ b/test_files/recompilation/failed_no_caller_recheck/bar_V1+2.erl
@@ -1,0 +1,6 @@
+-module(bar).
+
+-export([b1/0]).
+
+-spec b1() -> boolean().
+b1() -> foo:broken().

--- a/test_files/recompilation/failed_no_caller_recheck/foo_V1+2.erl
+++ b/test_files/recompilation/failed_no_caller_recheck/foo_V1+2.erl
@@ -1,0 +1,9 @@
+-module(foo).
+
+-export([broken/0, safe/0]).
+
+-spec broken() -> boolean().
+broken() -> 42.
+
+-spec safe() -> boolean().
+safe() -> true.

--- a/test_files/recompilation/failed_no_caller_recheck/main_V1+2.erl
+++ b/test_files/recompilation/failed_no_caller_recheck/main_V1+2.erl
@@ -1,0 +1,6 @@
+-module(main).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() -> foo:safe() and bar:b1().

--- a/test_files/recompilation/fix_then_recheck/foo_V1.erl
+++ b/test_files/recompilation/fix_then_recheck/foo_V1.erl
@@ -1,0 +1,12 @@
+-module(foo).
+
+-export([safe1/0, safe2/0, broken/0]).
+
+-spec safe1() -> boolean().
+safe1() -> true.
+
+-spec safe2() -> integer().
+safe2() -> 42.
+
+-spec broken() -> boolean().
+broken() -> true.

--- a/test_files/recompilation/fix_then_recheck/foo_V2.erl
+++ b/test_files/recompilation/fix_then_recheck/foo_V2.erl
@@ -1,0 +1,12 @@
+-module(foo).
+
+-export([safe1/0, safe2/0, broken/0]).
+
+-spec safe1() -> boolean().
+safe1() -> true.
+
+-spec safe2() -> integer().
+safe2() -> 42.
+
+-spec broken() -> boolean().
+broken() -> 42.

--- a/test_files/recompilation/fix_then_recheck/foo_V3.erl
+++ b/test_files/recompilation/fix_then_recheck/foo_V3.erl
@@ -1,0 +1,12 @@
+-module(foo).
+
+-export([safe1/0, safe2/0, broken/0]).
+
+-spec safe1() -> boolean().
+safe1() -> true.
+
+-spec safe2() -> integer().
+safe2() -> 42.
+
+-spec broken() -> boolean().
+broken() -> false.

--- a/test_files/recompilation/fix_then_recheck/main_V1+2+3.erl
+++ b/test_files/recompilation/fix_then_recheck/main_V1+2+3.erl
@@ -1,0 +1,6 @@
+-module(main).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() -> foo:safe1().

--- a/test_files/recompilation/persistent_type_error/foo_V1+2.erl
+++ b/test_files/recompilation/persistent_type_error/foo_V1+2.erl
@@ -1,0 +1,6 @@
+-module(foo).
+
+-export([broken/0]).
+
+-spec broken() -> boolean().
+broken() -> 42.

--- a/test_files/recompilation/persistent_type_error/main_V1+2.erl
+++ b/test_files/recompilation/persistent_type_error/main_V1+2.erl
@@ -1,0 +1,6 @@
+-module(main).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() -> foo:broken().

--- a/test_files/recompilation/report_mode_redetect/foo_V1+2.erl
+++ b/test_files/recompilation/report_mode_redetect/foo_V1+2.erl
@@ -1,0 +1,9 @@
+-module(foo).
+
+-export([safe1/0, broken/0]).
+
+-spec safe1() -> boolean().
+safe1() -> true.
+
+-spec broken() -> boolean().
+broken() -> 42.

--- a/test_files/recompilation/report_mode_redetect/main_V1+2.erl
+++ b/test_files/recompilation/report_mode_redetect/main_V1+2.erl
@@ -1,0 +1,6 @@
+-module(main).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() -> foo:safe1().

--- a/test_files/recompilation/spec_change_recheck/bar_V1+2.erl
+++ b/test_files/recompilation/spec_change_recheck/bar_V1+2.erl
@@ -1,0 +1,9 @@
+-module(bar).
+
+-export([b1/0, b2/0]).
+
+-spec b1() -> boolean().
+b1() -> foo:f1().
+
+-spec b2() -> boolean().
+b2() -> true.

--- a/test_files/recompilation/spec_change_recheck/foo_V1.erl
+++ b/test_files/recompilation/spec_change_recheck/foo_V1.erl
@@ -1,0 +1,6 @@
+-module(foo).
+
+-export([f1/0]).
+
+-spec f1() -> boolean().
+f1() -> true.

--- a/test_files/recompilation/spec_change_recheck/foo_V2.erl
+++ b/test_files/recompilation/spec_change_recheck/foo_V2.erl
@@ -1,0 +1,6 @@
+-module(foo).
+
+-export([f1/0]).
+
+-spec f1() -> boolean() | integer().
+f1() -> true.

--- a/test_files/recompilation/spec_change_recheck/main_V1+2.erl
+++ b/test_files/recompilation/spec_change_recheck/main_V1+2.erl
@@ -1,0 +1,6 @@
+-module(main).
+
+-export([main/0]).
+
+-spec main() -> boolean().
+main() -> bar:b1() and bar:b2().

--- a/test_files/tycheck_simple/case_of.erl
+++ b/test_files/tycheck_simple/case_of.erl
@@ -72,12 +72,23 @@ case_09(X) ->
         _ -> 42.0
     end.
 
--spec case_10_fail(any()) -> integer().
-case_10_fail(X) ->
+% With guard BIF extension, abs is total in guards (non-numbers cause guard
+% failure). is_integer(Y) narrows Y to integer, so this passes.
+-spec case_10(any()) -> integer().
+case_10(X) ->
     case X of
-        % should fail because Y does not have type integer
-        % in the guard but abs requires a number
         Y when abs(Y) > 2 andalso is_integer(Y) -> Y;
+        _ -> 42
+    end.
+
+% not equivalent: we have no way to escape out of the inner case, not all cases are covered
+-spec case_10_equiv_fail(any()) -> integer().
+case_10_equiv_fail(X) ->
+    case X of
+        Y when abs(Y) > 2 ->
+            case Y of
+                Z when is_integer(Z) -> Z
+            end;
         _ -> 42
     end.
 
@@ -216,3 +227,85 @@ case_33_fail(F, Ref) ->
       __Z = [{Ref, _}] -> __Z; _ -> error(badarg)
   end,
   Node.
+
+% With guard BIF extension, abs is total in guards. Both branches return
+% integer literals, so this passes.
+-spec case_34(any()) -> integer().
+case_34(X) ->
+    case X of
+        Y when abs(Y) > 2 -> 2;
+        _ -> 42
+    end.
+
+-spec myabs
+(float()) -> float();
+(integer()) -> non_neg_integer();
+(etylizer:without(etylizer:without(any(), float()), integer())) -> none().
+myabs(X) -> error(err).
+
+-spec case_35_fail(any()) -> integer().
+case_35_fail(X) ->
+    myabs(X).
+
+%%%%%%%%%%%%%%%% GUARD BIF EXTENSION %%%%%%%%%%%%%%%
+
+% Guard BIFs are extended to be total on any() in guard context.
+% Non-domain inputs cause guard failure (modeled as none()).
+
+% abs(Y) in guard: Y is any(), body returns literal -> passes
+-spec guard_bif_01(any()) -> integer().
+guard_bif_01(X) ->
+    case X of
+        Y when abs(Y) > 0 -> 1;
+        _ -> 0
+    end.
+
+% abs(Y) in guard without narrowing: Y stays any(), returning Y should fail
+-spec guard_bif_02_fail(any()) -> integer().
+guard_bif_02_fail(X) ->
+    case X of
+        Y when abs(Y) > 0 -> Y;
+        _ -> 0
+    end.
+
+% hd(Y) in guard: Y is any(), body returns literal -> passes
+-spec guard_bif_03(any()) -> ok.
+guard_bif_03(X) ->
+    case X of
+        Y when hd(Y) =:= 1 -> ok;
+        _ -> ok
+    end.
+
+% length(Y) in guard: Y is any(), body returns literal -> passes
+-spec guard_bif_04(any()) -> integer().
+guard_bif_04(X) ->
+    case X of
+        Y when length(Y) > 0 -> 1;
+        _ -> 0
+    end.
+
+% abs + is_integer: guard narrows Y to integer, returning Y passes
+-spec guard_bif_05(any()) -> integer().
+guard_bif_05(X) ->
+    case X of
+        Y when abs(Y) > 0 andalso is_integer(Y) -> Y;
+        _ -> 0
+    end.
+
+% abs + is_integer reordered: is_integer before abs, should also pass
+-spec guard_bif_06(any()) -> integer().
+guard_bif_06(X) ->
+    case X of
+        Y when is_integer(Y) andalso abs(Y) > 0 -> Y;
+        _ -> 0
+    end.
+
+% Non-boolean second operand of andalso: valid Erlang (guard just fails),
+% should not be rejected. abs(Y) returns a number, not boolean, but in
+% guard context andalso doesn't require boolean operands.
+-spec guard_bif_07(any()) -> ok.
+guard_bif_07(X) ->
+    case X of
+        Y when is_integer(Y) andalso abs(Y) -> ok;
+        _ -> ok
+    end.

--- a/test_files/tycheck_simple/intersection.erl
+++ b/test_files/tycheck_simple/intersection.erl
@@ -122,11 +122,11 @@ foo4_b(X) ->
         _ -> X
     end.
 
--spec inter_with_guard_constraints_fail(any()) -> integer(); (any()) -> integer().
-inter_with_guard_constraints_fail(X) ->
+% With guard BIF extension, abs is total in guards. is_integer(Y) narrows
+% Y to integer, so this passes.
+-spec inter_with_guard_constraints(any()) -> integer(); (any()) -> integer().
+inter_with_guard_constraints(X) ->
     case X of
-        % should fail because Y does not have type integer
-        % in the guard but abs requires a number
         Y when abs(Y) > 2 andalso is_integer(Y) -> Y;
         _ -> 42
     end.

--- a/test_files/tycheck_simple/type_annotation.erl
+++ b/test_files/tycheck_simple/type_annotation.erl
@@ -54,6 +54,7 @@ assert_04(N) -> ?assert_type(N, atom()). % downcast
 -spec to_upper([byte()]) -> Result when Result :: [byte()] ; (char()) -> char().
 %-spec to_upper([byte()]) -> [byte()] ; (char()) -> char().
 to_upper(_) -> error(impl).
+
 -spec assert_05() -> nonempty_string().
 assert_05() ->
     to_upper(?assert_type("FOO", [byte()])).

--- a/typecheck_erlang_types
+++ b/typecheck_erlang_types
@@ -108,7 +108,6 @@ for file in "${files[@]}"; do
         -I ./erlang_types/dnf \
         -l error \
         --type-overlay overlays/etylizer_overlay.erl \
-        -f \
         --no-deps "$TYPE_LIB""$file" \
         $TO \
         -i 'ty_parser:convert/3' \

--- a/typecheck_erlang_types
+++ b/typecheck_erlang_types
@@ -50,7 +50,6 @@ for file in "${files[@]}"; do
         -I ./erlang_types/dnf \
         -l error \
         --type-overlay overlays/etylizer_overlay.erl \
-        -f \
         --no-deps "$TYPE_LIB""$file" \
         $TO \
         -i 'dnf_ty_function:minimize_node_dnf/1' \


### PR DESCRIPTION
function-level dependency tracking, hash-based recompilation detection.

We have one main design decision: we hash our transformed AST nodes, not raw Erlang source code. We have to make a few things sure so that the hash is stable, but overall it improves the experience of using hashing by a lot.
                                                                                                                                                                                                                    
1. Location stability: Raw Erlang AST embeds line/column numbers in every node. If you add a comment or blank line above a function, every line number shifts, changing the hash of every function below it. But we want to capture semantic changes only, or rather keep as much non-semantic syntax changes out of the hash.
2. Macro normalization: Erlang macros like ?FILE and ?LINE expand to literal file paths and line numbers. The ?LOG_* macros (which expand to log:macro_log/5 calls) embed these. Adding lines anywhere in the file changes ?LINE expansions in unrelated functions. normalize_macro_args replaces these with constants before hashing.
3. Resolved references: After ast_transform, function references are resolved to {ref, Name, Arity} and {qref, Mod, Name, Arity} forms. This is what the type checker actually operates on, so hashing this representation means the hash reflects what the checker sees.