### PR TITLE
Native `ty_node` substitution

### DIFF
--- a/overlays/etylizer_overlay.erl
+++ b/overlays/etylizer_overlay.erl
@@ -99,6 +99,8 @@
 'maps:merge'(_, _) -> error(badarg).
 -spec 'maps:map'(fun((Key, Value1) -> Value2), #{Key => Value1}) -> #{Key => Value2}.
 'maps:map'(_, _) -> error(overlay).
+-spec 'maps:update_with'(Key, fun((Value) -> Value), Value, #{Key => Value}) -> #{Key => Value}.
+'maps:update_with'(_, _, _, _) -> error(overlay).
 -spec 'maps:find'(Key, #{Key => Value}) -> {ok, Value} | error.
 'maps:find'(_, _) -> error(overlay).
 

--- a/src/erlang_types/dnf/bdd.hrl
+++ b/src/erlang_types/dnf/bdd.hrl
@@ -20,7 +20,8 @@
     normalize/3,
     unparse/2,
     all_variables/2,
-    has_negative_only_line/1
+    has_negative_only_line/1,
+    substitute/3
 ]).
 
 -include("erlang_types.hrl").
@@ -338,3 +339,29 @@ minimize_node_dnf(Dnf) ->
 has_negative_only_line(T) ->
     D = minimize_dnf(T),
     lists:any(fun({[], [_|_], _}) -> true; (_) -> false end, D).
+
+% Generic BDD substitution
+% LeafFun rewrites a leaf
+% AtomFun maps an atom to a replacement BDD
+-spec substitute_bdd(bdd(), fun((?LEAF:type()) -> ?LEAF:type()),
+                            fun((?ATOM:type()) -> bdd())) -> bdd().
+substitute_bdd({leaf, L}, LeafFun, _AtomFun) -> {leaf, LeafFun(L)};
+substitute_bdd({node, Atom, P, N}, LeafFun, AtomFun) ->
+    P2 = substitute_bdd(P, LeafFun, AtomFun),
+    N2 = substitute_bdd(N, LeafFun, AtomFun),
+    AtomBdd = AtomFun(Atom),
+    union(intersect(AtomBdd, P2), difference(N2, AtomBdd)).
+
+% Default substitute/3 for atom BDDs
+%
+% The Sigma argument is unused here and exists only for
+% signature-uniformity with the variable BDD, which substitutes variables and
+% supplies its own substitute/3 (it sets VARIABLE_BDD to suppress this default).
+% Atom BDDs are always called with an empty Sigma.
+-ifndef(VARIABLE_BDD).
+-spec substitute(bdd(), #{}, #{ty_node:type() => ty_node:type()}) -> bdd().
+substitute(BDD, _Sigma, NodeMap) ->
+    substitute_bdd(BDD,
+        fun(Leaf) -> ?LEAF:substitute(Leaf, NodeMap) end,
+        fun(Atom) -> singleton(?ATOM:substitute(Atom, NodeMap)) end).
+-endif.

--- a/src/erlang_types/dnf_ty_variable.erl
+++ b/src/erlang_types/dnf_ty_variable.erl
@@ -18,6 +18,9 @@
 
 -define(ATOM, ty_variable).
 -define(LEAF, ty_rec).
+% the variable BDD substitutes variables, so it supplies its own substitute/3
+% instead of the node-remapping default in bdd.hrl
+-define(VARIABLE_BDD, true).
 
 -include("dnf/bdd.hrl").
 
@@ -129,3 +132,19 @@ all_variables_line(P, N, Leaf, Cache) ->
               sets:from_list(N),
               ty_rec:all_variables(Leaf, Cache)
              ]).
+
+% Substitute variables (Sigma) and node references (NodeMap) in this BDD. 
+% Sigma maps a ty_variable to the ty_node whose BDD replaces it
+% NodeMap remaps the ty_nodes referenced in the ty_rec leaves. 
+% Shares the generic traversal with the atom BDDs in bdd.hrl.
+-spec substitute(bdd(), #{variable() => ty_node:type()}, #{ty_node:type() => ty_node:type()}) -> bdd().
+substitute(BDD, Sigma, NodeMap) ->
+  substitute_bdd(BDD,
+    fun(Leaf) -> ty_rec:substitute(Leaf, NodeMap) end,
+    fun(Var) ->
+      case maps:find(Var, Sigma) of
+        {ok, TNode} -> ty_node:load(TNode);
+        error -> singleton(Var)
+      end
+    end).
+

--- a/src/erlang_types/ty_bool.erl
+++ b/src/erlang_types/ty_bool.erl
@@ -16,7 +16,8 @@
   is_empty/2,
   normalize/3,
   unparse/2,
-  all_variables/2
+  all_variables/2,
+  substitute/2
 ]).
 -export_type([type/0]).
 
