### PR TITLE
Drop expensive Unconstrained and Meaningful poly_var stats

### DIFF
--- a/ety_metrics_report
+++ b/ety_metrics_report
@@ -120,27 +120,24 @@ print_time_section(Title, Unit, PrEntries, BaseEntries, HasBase) ->
 
 poly_stats([]) ->
     Z = #{total => 0, avg => 0.0, min => 0, max => 0},
-    #{invocations => 0, poly => Z, mono_used => Z, mono_unused => Z, meaningful => Z, unconstrained => Z};
+    #{invocations => 0, poly => Z, mono_used => Z, mono_unused => Z};
 poly_stats(Entries) ->
-    Polys = [P || [P, _, _, _, _] <- Entries],
-    MonoUsed = [U || [_, U, _, _, _] <- Entries],
-    MonoUnused = [X || [_, _, X, _, _] <- Entries],
-    Meaningful = [M || [_, _, _, M, _] <- Entries],
-    Unconstrained = [R || [_, _, _, _, R] <- Entries],
+    Polys = [P || [P, _, _ | _] <- Entries],
+    MonoUsed = [U || [_, U, _ | _] <- Entries],
+    MonoUnused = [X || [_, _, X | _] <- Entries],
     N = length(Entries),
     Calc = fun(Vs) ->
         #{total => lists:sum(Vs), avg => lists:sum(Vs) / max(1, N),
           min => lists:min(Vs), max => lists:max(Vs)}
     end,
     #{invocations => N, poly => Calc(Polys),
-      mono_used => Calc(MonoUsed), mono_unused => Calc(MonoUnused),
-      meaningful => Calc(Meaningful), unconstrained => Calc(Unconstrained)}.
+      mono_used => Calc(MonoUsed), mono_unused => Calc(MonoUnused)}.
 
 print_poly_section(Title, PrEntries, BaseEntries, HasBase) ->
     PrS = poly_stats(PrEntries),
     io:format("## ~s~n~n", [Title]),
-    Cats = [poly, mono_used, mono_unused, meaningful, unconstrained],
-    CatNames = ["Poly", "Mono (used)", "Mono (unused)", "Meaningful", "Unconstrained"],
+    Cats = [poly, mono_used, mono_unused],
+    CatNames = ["Poly", "Mono (used)", "Mono (unused)"],
     case HasBase of
         true ->
             BaseS = poly_stats(BaseEntries),

--- a/src/tally.erl
+++ b/src/tally.erl
@@ -16,39 +16,13 @@
 -export_type([monomorphic_variables/0]).
 
 -ifdef(ety_metrics).
-var_metrics(FixedVars, Constraints, SymTab) ->
+var_metrics(FixedVars, Constraints, _SymTab) ->
     AllVars = sets:from_list(utils:everything(
         fun({var, V}) when is_atom(V) -> {ok, V}; (_) -> error end, Constraints)),
     MonoUsed = sets:size(sets:intersection(AllVars, FixedVars)),
     MonoUnused = sets:size(FixedVars) - MonoUsed,
     Poly = sets:size(AllVars) - MonoUsed,
-    PolyVars = sets:subtract(AllVars, FixedVars),
-    Types = lists:flatmap(fun({S, T}) -> [S, T] end, Constraints),
-    Meaningful = sets:size(sets:filter(fun(Alpha) ->
-        Subst = #{Alpha => {predef, none}},
-        lists:any(fun(T) ->
-            T2 = subst:apply_base(Subst, T),
-            not subty:is_equivalent(SymTab, T, T2)
-        end, Types)
-    end, PolyVars)),
-    %% Unconstrained: poly vars where both α→⊥ and α→⊤ preserve satisfiability
-    MonoMap = maps:from_list([{ty_variable:new_with_name(V), []} || V <- sets:to_list(FixedVars)]),
-    Unconstrained = sets:size(sets:filter(fun(Alpha) ->
-        SubstBot = #{Alpha => {predef, none}},
-        SubstTop = #{Alpha => {predef, any}},
-        ConsBot = [{subst:apply_base(SubstBot, S), subst:apply_base(SubstBot, T)} || {S, T} <- Constraints],
-        ConsTop = [{subst:apply_base(SubstTop, S), subst:apply_base(SubstTop, T)} || {S, T} <- Constraints],
-        MonoWithAlpha = maps:put(ty_variable:new_with_name(Alpha), [], MonoMap),
-        case do_satisfiable(ConsBot, MonoWithAlpha) of
-            {false, _} -> false;
-            {true, _} ->
-                case do_satisfiable(ConsTop, MonoWithAlpha) of
-                    {false, _} -> false;
-                    {true, _} -> true
-                end
-        end
-    end, PolyVars)),
-    {Poly, MonoUsed, MonoUnused, Meaningful, Unconstrained}.
+    {Poly, MonoUsed, MonoUnused}.
 -endif.
 
 -type monomorphic_variables() :: sets:set(ast:ty_varname()).


### PR DESCRIPTION
The per-poly-var do_satisfiable and is_equivalent calls in var_metrics/3 caused tally invocations to balloon each time the metrics build was used. This made functions like intersection:scrutiny_with_redundant_branch_local_fun/1 take >60s under report_typecheck despite completing in <1s under eunit (no ety_metrics).

Since the stats are mostly used to guard against regressions and measure performance improvements, we want it to be more stable, thus we'll remove the expensive metrics computation for now. Tracked in #350.

