### PR TITLE
Bug fixes for case study

### DIFF
--- a/overlays/etylizer_overlay.erl
+++ b/overlays/etylizer_overlay.erl
@@ -103,6 +103,21 @@
 'maps:update_with'(_, _, _, _) -> error(overlay).
 -spec 'maps:find'(Key, #{Key => Value}) -> {ok, Value} | error.
 'maps:find'(_, _) -> error(overlay).
+-spec 'maps:get'(Key, #{Key => Value}, Value) -> Value.
+'maps:get'(_, _, _) -> error(overlay).
+-spec 'maps:keys'(#{Key => _Value}) -> [Key].
+'maps:keys'(_) -> error(overlay).
+-spec 'maps:values'(#{_Key => Value}) -> [Value].
+'maps:values'(_) -> error(overlay).
+-spec 'maps:size'(#{_Key => _Value}) -> non_neg_integer().
+'maps:size'(_) -> error(overlay).
+-spec 'maps:without'([Key], #{Key => Value}) -> #{Key => Value}.
+'maps:without'(_, _) -> error(overlay).
+-spec 'maps:update_with'(Key, fun((Value) -> Value), Value, #{Key => Value}) ->
+    #{Key => Value}.
+'maps:update_with'(_, _, _, _) -> error(overlay).
+-spec 'maps:foreach'(fun((Key, Value) -> _), #{Key => Value}) -> ok.
+'maps:foreach'(_, _) -> error(overlay).
 
 % filename overlays
 -spec 'filename:join'(string(), string()) -> string().

--- a/overlays/etylizer_overlay.erl
+++ b/overlays/etylizer_overlay.erl
@@ -113,9 +113,6 @@
 'maps:size'(_) -> error(overlay).
 -spec 'maps:without'([Key], #{Key => Value}) -> #{Key => Value}.
 'maps:without'(_, _) -> error(overlay).
--spec 'maps:update_with'(Key, fun((Value) -> Value), Value, #{Key => Value}) ->
-    #{Key => Value}.
-'maps:update_with'(_, _, _, _) -> error(overlay).
 -spec 'maps:foreach'(fun((Key, Value) -> _), #{Key => Value}) -> ok.
 'maps:foreach'(_, _) -> error(overlay).
 

--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -1061,7 +1061,9 @@ trans_map_assoc(Ctx, Env, Assoc) ->
 
 % Expands record_field_other (the _ = Expr syntax) into individual record_field entries
 % for each field not explicitly given. The record_field_other entry is removed.
--spec expand_record_field_other(ctx(), atom(), [ast:exp_record_create_field()]) ->
+-spec expand_record_field_other(ctx(), atom(),
+    [{record_field, ast:loc(), atom(), ast:exp()}
+     | {record_field_other, ast:loc(), ast:exp()}]) ->
     [{record_field, ast:loc(), atom(), ast:exp()}].
 expand_record_field_other(Ctx, RecName, Fields) ->
     % Split into explicit fields and the optional wildcard

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -39,7 +39,7 @@ compute_search_path(Opts) ->
     {OtpPaths, OtpIncDirs} = find_otp_paths(),
     {DepPaths, DepIncDirs} = find_dependency_roots(RootDir, OtpIncDirs),
     ImplicitDirs = lists:map(fun(F) -> filename:dirname(F) end, Opts#opts.files),
-    SrcDirs = ImplicitDirs ++ Opts#opts.src_paths,
+    SrcDirs = ImplicitDirs ++ Opts#opts.src_paths ++ Opts#opts.includes,
     LocalIncDirs =
         Opts#opts.includes ++
         Opts#opts.src_paths ++

--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -70,7 +70,7 @@ is_tlist({improper_list, _, _}) -> true;
 is_tlist({negation, {improper_list, _, _}}) -> true;
 is_tlist(_) -> false.
 
--spec tmu(ast:ty_var(), ast:ty()) -> ast:ty().
+-spec tmu(ast:ty_mu_var(), ast:ty()) -> ast:ty().
 tmu(Var,Ty) -> {mu, Var, Ty}.
 
 -spec tinter([ast:ty()]) -> ast:ty().

--- a/src/typing_common.erl
+++ b/src/typing_common.erl
@@ -23,7 +23,7 @@ format_src_loc({loc, File, LineNo, ColumnNo}) ->
             if
                 LineNo >= 1 andalso LineNo =< N ->
                     Line = string:trim(lists:nth(LineNo, ?assert_type(Lines, nonempty_list(string()))), trailing),
-                    ColumnSpace = lists:duplicate(?assert_type(ColumnNo - 1, non_neg_integer()), $\s),
+                    ColumnSpace = lists:duplicate(?assert_type(max(0, ColumnNo - 1), non_neg_integer()), $\s),
                     utils:sformat("%~5.B| ~s~n%     | ~s^", LineNo, Line, ColumnSpace);
                 true ->
                     ErrMsg

--- a/src/utils.erl
+++ b/src/utils.erl
@@ -355,11 +355,6 @@ replace_term({node, _} = Ref, Mapping) ->
         {ok, NewTerm} -> NewTerm;
         error -> Ref
     end;
-replace_term({local_ref, _} = Ref, Mapping) ->
-    case maps:find(Ref, Mapping) of
-        {ok, NewTerm} -> NewTerm;
-        error -> Ref
-    end;
 replace_term(Tuple, Mapping) when is_tuple(Tuple) ->
     list_to_tuple([replace_term(Element, Mapping) || Element <- tuple_to_list(Tuple)]);
 replace_term([H|T], Mapping) ->

--- a/test_files/tycheck_simple/special.erl
+++ b/test_files/tycheck_simple/special.erl
@@ -39,3 +39,12 @@ error04(_) -> ok.
 error05(1) -> error(impl);
 error05(2) -> ok;
 error05(_) -> error(badarg).
+
+%% Regression test for an optimization that was dropped.
+%% Local stand-in for maps:fold/3
+-spec my_fold(fun((K, V, Acc) -> Acc), Acc, #{K => V}) -> Acc.
+my_fold(_F, Init, _M) -> Init.
+
+-spec hof_value_tuple_pat(dynamic()) -> dynamic().
+hof_value_tuple_pat(M) ->
+    my_fold(fun(_K, {_, _, Xs}, _Acc) -> Xs ++ Xs end, [], M).


### PR DESCRIPTION
Fixed various bugs needed to do a proper case study.
  
* Some AST bugs fixed
* type overlay for maps extended
* stdtypes: fix `tmu` to destructure `{var, Name}` into `{mu_var, Name}` (a33296a2)
* module lookup also searches `-I` SrcDirs, not just `-S` (e6ff9878)
* clamp `ColumnNo - 1` at 0 to avoid `lists:duplicate/-1` crash on column-0 errors (706e7b55)