@@ -46,6 +47,9 @@ is_any(1) -> true; is_any(_) -> false.
 is_empty(0, S) -> {true, S}; is_empty(_, S) -> {false, S}.
 -spec all_variables(type(), _) -> sets:set().
 all_variables(_, _) -> sets:new().
+% a 0/1 terminal carries no ty_node references, so substitution is a no-op
+-spec substitute(type(), #{ty_node:type() => ty_node:type()}) -> type().
+substitute(B, _NodeMap) -> B.
 -spec unparse(type(), T) -> {ast_ty(), T}.
 unparse(0, C) -> {{predef, none}, C};
 unparse(1, C) -> {{predef, any}, C}.

--- a/src/erlang_types/ty_function.erl
+++ b/src/erlang_types/ty_function.erl
@@ -11,7 +11,8 @@
   domain/1,
   codomain/1,
   unparse/2,
-  all_variables/2
+  all_variables/2,
+  substitute/2
 ]).
 
 -export_type([type/0]).
@@ -63,3 +64,9 @@ all_variables({ty_function, Domains, Codomain}, Cache) ->
      [ty_node:all_variables(F, Cache) || F <- Domains]
   ++ [ty_node:all_variables(Codomain, Cache)]
   ).
+
+-spec substitute(type(), #{?NODE:type() => ?NODE:type()}) -> type().
+substitute({ty_function, Domains, Codomain}, NodeMap) ->
+  NewDomains = [maps:get(D, NodeMap, D) || D <- Domains],
+  NewCodomain = maps:get(Codomain, NodeMap, Codomain),
+  {ty_function, NewDomains, NewCodomain}.

--- a/src/erlang_types/ty_list.erl
+++ b/src/erlang_types/ty_list.erl
@@ -4,6 +4,7 @@
   equal/2,
   compare/2,
   unparse/2,
+  substitute/2,
   list/1
 ]).
 
@@ -29,6 +30,9 @@ compare(A, B) -> ty_tuple:compare(A, B).
 
 -spec equal(type(), type()) -> boolean().
 equal(P1, P2) -> ty_tuple:equal(P1, P2).
+
+-spec substitute(type(), #{ty_node:type() => ty_node:type()}) -> type().
+substitute(T, NodeMap) -> ty_tuple:substitute(T, NodeMap).
 
 -spec unparse(type(), T) -> {ast_ty(), T} when T :: unparse_cache().
 unparse({ty_tuple, 2, [List, Termination]}, ST0) ->

--- a/src/erlang_types/ty_map.erl
+++ b/src/erlang_types/ty_map.erl
@@ -4,7 +4,8 @@
   equal/2,
   compare/2,
   map/2,
-  unparse/2
+  unparse/2,
+  substitute/2
 ]).
 
 % invariants
@@ -21,6 +22,9 @@ compare(A, B) -> ty_tuple:compare(A, B).
 
 -spec equal(type(), type()) -> boolean().
 equal(A, B) -> compare(A, B) == eq.
+
+-spec substitute(type(), #{ty_node:type() => ty_node:type()}) -> type().
+substitute(T, NodeMap) -> ty_tuple:substitute(T, NodeMap).
 
 -spec map(N, N) -> type() when N :: ty_node:type().
 map(TupPart, FunPart) -> ty_tuple:tuple([TupPart, FunPart]).

--- a/src/erlang_types/ty_node.erl
+++ b/src/erlang_types/ty_node.erl
@@ -376,25 +376,208 @@ unparse(Node = {node, Id}, Cache) ->
   end.
 
 % ===
-% substitution
+% Native substitution on the internal BDD representation.
+% Unlike the old unparse/parse hack, this preserves frame variable identities,
+% which avoids the proliferation of fresh frame variables across substitution
+% rounds (e.g. inside etally:unify).
 % ===
-% FIXME hack: unparse, substitute, then parse again
 -spec substitute(type(), #{variable() => type()}) -> type().
 substitute(Node, Varmap) ->
-  T1 = ty_parser:unparse(Node),
-  % Filter out frame variables (dynamic()) which unparse to {predef, dynamic} instead of {var, _}
-  Subst =
-   maps:fold(
+  % Filter out frame variables TODO crash instead, caller should not use frame vars
+  Sigma = maps:fold(
     fun(K, V, Acc) ->
             case ty_variable:is_frame(K) of
                 {true, _} -> Acc;
-                {false, NotFrame} ->
-                    {{var, Name}, _} = ty_variable:unparse(NotFrame, #{}),
-                    Acc#{Name => ty_parser:unparse(V)}
+                {false, _} -> Acc#{K => V}
             end
     end, #{}, Varmap),
-  Res = subst:apply(Subst, T1, no_clean),
-  ty_parser:parse(Res).
+  case maps:size(Sigma) of
+    0 -> Node;
+    _ -> do_substitute(Node, Sigma)
+  end.
+
+-spec do_substitute(type(), #{variable() => type()}) -> type().
+do_substitute(Node, Sigma) ->
+  Dom = sets:from_list(maps:keys(Sigma)),
+  % Walk reachable nodes; only those whose variable set intersects dom(Sigma) need substitution.
+  NeedsSub = collect_needs_sub(Node, Dom),
+  case maps:is_key(Node, NeedsSub) of
+    false -> Node;
+    true ->
+      % Pre-allocate fresh ty_node IDs as placeholders. The two-phase scheme
+      % lets us handle recursive references: cycles in the substitution image
+      % loop back to the new placeholders.
+      Placeholders = maps:map(fun(_K, _V) -> new_ty_node() end, NeedsSub),
+      % Compute the substituted body for each placeholder. 
+      % Reorder to restore the BDD invariant
+      Bodies0 = maps:fold(
+        fun(OldNode, Placeholder, Acc) ->
+          OldBdd = load(OldNode),
+          NewBdd = dnf_ty_variable:substitute(OldBdd, Sigma, Placeholders),
+          Acc#{Placeholder => dnf_ty_variable:reorder(NewBdd)}
+        end, #{}, Placeholders),
+      StartRef = maps:get(Node, Placeholders),
+      % Topological define-with-consing. Without this, every call would leak
+      % fresh ty_node IDs that already exist globally, defeating consing.
+      unify_and_define(StartRef, Bodies0)
+  end.
+
+% Returns the consed/defined ty_node for StartRef after reusing globally
+% consed nodes (and run-local equivalents) wherever possible.
+-spec unify_and_define(type(), #{type() => type_descriptor()}) -> type().
+unify_and_define(StartRef, Bodies) ->
+  {DefineOrder, RevGraph} = topo_sccs(Bodies),
+  {FinalStartRef, FinalBodies} = consing_pass(DefineOrder, RevGraph, StartRef, Bodies),
+  define_remaining(FinalBodies),
+  FinalStartRef.
+
+% Build the dependency graph (only edges within Bodies; external refs need no
+% ordering), compute SCCs, and return them in reverse-topological order along
+% with the reverse graph (for back-reference rewriting).
+-spec topo_sccs(#{type() => type_descriptor()}) -> {[[type()]], #{type() => [type()]}}.
+topo_sccs(Bodies) ->
+  KeySet = sets:from_list(maps:keys(Bodies)),
+  Graph = build_internal_graph(Bodies, KeySet),
+  RevGraph = tarjan:reverse_graph(Graph),
+  % tarjan widens Node to term(); we know inputs are type(), so re-tag.
+  {SCCsRaw, CondensedRaw} = tarjan:condense(Graph),
+  SCCs = ?assert_type(SCCsRaw, #{type() => type()}),
+  Condensed = ?assert_type(CondensedRaw, #{type() => [type()]}),
+  Components = group_components(SCCs),
+  Sort = ?assert_type(tarjan:dfs(Condensed), [type()]),
+  DefineOrder = [maps:get(R, Components) || R <- Sort],
+  {DefineOrder, RevGraph}.
+
+-spec build_internal_graph(#{type() => type_descriptor()}, sets:set(type())) ->
+    #{type() => [type()]}.
+build_internal_graph(Bodies, KeySet) ->
+  maps:fold(
+    fun(R, B, Acc) ->
+      Internal = [C || C <- collect_node_refs(B), sets:is_element(C, KeySet)],
+      Acc#{R => lists:usort(Internal)}
+    end, #{}, Bodies).
+
+-spec group_components(#{type() => type()}) -> #{type() => [type()]}.
+group_components(SCCs) ->
+  Acc0 = ?assert_type(#{}, #{type() => [type()]}),
+  lists:foldl(
+    fun({N, Root}, Acc) ->
+      maps:update_with(Root, fun(Ns) -> [N | Ns] end, [N], Acc)
+    end, Acc0, lists:sort(maps:to_list(SCCs))).
+
+% Walk SCCs in topological order, redirecting nodes whose body is already
+% globally consed (or appeared earlier in this run).
+-spec consing_pass([[type()]], #{type() => [type()]}, type(),
+                   #{type() => type_descriptor()}) ->
+    {type(), #{type() => type_descriptor()}}.
+consing_pass(DefineOrder, RevGraph, StartRef, Bodies) ->
+  LocalDefs0 = ?assert_type(#{}, #{type_descriptor() => type()}),
+  {S, B, _} = lists:foldl(
+    fun(SCC, Acc) -> process_scc(SCC, RevGraph, Acc) end,
+    {StartRef, Bodies, LocalDefs0},
+    DefineOrder),
+  {S, B}.
+
+-spec define_remaining(#{type() => type_descriptor()}) -> ok.
+define_remaining(Bodies) ->
+  maps:foreach(
+    fun(Ref, Body) ->
+      case is_defined(Ref) of
+        true -> ok;
+        false -> define(Ref, Body), ok
+      end
+    end, Bodies).
+
+% Process one SCC: for each node, try to globally cons; if hit, redirect.
+-spec process_scc([type()], #{type() => [type()]},
+                  {type(), #{type() => type_descriptor()}, #{type_descriptor() => type()}}) ->
+    {type(), #{type() => type_descriptor()}, #{type_descriptor() => type()}}.
+process_scc(SCC, RevGraph, Acc) ->
+  lists:foldl(
+    fun(ToDefine, {StartRef, Bodies, LocalDefs}) ->
+      case is_defined(ToDefine) of
+        true ->
+          % Could happen if our pre-allocated ID collided with prior state;
+          % shouldn't, but be defensive.
+          {StartRef, Bodies, LocalDefs};
+        false ->
+          case maps:find(ToDefine, Bodies) of
+            error ->
+              % Already redirected in an earlier iteration of this SCC.
+              {StartRef, Bodies, LocalDefs};
+            {ok, Body} ->
+              case is_consed_local_or_global(Body, LocalDefs) of
+                {true, ExistingNode} ->
+                  redirect_to_existing(ToDefine, ExistingNode, StartRef, Bodies, LocalDefs, RevGraph);
+                false ->
+                  {StartRef, Bodies, LocalDefs#{Body => ToDefine}}
+              end
+          end
+      end
+    end, Acc, SCC).
+
+-spec is_consed_local_or_global(type_descriptor(), #{type_descriptor() => type()}) ->
+    {true, type()} | false.
+is_consed_local_or_global(Body, LocalDefs) ->
+  case is_consed(Body) of
+    {true, N} -> {true, N};
+    false ->
+      case LocalDefs of
+        #{Body := N} -> {true, N};
+        _ -> false
+      end
+  end.
+
+-spec redirect_to_existing(type(), type(), type(),
+                           #{type() => type_descriptor()},
+                           #{type_descriptor() => type()},
+                           #{type() => [type()]}) ->
+    {type(), #{type() => type_descriptor()}, #{type_descriptor() => type()}}.
+redirect_to_existing(ToDefine, ExistingNode, StartRef, Bodies, LocalDefs, RevGraph) ->
+  Bodies1 = maps:remove(ToDefine, Bodies),
+  % Rewrite bodies that contained ToDefine to reference ExistingNode instead.
+  ContainedIn = maps:get(ToDefine, RevGraph, []),
+  Bodies2 = lists:foldl(
+    fun(E, Acc) ->
+      case maps:find(E, Acc) of
+        error -> Acc;
+        {ok, Val} ->
+          NewVal = utils:replace(Val, #{ToDefine => ExistingNode}),
+          Acc#{E => dnf_ty_variable:reorder(NewVal)}
+      end
+    end, Bodies1, ContainedIn),
+  NewStartRef = case StartRef of ToDefine -> ExistingNode; _ -> StartRef end,
+  {NewStartRef, Bodies2, LocalDefs}.
+
+% Walk all reachable nodes; return a map keyed by ty_node of the ones whose
+% transitive variable set intersects Dom (i.e. those that need a substituted copy).
+-spec collect_needs_sub(type(), sets:set(variable())) -> #{type() => true}.
+collect_needs_sub(Node, Dom) ->
+  do_collect_needs_sub([Node], #{}, Dom, #{}).
+
+-spec do_collect_needs_sub([type()], #{type() => boolean()}, sets:set(variable()), #{type() => true}) ->
+    #{type() => true}.
+do_collect_needs_sub([], _Visited, _Dom, Acc) -> Acc;
+do_collect_needs_sub([N | Rest], Visited, Dom, Acc) ->
+  case Visited of
+    #{N := _} -> do_collect_needs_sub(Rest, Visited, Dom, Acc);
+    _ ->
+      Vars = all_variables(N),
+      case sets:size(sets:intersection(Vars, Dom)) of
+        0 ->
+          do_collect_needs_sub(Rest, Visited#{N => true}, Dom, Acc);
+        _ ->
+          Body = load(N),
+          Children = collect_node_refs(Body),
+          do_collect_needs_sub(Rest ++ Children, Visited#{N => true}, Dom, Acc#{N => true})
+      end
+  end.
+
+-spec collect_node_refs(type_descriptor()) -> [type()].
+collect_node_refs(Body) ->
+  utils:everything(
+    fun(E = {node, Id}) when is_integer(Id) -> {ok, E}; (_) -> error end,
+    Body).
 
 -spec all_variables(type()) -> sets:set(variable()).
 all_variables(Ty) ->

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -28,7 +28,8 @@
   map/1,
 
   tuple_to_map/1,
-  is_literal_empty/1
+  is_literal_empty/1,
+  substitute/2
 ]).
 
 -export_type([type/0, type_record/0]).
@@ -360,6 +361,24 @@ bitstring(A) -> (empty0())#ty{dnf_ty_bitstring = A}.
 
 -spec map(dnf_ty_map:type()) -> type().
 map(A) -> (empty0())#ty{dnf_ty_map = A}.
+
+-spec substitute(type(), #{ty_node:type() => ty_node:type()}) -> type().
+substitute(any, _NodeMap) -> any;
+substitute(empty, _NodeMap) -> empty;
+substitute(#ty{
+    dnf_ty_predefined = P, dnf_ty_atom = A, dnf_ty_interval = I, dnf_ty_list = L,
+    dnf_ty_bitstring = B, ty_tuples = T, ty_functions = F, dnf_ty_map = M
+}, NodeMap) ->
+    simpl_to_repr(#ty{
+        dnf_ty_predefined = P,
+        dnf_ty_atom = A,
+        dnf_ty_interval = I,
+        dnf_ty_list = dnf_ty_list:substitute(L, #{}, NodeMap),
+        dnf_ty_bitstring = B,
+        ty_tuples = ty_tuples:substitute(T, NodeMap),
+        ty_functions = ty_functions:substitute(F, NodeMap),
+        dnf_ty_map = dnf_ty_map:substitute(M, #{}, NodeMap)
+    }).
 
 % Converter used by ty_parser
 % to convert from a map encoded in the 2-arity tuple part to the map part

--- a/src/erlang_types/ty_tuple.erl
+++ b/src/erlang_types/ty_tuple.erl
@@ -9,7 +9,8 @@
   all_variables/2,
   unparse/2,
   big_intersect/1,
-  components/1
+  components/1,
+  substitute/2
 ]).
 
 -export_type([type/0]).
@@ -66,4 +67,8 @@ unparse({ty_tuple, _, Refs}, ST0) ->
                  Refs
                 ),
   {{tuple, All}, ST3}.
+
+-spec substitute(type(), #{?NODE:type() => ?NODE:type()}) -> type().
+substitute({ty_tuple, Dim, Refs}, NodeMap) ->
+  {ty_tuple, Dim, [maps:get(R, NodeMap, R) || R <- Refs]}.
 

--- a/src/erlang_types/utils/multi_arity.hrl
+++ b/src/erlang_types/utils/multi_arity.hrl
@@ -25,7 +25,8 @@
   normalize/3,
   unparse/2,
   all_variables/2,
-  has_negative_only_line/1
+  has_negative_only_line/1,
+  substitute/2
 ]).
 
 -spec reorder(X) -> X when X :: type().
@@ -184,3 +185,8 @@ has_negative_only_line({Default, All}) ->
   ?MULTIARITY:has_negative_only_line(Default) 
   orelse
   lists:any(fun({_, M}) -> ?MULTIARITY:has_negative_only_line(M) end, maps:to_list(All)).
+
+-spec substitute(type(), #{ty_node:type() => ty_node:type()}) -> type().
+substitute({Default, All}, NodeMap) ->
+  {?MULTIARITY:substitute(Default, #{}, NodeMap),
+   maps:map(fun(_K, V) -> ?MULTIARITY:substitute(V, #{}, NodeMap) end, All)}.


### PR DESCRIPTION
Implement ty_node:substitute/2 natively on the internal BDD. Some optimization introduce regressions on performance, because `dynamic()` could be used more often than before. The roundtrip unparse -> parse when doing substitution then introduces a lot of frame variables, which exponentially slows down the tally solver. One example that triggers after optimization: `dyn_union_case_01 (infer)` 15s -> 0.024s.

The implementation uses the same concepts that `ty_parser` uses, minus the local unification.

A positive side-effect is that the inference test suite uses now half the time it used to.