### PR TITLE
Prototype: erlang message types

### DIFF
--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -120,6 +120,66 @@ trans_form(Ctx, Form, Mode) ->
                         {attribute, to_loc(Ctx, Anno), etylizer, EtylizerOpt};
                     {functions_redundant, off, _Funs} ->
                         {attribute, to_loc(Ctx, Anno), etylizer, EtylizerOpt};
+                    {msg_type, FunName, Arity, TypeStrs, noexhaustiveness}
+                            when is_atom(FunName), is_integer(Arity),
+                                 is_list(TypeStrs), TypeStrs =/= [],
+                                 is_list(hd(TypeStrs)) ->
+                        % List form with noexhaustiveness flag.
+                        Loc = to_loc(Ctx, Anno),
+                        FunTys = lists:map(
+                            fun(TyStr) ->
+                                case parse_type(Ctx, TyStr) of
+                                    {ok, Ty = {fun_full, _, _}} -> Ty;
+                                    {ok, Ty} -> {fun_full, [Ty], {predef, any}};
+                                    error ->
+                                        errors:ty_error(Loc,
+                                            "Invalid type in msg_type list: ~s", [TyStr])
+                                end
+                            end, TypeStrs),
+                        {attribute, Loc, etylizer, {msg_type, FunName, Arity, FunTys, noexhaustiveness}};
+                    {msg_type, FunName, Arity, TypeStr, noexhaustiveness}
+                            when is_atom(FunName), is_integer(Arity), is_list(TypeStr) ->
+                        % String form with noexhaustiveness flag.
+                        Loc = to_loc(Ctx, Anno),
+                        case parse_type(Ctx, TypeStr) of
+                            {ok, Ty} ->
+                                {attribute, Loc, etylizer, {msg_type, FunName, Arity, Ty, noexhaustiveness}};
+                            error ->
+                                errors:ty_error(Loc,
+                                    "Invalid type in -etylizer({msg_type, ...}): ~s", TypeStr)
+                        end;
+                    {msg_type, FunName, Arity, TypeStrs}
+                            when is_atom(FunName), is_integer(Arity),
+                                 is_list(TypeStrs), TypeStrs =/= [],
+                                 is_list(hd(TypeStrs)) ->
+                        % List form: -etylizer({msg_type, FunName, Arity, [FunTypeStr, ...]}).
+                        % Each string must parse as a function type (fun((T) -> S)).
+                        % Desugaring creates a helper function with intersection spec.
+                        Loc = to_loc(Ctx, Anno),
+                        FunTys = lists:map(
+                            fun(TyStr) ->
+                                case parse_type(Ctx, TyStr) of
+                                    {ok, Ty = {fun_full, _, _}} -> Ty;
+                                    {ok, Ty} -> {fun_full, [Ty], {predef, any}};
+                                    error ->
+                                        errors:ty_error(Loc,
+                                            "Invalid type in msg_type list: ~s", [TyStr])
+                                end
+                            end, TypeStrs),
+                        {attribute, Loc, etylizer, {msg_type, FunName, Arity, FunTys}};
+                    {msg_type, FunName, Arity, TypeStr}
+                            when is_atom(FunName), is_integer(Arity), is_list(TypeStr) ->
+                        % Parse the type string and emit a typed msg_type attribute.
+                        % Format: -etylizer({msg_type, FunName, Arity, "TypeString"}).
+                        % Must appear before function definitions (OTP 28+ requirement).
+                        Loc = to_loc(Ctx, Anno),
+                        case parse_type(Ctx, TypeStr) of
+                            {ok, Ty} ->
+                                {attribute, Loc, etylizer, {msg_type, FunName, Arity, Ty}};
+                            error ->
+                                errors:ty_error(Loc,
+                                    "Invalid type in -etylizer({msg_type, ...}): ~s", TypeStr)
+                        end;
                     _ ->
                         error
                 end;
@@ -388,8 +448,16 @@ trans_ty(Ctx, Env, Ty) ->
         {user_type, Anno, Name, ArgTys} ->
             % FIXME: should we check whether the reference is valid?
             Loc = to_loc(Ctx, Anno),
-            Ref = {ty_ref, Ctx#ctx.module_name, Name, arity(Loc, ArgTys)},
-            {named, Loc, Ref, trans_tys(Ctx, Env, ArgTys)};
+            NewArgTys = trans_tys(Ctx, Env, ArgTys),
+            case {Name, NewArgTys} of
+                {pid, [ArgTy]} ->
+                    % pid(T) is the Marlow-Wadler parameterized pid type.
+                    % Map to erlang:pid/1 so symtab lookups use the standard registration.
+                    {named, Loc, {ty_ref, erlang, pid, 1}, [ArgTy]};
+                _ ->
+                    Ref = {ty_ref, Ctx#ctx.module_name, Name, arity(Loc, ArgTys)},
+                    {named, Loc, Ref, NewArgTys}
+            end;
         {remote_type, Anno, [{'atom', _, etylizer}, {'atom', _, Name}, ArgTys]} ->
             resolve_ety_ty(to_loc(Ctx, Anno), Name, trans_tys(Ctx, Env, ArgTys));
         {remote_type, Anno, [{'atom', _, Mod}, {'atom', _, Name}, ArgTys]} ->
@@ -417,6 +485,9 @@ trans_ty(Ctx, Env, Ty) ->
                 _ ->
                     case {ast:is_predef_name(Name), NewArgTys} of
                         {true, []} -> {predef, Name};
+                        {true, [ArgTy]} when Name =:= pid ->
+                            % pid(T) is a parameterized pid type: process accepting messages of type T
+                            {named, Loc, {ty_ref, erlang, pid, 1}, [ArgTy]};
                         {true, _} ->
                             errors:ty_error(Loc, "Invalid application of builtin type: ~w", Ty);
                         {false, _} ->

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -3,7 +3,7 @@
 -include("log.hrl").
 
 -export([
-         gen_constrs_fun_group/4, gen_constrs_annotated_fun/5,
+         gen_constrs_fun_group/4, gen_constrs_annotated_fun/6,
          sanity_check/2,
          new_ctx/2, fun_clauses_to_exp/3
         ]).
@@ -31,7 +31,11 @@
           % directly to a closed type.
           env = #{} :: #{ ast:any_ref() => ast:ty() },
           % true when generating constraints inside a guard expression
-          in_guard = false :: boolean()
+          in_guard = false :: boolean(),
+          % declared receive message type (from -etylizer({msg_type, T})), if any
+          recv_msg_ty = none :: none | ast:ty(),
+          % per-receive exhaustiveness: exhaust (default) or noexhaust
+          recv_exhaust = exhaust :: exhaust | noexhaust
         }).
 -type ctx() :: #ctx{}.
 
@@ -97,8 +101,8 @@ gen_constrs_fun_group(ExhaustivenessMode, Symtab, {DisableExhaustiveness, Disabl
 % This function is invoked for each branch of the intersection type in the type spec.
 % The idea is that we can give better error messages by pointing out which part of the
 % intersection did not type check.
--spec gen_constrs_annotated_fun(feature_flags:exhaustiveness_mode(), symtab:t(), {boolean(), boolean()}, ast:ty_full_fun(), ast:fun_decl()) -> constr:constrs().
-gen_constrs_annotated_fun(ExhaustivenessMode, Symtab, {DisableExhaustiveness, DisableRedundancy}, {fun_full, ArgTys, ResTy}, {function, L, Name, Arity, FunClauses}) ->
+-spec gen_constrs_annotated_fun(feature_flags:exhaustiveness_mode(), symtab:t(), {boolean(), boolean()}, none | {ast:ty(), exhaust | noexhaust}, ast:ty_full_fun(), ast:fun_decl()) -> constr:constrs().
+gen_constrs_annotated_fun(ExhaustivenessMode, Symtab, {DisableExhaustiveness, DisableRedundancy}, RecvMsgTyArg, {fun_full, ArgTys, ResTy}, {function, L, Name, Arity, FunClauses}) ->
     Ctx0 = new_ctx(Symtab, ExhaustivenessMode),
     Ctx1 = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy },
     {Args, Body} = fun_clauses_to_exp(Ctx1, L, FunClauses),
@@ -108,9 +112,14 @@ gen_constrs_annotated_fun(ExhaustivenessMode, Symtab, {DisableExhaustiveness, Di
     end,
     ArgRefs = lists:map(fun(V) -> {local_ref, V} end, Args),
     Env = maps:from_list(lists:zip(ArgRefs, ArgTys)),
+    % recv_msg_ty for typed receive; recv_exhaust for per-receive exhaustiveness opt-out
+    {RecvTy, RecvExhaust} = case RecvMsgTyArg of
+        none -> {none, exhaust};
+        {Ty, Exhaust} -> {Ty, Exhaust}
+    end,
     %% Thread Env into Ctx so exp_constrs_tyof can resolve arg-var lookups
     %% to their declared (closed) spec types directly
-    Ctx = Ctx1#ctx{ env = Env },
+    Ctx = Ctx1#ctx{ env = Env, recv_msg_ty = RecvTy, recv_exhaust = RecvExhaust },
     BodyCs = exps_constrs(Ctx, L, Body, ResTy),
     Msg = utils:sformat("definition of ~w/~w", Name, Arity),
     utils:single({cdef, mk_locs(Msg, L), Env, BodyCs}).
@@ -409,6 +418,20 @@ exp_constrs(Ctx, E, T) ->
             Cs2 = exp_constrs(Ctx, Rhs, Alpha2),
             BoolCs = utils:single({csubty, mk_locs("boolean shortcircuit", L), {predef_alias, boolean}, T}),
             sets:union([Cs1, Cs2, BoolCs]);
+        {op, L, '!', PidExp, MsgExp} ->
+            % Send operator: Pid ! Msg
+            % Standard cop constraint (checks Pid is a valid receiver, returns Msg).
+            Alpha1 = fresh_tyvar(Ctx),
+            Cs1 = exp_constrs(Ctx, PidExp, Alpha1),
+            Alpha2 = fresh_tyvar(Ctx),
+            Cs2 = exp_constrs(Ctx, MsgExp, Alpha2),
+            Beta = fresh_tyvar(Ctx),
+            OpCs = sets:from_list(
+                     [{cop, mk_locs("type of op !", L), '!', 2, {fun_full, [Alpha1, Alpha2], Beta}},
+                      {csubty, mk_locs("result of op !", L), Beta, T}], [{version, 2}]),
+            % Additional pid(T) check: if Pid has type pid(T), require Msg <: T
+            PidMsgCs = pid_send_constrs(Ctx, L, PidExp, Alpha2),
+            sets:union([Cs1, Cs2, OpCs, PidMsgCs]);
         {op, L, Op, Lhs, Rhs} ->
             Alpha1 = fresh_tyvar(Ctx),
             Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
@@ -1139,16 +1162,122 @@ dyncall_constrs(Ctx, L, ModExp, FunExp, Args, T) ->
 -spec ty_without(ast:ty(), ast:ty()) -> ast:ty().
 ty_without(T1, T2) -> ast_lib:mk_intersection([T1, ast_lib:mk_negation(T2)]).
 
+% Checks if a pid send expression carries a pid(T) type annotation in the local environment.
+% If so, generates a constraint that the message type is a subtype of T.
+% This implements the Marlow-Wadler pid(T) parametric process type.
+-spec pid_send_constrs(ctx(), ast:loc(), ast:exp(), ast:ty()) -> constr:constrs().
+pid_send_constrs(Ctx, L, PidExp, MsgTy) ->
+    case PidExp of
+        {var, _, {local_ref, Var}} ->
+            case maps:find({local_ref, Var}, Ctx#ctx.env) of
+                {ok, {named, _, Ref, [T]}}
+                    when Ref =:= {ty_ref, erlang, pid, 1};
+                         Ref =:= {ty_qref, erlang, pid, 1} ->
+                    utils:single({csubty, mk_locs("pid(T) message type constraint", L), MsgTy, T});
+                _ ->
+                    sets:new([{version, 2}])
+            end;
+        _ ->
+            sets:new([{version, 2}])
+    end.
+
 % Generates constraints for a receive expression.
-% Pattern variables are bound to dynamic() since we don't know message types.
-% Guards override dynamic with specific types (e.g., is_integer(X) makes X :: integer()).
--spec receive_constrs(ctx(), ast:loc(), [ast:case_clause()], ast:ty()) ->
-    constr:constrs().
-receive_constrs(Ctx, _L, CaseClauses, T) ->
-    ClauseCs = lists:map(
-        fun(Clause) -> receive_clause_constrs(Ctx, Clause, T) end,
+% When recv_msg_ty is set, applies full case-like exhaustiveness and redundancy checking
+% against the declared message type. Otherwise, pattern variables default to dynamic().
+-spec receive_constrs(ctx(), ast:loc(), [ast:case_clause()], ast:ty()) -> constr:constrs().
+receive_constrs(Ctx, L, CaseClauses, T) ->
+    case Ctx#ctx.recv_msg_ty of
+        none ->
+            ClauseCs = lists:map(
+                fun(Clause) -> receive_clause_constrs(Ctx, Clause, T) end,
+                CaseClauses),
+            sets:union(ClauseCs);
+        MsgTy ->
+            typed_receive_constrs(Ctx, L, MsgTy, CaseClauses, T)
+    end.
+
+% Generates constraints for a typed receive using the declared message type as the scrutinee.
+% Applies exhaustiveness and redundancy checking, mirroring case_constrs.
+-spec typed_receive_constrs(ctx(), ast:loc(), ast:ty(), [ast:case_clause()],
+                            ast:ty()) -> constr:constrs().
+typed_receive_constrs(Ctx, L, MsgTy, CaseClauses, T) ->
+    HasBinPat = lists:any(
+        fun({case_clause, _, Pat, _, _}) -> has_bin_pat(Pat) end,
         CaseClauses),
-    sets:union(ClauseCs).
+    NeedsUnmatchedCheck = needs_unmatched_check(CaseClauses),
+    % A neutral atom literal serves as the virtual scrutinee: pat_of_exp maps any
+    % non-structural expression to a wildcard pattern, so Lower/Upper are determined
+    % purely by the clause pattern (the receive has no real scrutinee expression).
+    WildScrut = {atom, L, '_'},
+    {BodyList, Lowers, PatCs} =
+        lists:foldl(
+            fun({case_clause, CL, Pat, Guards, Exps}, {AccBodyList, PrevLowers, AccPatCs}) ->
+                % Compute bounds and environments with/without guards (mirrors case_clause_constrs).
+                {_GuardLower, GuardUpper, GuardPatCs, GuardPatEnv} =
+                    case_clause_env(Ctx, CL, MsgTy, WildScrut, Pat, []),
+                {BodyLower, _BodyUpper, BodyPatCs, BodyPatEnv} =
+                    case_clause_env(Ctx, CL, MsgTy, WildScrut, Pat, Guards),
+                % Redundancy: clause is redundant iff MsgTy <: not(GuardUpper) | union(PrevLowers)
+                RedundancyCs =
+                    if NeedsUnmatchedCheck ->
+                        recv_clause_unmatched_constraints(MsgTy, PrevLowers, GuardUpper, CL);
+                    true -> none
+                    end,
+                % Guard constraints
+                GuardCtx = Ctx#ctx{in_guard = true},
+                CGuards = sets:union(lists:map(
+                    fun(Guard) ->
+                        exps_constrs(GuardCtx, CL, Guard, {predef_alias, boolean})
+                    end, Guards)),
+                % Body constraints
+                Beta = fresh_tyvar(Ctx),
+                BodyCs = exps_constrs(Ctx, CL, Exps, Beta),
+                RL = case Exps of [E | _] -> ast:loc_exp(E) end,
+                ResultCs = utils:single({csubty, mk_locs("typed receive result", RL), Beta, T}),
+                % Build ccase_branch payload (same structure as case_clause_constrs)
+                Payload = constr:mk_case_branch_payload(
+                    {GuardPatEnv, CGuards},
+                    {BodyPatEnv, BodyCs},
+                    RedundancyCs,
+                    ResultCs),
+                BranchC = {ccase_branch, mk_locs("typed receive branch", CL), Payload},
+                % BranchC goes into BodyList; pattern constraints accumulate in PatCs
+                NewPatCs = sets:union(AccPatCs, sets:union(GuardPatCs, BodyPatCs)),
+                {AccBodyList ++ [BranchC], PrevLowers ++ [BodyLower], NewPatCs}
+            end,
+            {[], [], sets:new([{version, 2}])},
+            CaseClauses),
+    % Exhaustiveness: all message values must be covered by some clause.
+    % Suppressed when recv_exhaust is noexhaust (per-receive opt-out).
+    ExhaustCs =
+        case {Ctx#ctx.exhaustiveness_mode, Ctx#ctx.recv_exhaust, HasBinPat} of
+            {enabled, exhaust, false} ->
+                utils:single({csubty, mk_locs("typed receive exhaustiveness", L),
+                    MsgTy, ast_lib:mk_union(Lowers)});
+            _ -> sets:new([{version, 2}])
+        end,
+    % PatCs may be empty if all patterns are wildcards/vars (no constraints generated).
+    % loc(PatCs) in constr_simp requires at least one location-carrying constraint,
+    % so add a trivially-true baseline: MsgTy <: any().
+    BaseCs = utils:single({csubty, mk_locs("typed receive", L), MsgTy, {predef, any}}),
+    FinalPatCs = sets:union(PatCs, BaseCs),
+    CcaseC = {ccase, mk_locs("typed receive", L), FinalPatCs, ExhaustCs, BodyList},
+    utils:single(CcaseC).
+
+% Computes the redundancy constraint for a typed receive clause.
+% The clause is redundant iff the constraint MsgTy <: not(Upper) | union(LowersBefore) is satisfiable.
+-spec recv_clause_unmatched_constraints(ast:ty(), [ast:ty()], ast:ty(), ast:loc()) ->
+    constr:constr_case_branch_cond().
+recv_clause_unmatched_constraints(MsgTy, LowersBefore, Upper, L) ->
+    Ui = ast_lib:mk_union([ast_lib:mk_negation(Upper) | LowersBefore]),
+    utils:single({csubty, mk_locs("redundant receive clause", L), MsgTy, Ui}).
+
+% Check if a pattern contains a binary pattern at the top level (possibly inside a tuple).
+-spec has_bin_pat(ast:pat()) -> boolean().
+has_bin_pat({bin, _, _}) -> true;
+has_bin_pat({tuple, _, Ps}) -> lists:any(fun has_bin_pat/1, Ps);
+has_bin_pat({match, _, P1, P2}) -> has_bin_pat(P1) orelse has_bin_pat(P2);
+has_bin_pat(_) -> false.
 
 % Generates constraints for a receive...after expression.
 % Combines receive clause constraints with the after body constraints.
@@ -1169,20 +1298,31 @@ receive_after_constrs(Ctx, L, CaseClauses, TimeoutExp, AfterBody, T) ->
 
 % Generates constraints for a single receive clause.
 % Pattern variables get type dynamic(). Guards override with specific types.
+% If the context has a recv_msg_ty (typed receive...after), pattern variables are
+% bound to types inferred from the declared message type instead.
 -spec receive_clause_constrs(ctx(), ast:case_clause(), ast:ty()) -> constr:constrs().
 receive_clause_constrs(Ctx, {case_clause, L, Pat, Guards, Exps}, T) ->
-    % Bind pattern variables to dynamic
-    BoundVars = bound_vars_pat(Pat),
-    DynamicPatEnv = sets:fold(
-        fun(V, Acc) -> maps:put({local_ref, V}, {predef, dynamic}, Acc) end,
-        #{},
-        BoundVars),
-    {GuardEnv, _} = guard_seq_env(Guards),
-    % #FIXME HACK until #329 is fixed
-    % Guard refinements override dynamic(), not intersect with it.
-    % Overriding ensures guarded variables get only the guard type.
-    % Unguarded variables remain dynamic().
-    VarEnv = maps:merge(DynamicPatEnv, GuardEnv),
+    {VarEnv, ExtraCs} =
+        case Ctx#ctx.recv_msg_ty of
+            none ->
+                % Bind pattern variables to dynamic
+                BoundVars = bound_vars_pat(Pat),
+                DynamicPatEnv = sets:fold(
+                    fun(V, Acc) -> maps:put({local_ref, V}, {predef, dynamic}, Acc) end,
+                    #{},
+                    BoundVars),
+                {GuardEnv, _} = guard_seq_env(Guards),
+                % #FIXME HACK until #329 is fixed
+                % Guard refinements override dynamic(), not intersect with it.
+                % Overriding ensures guarded variables get only the guard type.
+                % Unguarded variables remain dynamic().
+                {maps:merge(DynamicPatEnv, GuardEnv), sets:new([{version, 2}])};
+            MsgTy ->
+                % Typed receive: bind pattern variables to types inferred from the
+                % declared message type (like a case clause scrutinizing MsgTy).
+                {PatCs, PatEnv} = pat_guard_env(Ctx, L, MsgTy, Pat, Guards),
+                {PatEnv, PatCs}
+        end,
     % Generate guard constraints to evaluate to boolean()
     GuardCtx = Ctx#ctx{in_guard = true},
     GuardCs = sets:union(
@@ -1196,7 +1336,7 @@ receive_clause_constrs(Ctx, {case_clause, L, Pat, Guards, Exps}, T) ->
     BodyCs = exps_constrs(Ctx, L, Exps, Beta),
     ResultCs = utils:single({csubty, mk_locs("receive clause result", L), Beta, T}),
     % Wrap in cdef with variable bindings
-    InnerCs = sets:union([GuardCs, BodyCs, ResultCs]),
+    InnerCs = sets:union([ExtraCs, GuardCs, BodyCs, ResultCs]),
     utils:single({cdef, mk_locs("receive clause", L), VarEnv, InnerCs}).
 
 -spec needs_unmatched_check(list(ast:case_clause())) -> boolean().

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -3,7 +3,7 @@
 -include("log.hrl").
 
 -export([
-         gen_constrs_fun_group/4, gen_constrs_annotated_fun/5,
+         gen_constrs_fun_group/4, gen_constrs_annotated_fun/6,
          sanity_check/2,
          new_ctx/2, fun_clauses_to_exp/3
         ]).
@@ -31,7 +31,11 @@
           % directly to a closed type.
           env = #{} :: #{ ast:any_ref() => ast:ty() },
           % true when generating constraints inside a guard expression
-          in_guard = false :: boolean()
+          in_guard = false :: boolean(),
+          % declared receive message type (from -etylizer({msg_type, T})), if any
+          recv_msg_ty = none :: none | ast:ty(),
+          % per-receive exhaustiveness: exhaust (default) or noexhaust
+          recv_exhaust = exhaust :: exhaust | noexhaust
         }).
 -type ctx() :: #ctx{}.
 
@@ -97,8 +101,8 @@ gen_constrs_fun_group(ExhaustivenessMode, Symtab, {DisableExhaustiveness, Disabl
 % This function is invoked for each branch of the intersection type in the type spec.
 % The idea is that we can give better error messages by pointing out which part of the
 % intersection did not type check.
--spec gen_constrs_annotated_fun(feature_flags:exhaustiveness_mode(), symtab:t(), {boolean(), boolean()}, ast:ty_full_fun(), ast:fun_decl()) -> constr:constrs().
-gen_constrs_annotated_fun(ExhaustivenessMode, Symtab, {DisableExhaustiveness, DisableRedundancy}, {fun_full, ArgTys, ResTy}, {function, L, Name, Arity, FunClauses}) ->
+-spec gen_constrs_annotated_fun(feature_flags:exhaustiveness_mode(), symtab:t(), {boolean(), boolean()}, none | {ast:ty(), exhaust | noexhaust}, ast:ty_full_fun(), ast:fun_decl()) -> constr:constrs().
+gen_constrs_annotated_fun(ExhaustivenessMode, Symtab, {DisableExhaustiveness, DisableRedundancy}, RecvMsgTyArg, {fun_full, ArgTys, ResTy}, {function, L, Name, Arity, FunClauses}) ->
     Ctx0 = new_ctx(Symtab, ExhaustivenessMode),
     Ctx1 = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy },
     {Args, Body} = fun_clauses_to_exp(Ctx1, L, FunClauses),
@@ -108,9 +112,14 @@ gen_constrs_annotated_fun(ExhaustivenessMode, Symtab, {DisableExhaustiveness, Di
     end,
     ArgRefs = lists:map(fun(V) -> {local_ref, V} end, Args),
     Env = maps:from_list(lists:zip(ArgRefs, ArgTys)),
+    % recv_msg_ty for typed receive; recv_exhaust for per-receive exhaustiveness opt-out
+    {RecvTy, RecvExhaust} = case RecvMsgTyArg of
+        none -> {none, exhaust};
+        {Ty, Exhaust} -> {Ty, Exhaust}
+    end,
     % thread Env into Ctx so exp_constrs_tyof can resolve arg-var lookups
     % to their declared (closed) spec types directly
-    Ctx = Ctx1#ctx{ env = Env },
+    Ctx = Ctx1#ctx{ env = Env, recv_msg_ty = RecvTy, recv_exhaust = RecvExhaust },
     BodyCs = exps_constrs(Ctx, L, Body, ResTy),
     Msg = utils:sformat("definition of ~w/~w", Name, Arity),
     utils:single({cdef, mk_locs(Msg, L), Env, BodyCs}).
@@ -405,6 +414,20 @@ exp_constrs(Ctx, E, T) ->
             Cs2 = exp_constrs(Ctx, Rhs, Alpha2),
             BoolCs = utils:single({csubty, mk_locs("boolean shortcircuit", L), {predef_alias, boolean}, T}),
             sets:union([Cs1, Cs2, BoolCs]);
+        {op, L, '!', PidExp, MsgExp} ->
+            % Send operator: Pid ! Msg
+            % Standard cop constraint (checks Pid is a valid receiver, returns Msg).
+            Alpha1 = fresh_tyvar(Ctx),
+            Cs1 = exp_constrs(Ctx, PidExp, Alpha1),
+            Alpha2 = fresh_tyvar(Ctx),
+            Cs2 = exp_constrs(Ctx, MsgExp, Alpha2),
+            Beta = fresh_tyvar(Ctx),
+            OpCs = sets:from_list(
+                     [{cop, mk_locs("type of op !", L), '!', 2, {fun_full, [Alpha1, Alpha2], Beta}},
+                      {csubty, mk_locs("result of op !", L), Beta, T}], [{version, 2}]),
+            % Additional pid(T) check: if Pid has type pid(T), require Msg <: T
+            PidMsgCs = pid_send_constrs(Ctx, L, PidExp, Alpha2),
+            sets:union([Cs1, Cs2, OpCs, PidMsgCs]);
         {op, L, Op, Lhs, Rhs} ->
             Alpha1 = fresh_tyvar(Ctx),
             Cs1 = exp_constrs(Ctx, Lhs, Alpha1),
@@ -1132,16 +1155,122 @@ dyncall_constrs(Ctx, L, ModExp, FunExp, Args, T) ->
 -spec ty_without(ast:ty(), ast:ty()) -> ast:ty().
 ty_without(T1, T2) -> ast_lib:mk_intersection([T1, ast_lib:mk_negation(T2)]).
 
+% Checks if a pid send expression carries a pid(T) type annotation in the local environment.
+% If so, generates a constraint that the message type is a subtype of T.
+% This implements the Marlow-Wadler pid(T) parametric process type.
+-spec pid_send_constrs(ctx(), ast:loc(), ast:exp(), ast:ty()) -> constr:constrs().
+pid_send_constrs(Ctx, L, PidExp, MsgTy) ->
+    case PidExp of
+        {var, _, {local_ref, Var}} ->
+            case maps:find({local_ref, Var}, Ctx#ctx.env) of
+                {ok, {named, _, Ref, [T]}}
+                    when Ref =:= {ty_ref, erlang, pid, 1};
+                         Ref =:= {ty_qref, erlang, pid, 1} ->
+                    utils:single({csubty, mk_locs("pid(T) message type constraint", L), MsgTy, T});
+                _ ->
+                    sets:new([{version, 2}])
+            end;
+        _ ->
+            sets:new([{version, 2}])
+    end.
+
 % Generates constraints for a receive expression.
-% Pattern variables are bound to dynamic() since we don't know message types.
-% Guards override dynamic with specific types (e.g., is_integer(X) makes X :: integer()).
--spec receive_constrs(ctx(), ast:loc(), [ast:case_clause()], ast:ty()) ->
-    constr:constrs().
-receive_constrs(Ctx, _L, CaseClauses, T) ->
-    ClauseCs = lists:map(
-        fun(Clause) -> receive_clause_constrs(Ctx, Clause, T) end,
+% When recv_msg_ty is set, applies full case-like exhaustiveness and redundancy checking
+% against the declared message type. Otherwise, pattern variables default to dynamic().
+-spec receive_constrs(ctx(), ast:loc(), [ast:case_clause()], ast:ty()) -> constr:constrs().
+receive_constrs(Ctx, L, CaseClauses, T) ->
+    case Ctx#ctx.recv_msg_ty of
+        none ->
+            ClauseCs = lists:map(
+                fun(Clause) -> receive_clause_constrs(Ctx, Clause, T) end,
+                CaseClauses),
+            sets:union(ClauseCs);
+        MsgTy ->
+            typed_receive_constrs(Ctx, L, MsgTy, CaseClauses, T)
+    end.
+
+% Generates constraints for a typed receive using the declared message type as the scrutinee.
+% Applies exhaustiveness and redundancy checking, mirroring case_constrs.
+-spec typed_receive_constrs(ctx(), ast:loc(), ast:ty(), [ast:case_clause()],
+                            ast:ty()) -> constr:constrs().
+typed_receive_constrs(Ctx, L, MsgTy, CaseClauses, T) ->
+    HasBinPat = lists:any(
+        fun({case_clause, _, Pat, _, _}) -> has_bin_pat(Pat) end,
         CaseClauses),
-    sets:union(ClauseCs).
+    NeedsUnmatchedCheck = needs_unmatched_check(CaseClauses),
+    % A neutral atom literal serves as the virtual scrutinee: pat_of_exp maps any
+    % non-structural expression to a wildcard pattern, so Lower/Upper are determined
+    % purely by the clause pattern (the receive has no real scrutinee expression).
+    WildScrut = {atom, L, '_'},
+    {BodyList, Lowers, PatCs} =
+        lists:foldl(
+            fun({case_clause, CL, Pat, Guards, Exps}, {AccBodyList, PrevLowers, AccPatCs}) ->
+                % Compute bounds and environments with/without guards (mirrors case_clause_constrs).
+                {_GuardLower, GuardUpper, GuardPatCs, GuardPatEnv} =
+                    case_clause_env(Ctx, CL, MsgTy, WildScrut, Pat, []),
+                {BodyLower, _BodyUpper, BodyPatCs, BodyPatEnv} =
+                    case_clause_env(Ctx, CL, MsgTy, WildScrut, Pat, Guards),
+                % Redundancy: clause is redundant iff MsgTy <: not(GuardUpper) | union(PrevLowers)
+                RedundancyCs =
+                    if NeedsUnmatchedCheck ->
+                        recv_clause_unmatched_constraints(MsgTy, PrevLowers, GuardUpper, CL);
+                    true -> none
+                    end,
+                % Guard constraints
+                GuardCtx = Ctx#ctx{in_guard = true},
+                CGuards = sets:union(lists:map(
+                    fun(Guard) ->
+                        exps_constrs(GuardCtx, CL, Guard, {predef_alias, boolean})
+                    end, Guards)),
+                % Body constraints
+                Beta = fresh_tyvar(Ctx),
+                BodyCs = exps_constrs(Ctx, CL, Exps, Beta),
+                RL = case Exps of [E | _] -> ast:loc_exp(E) end,
+                ResultCs = utils:single({csubty, mk_locs("typed receive result", RL), Beta, T}),
+                % Build ccase_branch payload (same structure as case_clause_constrs)
+                Payload = constr:mk_case_branch_payload(
+                    {GuardPatEnv, CGuards},
+                    {BodyPatEnv, BodyCs},
+                    RedundancyCs,
+                    ResultCs),
+                BranchC = {ccase_branch, mk_locs("typed receive branch", CL), Payload},
+                % BranchC goes into BodyList; pattern constraints accumulate in PatCs
+                NewPatCs = sets:union(AccPatCs, sets:union(GuardPatCs, BodyPatCs)),
+                {AccBodyList ++ [BranchC], PrevLowers ++ [BodyLower], NewPatCs}
+            end,
+            {[], [], sets:new([{version, 2}])},
+            CaseClauses),
+    % Exhaustiveness: all message values must be covered by some clause.
+    % Suppressed when recv_exhaust is noexhaust (per-receive opt-out).
+    ExhaustCs =
+        case {Ctx#ctx.exhaustiveness_mode, Ctx#ctx.recv_exhaust, HasBinPat} of
+            {enabled, exhaust, false} ->
+                utils:single({csubty, mk_locs("typed receive exhaustiveness", L),
+                    MsgTy, ast_lib:mk_union(Lowers)});
+            _ -> sets:new([{version, 2}])
+        end,
+    % PatCs may be empty if all patterns are wildcards/vars (no constraints generated).
+    % loc(PatCs) in constr_simp requires at least one location-carrying constraint,
+    % so add a trivially-true baseline: MsgTy <: any().
+    BaseCs = utils:single({csubty, mk_locs("typed receive", L), MsgTy, {predef, any}}),
+    FinalPatCs = sets:union(PatCs, BaseCs),
+    CcaseC = {ccase, mk_locs("typed receive", L), FinalPatCs, ExhaustCs, BodyList},
+    utils:single(CcaseC).
+
+% Computes the redundancy constraint for a typed receive clause.
+% The clause is redundant iff the constraint MsgTy <: not(Upper) | union(LowersBefore) is satisfiable.
+-spec recv_clause_unmatched_constraints(ast:ty(), [ast:ty()], ast:ty(), ast:loc()) ->
+    constr:constr_case_branch_cond().
+recv_clause_unmatched_constraints(MsgTy, LowersBefore, Upper, L) ->
+    Ui = ast_lib:mk_union([ast_lib:mk_negation(Upper) | LowersBefore]),
+    utils:single({csubty, mk_locs("redundant receive clause", L), MsgTy, Ui}).
+
+% Check if a pattern contains a binary pattern at the top level (possibly inside a tuple).
+-spec has_bin_pat(ast:pat()) -> boolean().
+has_bin_pat({bin, _, _}) -> true;
+has_bin_pat({tuple, _, Ps}) -> lists:any(fun has_bin_pat/1, Ps);
+has_bin_pat({match, _, P1, P2}) -> has_bin_pat(P1) orelse has_bin_pat(P2);
+has_bin_pat(_) -> false.
 
 % Generates constraints for a receive...after expression.
 % Combines receive clause constraints with the after body constraints.
@@ -1162,20 +1291,31 @@ receive_after_constrs(Ctx, L, CaseClauses, TimeoutExp, AfterBody, T) ->
 
 % Generates constraints for a single receive clause.
 % Pattern variables get type dynamic(). Guards override with specific types.
+% If the context has a recv_msg_ty (typed receive...after), pattern variables are
+% bound to types inferred from the declared message type instead.
 -spec receive_clause_constrs(ctx(), ast:case_clause(), ast:ty()) -> constr:constrs().
 receive_clause_constrs(Ctx, {case_clause, L, Pat, Guards, Exps}, T) ->
-    % Bind pattern variables to dynamic
-    BoundVars = bound_vars_pat(Pat),
-    DynamicPatEnv = sets:fold(
-        fun(V, Acc) -> maps:put({local_ref, V}, {predef, dynamic}, Acc) end,
-        #{},
-        BoundVars),
-    {GuardEnv, _} = guard_seq_env(Guards),
-    % #FIXME HACK until #329 is fixed
-    % Guard refinements override dynamic(), not intersect with it.
-    % Overriding ensures guarded variables get only the guard type.
-    % Unguarded variables remain dynamic().
-    VarEnv = maps:merge(DynamicPatEnv, GuardEnv),
+    {VarEnv, ExtraCs} =
+        case Ctx#ctx.recv_msg_ty of
+            none ->
+                % Bind pattern variables to dynamic
+                BoundVars = bound_vars_pat(Pat),
+                DynamicPatEnv = sets:fold(
+                    fun(V, Acc) -> maps:put({local_ref, V}, {predef, dynamic}, Acc) end,
+                    #{},
+                    BoundVars),
+                {GuardEnv, _} = guard_seq_env(Guards),
+                % #FIXME HACK until #329 is fixed
+                % Guard refinements override dynamic(), not intersect with it.
+                % Overriding ensures guarded variables get only the guard type.
+                % Unguarded variables remain dynamic().
+                {maps:merge(DynamicPatEnv, GuardEnv), sets:new([{version, 2}])};
+            MsgTy ->
+                % Typed receive: bind pattern variables to types inferred from the
+                % declared message type (like a case clause scrutinizing MsgTy).
+                {PatCs, PatEnv} = pat_guard_env(Ctx, L, MsgTy, Pat, Guards),
+                {PatEnv, PatCs}
+        end,
     % Generate guard constraints to evaluate to boolean()
     GuardCtx = Ctx#ctx{in_guard = true},
     GuardCs = sets:union(
@@ -1189,7 +1329,7 @@ receive_clause_constrs(Ctx, {case_clause, L, Pat, Guards, Exps}, T) ->
     BodyCs = exps_constrs(Ctx, L, Exps, Beta),
     ResultCs = utils:single({csubty, mk_locs("receive clause result", L), Beta, T}),
     % Wrap in cdef with variable bindings
-    InnerCs = sets:union([GuardCs, BodyCs, ResultCs]),
+    InnerCs = sets:union([ExtraCs, GuardCs, BodyCs, ResultCs]),
     utils:single({cdef, mk_locs("receive clause", L), VarEnv, InnerCs}).
 
 -spec needs_unmatched_check(list(ast:case_clause())) -> boolean().

--- a/src/symtab.erl
+++ b/src/symtab.erl
@@ -180,7 +180,11 @@ build_std_symtab(SearchPath, OverlaySymtab, Gradual) ->
         lists:foldl(fun({Name, Arity, T}, Map) -> maps:put({Name, Arity}, T, Map) end,
                     #{},
                     stdtypes:builtin_ops()),
-    Tab = #tab { funs = Funs, ops = Ops, types = #{}, records = #{}, modules = #{}, gradual = Gradual },
+    % pid(T) is a parameterized pid type: pid(T) = pid() in the set-theoretic sense,
+    % but the T parameter is preserved for send-side checking (Pid ! Msg requires Msg <: T).
+    PidOneScm = {ty_scheme, [{a, {predef, any}}], {predef, pid}},
+    BuiltinTypes = #{{ty_key, erlang, pid, 1} => PidOneScm},
+    Tab = #tab { funs = Funs, ops = Ops, types = BuiltinTypes, records = #{}, modules = #{}, gradual = Gradual },
     ExtTab = extend_symtab_with_module_list(Tab, SearchPath, [erlang], OverlaySymtab),
     % Merge overlay types into the main symtab so they are available for type resolution
     ExtTab2 = ExtTab#tab { types = maps:merge(ExtTab#tab.types, OverlaySymtab#tab.types) },

--- a/src/typing.erl
+++ b/src/typing.erl
@@ -4,7 +4,9 @@
     check_forms/6, check_forms/7,
     new_ctx/3,
     new_ctx/7,
-    resolve_disabled_funs/2
+    resolve_disabled_funs/2,
+    recv_msg_tys_from_forms/1,
+    desugar_recv_funs/1
 ]).
 
 -include("log.hrl").
@@ -50,6 +52,299 @@ resolve_disabled_funs(Feature, Forms) ->
             PerFunOff
     end.
 
+% Extracts per-function receive message types from -etylizer({msg_type, ...}) attributes.
+% Format: -etylizer({msg_type, FunName, Arity, ParsedType[, noexhaustiveness]}).
+% Must appear before function definitions (OTP 28+ requirement).
+% Returns a map from {FunName, Arity} to {declared message type, exhaust | noexhaust}.
+-spec recv_msg_tys_from_forms(ast:forms()) -> #{{atom(), arity()} => {ast:ty(), exhaust | noexhaust}}.
+recv_msg_tys_from_forms(Forms) ->
+    lists:foldl(
+      fun(Form, Acc) ->
+          case Form of
+              {attribute, _, etylizer, {msg_type, FunName, Arity, Ty, noexhaustiveness}} ->
+                  maps:put({FunName, Arity}, {Ty, noexhaust}, Acc);
+              {attribute, _, etylizer, {msg_type, FunName, Arity, Ty}} ->
+                  maps:put({FunName, Arity}, {Ty, exhaust}, Acc);
+              _ -> Acc
+          end
+      end,
+      #{},
+      Forms).
+
+% Generate the helper function name for a desugared receive.
+% If the original function name ends in "_fail" (test-failure naming convention),
+% the helper name also ends in "_fail" so the test runner uses check_fail_fun.
+-spec mk_recv_help_name(atom(), non_neg_integer()) -> atom().
+mk_recv_help_name(FunName, Index) ->
+    BaseName = atom_to_list(FunName),
+    Suffix = "__" ++ integer_to_list(Index),
+    case utils:string_ends_with(BaseName, "_fail") of
+        true ->
+            Stripped = string:slice(BaseName, 0, string:length(BaseName) - 5),
+            list_to_atom("__recv__" ++ Stripped ++ Suffix ++ "_fail");
+        false ->
+            list_to_atom("__recv__" ++ BaseName ++ Suffix)
+    end.
+
+% Desugar list-form msg_type attributes into helper functions with intersection specs.
+% For each -etylizer({msg_type, F, N, [FunTy, ...]}) attribute (where FunTy is already
+% a parsed ast:ty_full_fun()), creates a helper '__recv__F__0' with case body and
+% intersection spec. Removes the list msg_type attribute from the resulting forms.
+%
+% Strategy A (msg_type arity = function arity): receive in original body is replaced
+% by a direct call to the helper passing the original parameters.
+%
+% Strategy B (msg_type arity > function arity): receive in original body is replaced
+% by an untyped pass-through receive that calls the helper with the message.
+-spec desugar_recv_funs(ast:forms()) -> ast:forms().
+desugar_recv_funs(Forms) ->
+    ListMsgTys =
+        lists:foldl(
+            fun(Form, Acc) ->
+                case Form of
+                    {attribute, _, etylizer, {msg_type, FunName, Arity, FunTys, noexhaustiveness}}
+                            when is_list(FunTys) ->
+                        maps:put({FunName, Arity}, {FunTys, noexhaust}, Acc);
+                    {attribute, _, etylizer, {msg_type, FunName, Arity, FunTys}}
+                            when is_list(FunTys) ->
+                        maps:put({FunName, Arity}, {FunTys, exhaust}, Acc);
+                    _ -> Acc
+                end
+            end,
+            #{},
+            Forms),
+    case maps:size(ListMsgTys) of
+        0 -> Forms;
+        _ ->
+            {RevForms, _Done} = lists:foldl(
+                fun(Form, {Acc, Done}) ->
+                    case Form of
+                        {attribute, _, etylizer, {msg_type, _, _, FunTys, noexhaustiveness}}
+                                when is_list(FunTys) ->
+                            % Drop: replaced by helper function + spec below
+                            {Acc, Done};
+                        {attribute, _, etylizer, {msg_type, _, _, FunTys}}
+                                when is_list(FunTys) ->
+                            % Drop: replaced by helper function + spec below
+                            {Acc, Done};
+                        {function, _, FunName, FunArity, _} ->
+                            Key = {FunName, FunArity},
+                            case maps:get(Key, ListMsgTys, not_found) of
+                                not_found ->
+                                    {[Form | Acc], Done};
+                                {FunTys, ExhaustFlag} ->
+                                    case sets:is_element(Key, Done) of
+                                        true ->
+                                            {[Form | Acc], Done};
+                                        false ->
+                                            NewForms = desugar_one(Form, FunTys, ExhaustFlag),
+                                            % Prepend in reverse (reversed list, so last-inserted
+                                            % = first in final output). NewForms is [Fun, Spec, Helper]
+                                            % (or [MsgTyAttr, Fun, Spec, Helper] for Strategy B).
+                                            {lists:reverse(NewForms) ++ Acc,
+                                             sets:add_element(Key, Done)}
+                                    end
+                            end;
+                        _ ->
+                            {[Form | Acc], Done}
+                    end
+                end,
+                {[], sets:new()},
+                Forms),
+            lists:reverse(RevForms)
+    end.
+
+% Desugar a single function with list msg_type.
+% Returns the list of forms to insert in place of the function + msg_type attribute.
+% For Strategy A: [NewFun, HelpSpec, HelpFun]
+% For Strategy B: [MsgTypeAttr, NewFun, HelpSpec, HelpFun]
+%   MsgTypeAttr pins the outer receive's message type to term() so that the original
+%   function's return type can be properly checked against its spec.
+% ExhaustFlag is exhaust | noexhaust, propagated to the helper's msg_type attribute.
+-spec desugar_one(ast:fun_decl(), [ast:ty_full_fun()], exhaust | noexhaust) -> [ast:form()].
+desugar_one({function, Loc, FunName, FunArity, Clauses}, FunTys, ExhaustFlag) ->
+    [{fun_full, ArgTys, _} | _] = FunTys,
+    HelpArity = length(ArgTys),
+    HelpName = mk_recv_help_name(FunName, 0),
+    if
+        HelpArity =:= FunArity ->
+            {NewFun, HelpSpec, HelpFun} =
+                desugar_strategy_a(Loc, FunName, FunArity, Clauses, FunTys, HelpName, HelpArity),
+            [NewFun, HelpSpec, HelpFun];
+        HelpArity > FunArity ->
+            {NewFun, HelpSpec, HelpFun} =
+                desugar_strategy_b(Loc, FunName, FunArity, Clauses, FunTys, HelpName, HelpArity),
+            % Add a bare msg_type for the outer pass-through receive (term() = top type).
+            % This pins _Msg to term() so helper(term()) is used, enabling meaningful
+            % return-type checking against the original function's spec.
+            % Inherit exhaustiveness flag from the original msg_type.
+            MsgTypeAttr = case ExhaustFlag of
+                exhaust ->
+                    {attribute, Loc, etylizer,
+                     {msg_type, FunName, FunArity, {predef_alias, term}}};
+                noexhaust ->
+                    {attribute, Loc, etylizer,
+                     {msg_type, FunName, FunArity, {predef_alias, term}, noexhaustiveness}}
+            end,
+            [MsgTypeAttr, NewFun, HelpSpec, HelpFun];
+        true ->
+            errors:ty_error(Loc,
+                "msg_type list arity ~w < function arity ~w for ~w/~w",
+                [HelpArity, FunArity, FunName, FunArity])
+    end.
+
+% Strategy A: msg_type arity = function arity.
+% Replaces the receive in the function body with a direct call to the helper.
+% The original function parameters become the helper's arguments.
+-spec desugar_strategy_a(ast:loc(), atom(), arity(), [ast:fun_clause()],
+    [ast:ty_full_fun()], atom(), arity()) ->
+    {ast:fun_decl(), ast:fun_spec(), ast:fun_decl()}.
+desugar_strategy_a(Loc, FunName, FunArity, Clauses, FunTys, HelpName, HelpArity) ->
+    [{fun_clause, CLoc, Pats, Guards, Body} | RestClauses] = Clauses,
+    case extract_recv_from_body(Body) of
+        {RecvCases, RecvKind, PreBody} ->
+            T1 = erlang:unique_integer([positive]),
+            T2 = erlang:unique_integer([positive]),
+            % Helper: fresh params, body = case on first param
+            HelpParams = mk_fresh_binds(Loc, HelpArity, T1),
+            {var, HP0Loc, {local_bind, HP0Name}} = hd(HelpParams),
+            HP0Ref = {var, HP0Loc, {local_ref, HP0Name}},
+            HelpBody = [mk_case_from_recv(RecvKind, Loc, HP0Ref, RecvCases)],
+            HelpFun = {function, Loc, HelpName, HelpArity,
+                       [{fun_clause, Loc, HelpParams, [], HelpBody}]},
+            HelpSpec = mk_help_spec(Loc, HelpName, HelpArity, FunTys),
+            % Original: convert pats to vars, replace receive with call to helper
+            {NewPats, ArgRefs} = collect_param_refs(Loc, Pats, T2),
+            CallExpr = {call, Loc,
+                        {var, Loc, {ref, HelpName, HelpArity}},
+                        ArgRefs},
+            NewFun = {function, Loc, FunName, FunArity,
+                      [{fun_clause, CLoc, NewPats, Guards, PreBody ++ [CallExpr]}
+                       | RestClauses]},
+            {NewFun, HelpSpec, HelpFun};
+        error ->
+            errors:ty_error(Loc,
+                "msg_type list: no receive found in body of ~w/~w",
+                [FunName, FunArity])
+    end.
+
+% Strategy B: msg_type arity > function arity (e.g., 0-arg function, 1-arg msg_type).
+% The original function gets an untyped pass-through receive; the helper holds the
+% receive patterns as a case expression.
+-spec desugar_strategy_b(ast:loc(), atom(), arity(), [ast:fun_clause()],
+    [ast:ty_full_fun()], atom(), arity()) ->
+    {ast:fun_decl(), ast:fun_spec(), ast:fun_decl()}.
+desugar_strategy_b(Loc, FunName, FunArity, Clauses, FunTys, HelpName, HelpArity) ->
+    [{fun_clause, CLoc, Pats, Guards, Body} | RestClauses] = Clauses,
+    case extract_recv_from_body(Body) of
+        {RecvCases, RecvKind, PreBody} ->
+            T1 = erlang:unique_integer([positive]),
+            T2 = erlang:unique_integer([positive]),
+            % Helper: first param is the message, body = case on it
+            HelpParams = mk_fresh_binds(Loc, HelpArity, T1),
+            {var, HMsgLoc, {local_bind, HMsgName}} = hd(HelpParams),
+            HMsgRef = {var, HMsgLoc, {local_ref, HMsgName}},
+            HelpBody = [mk_case_from_recv(RecvKind, Loc, HMsgRef, RecvCases)],
+            HelpFun = {function, Loc, HelpName, HelpArity,
+                       [{fun_clause, Loc, HelpParams, [], HelpBody}]},
+            HelpSpec = mk_help_spec(Loc, HelpName, HelpArity, FunTys),
+            % Original: replace receive with untyped pass-through
+            MsgBind = {var, Loc, {local_bind, {'__RecvMsg', T2}}},
+            MsgRef  = {var, Loc, {local_ref,  {'__RecvMsg', T2}}},
+            CallExpr = {call, Loc,
+                        {var, Loc, {ref, HelpName, HelpArity}},
+                        [MsgRef]},
+            PassThruClause = {case_clause, Loc, MsgBind, [], [CallExpr]},
+            OuterRecv = case RecvKind of
+                simple ->
+                    {'receive', Loc, [PassThruClause]};
+                {after_expr, AfterBody, TimerExp} ->
+                    {receive_after, Loc, [PassThruClause], TimerExp, AfterBody}
+            end,
+            NewFun = {function, Loc, FunName, FunArity,
+                      [{fun_clause, CLoc, Pats, Guards, PreBody ++ [OuterRecv]}
+                       | RestClauses]},
+            {NewFun, HelpSpec, HelpFun};
+        error ->
+            errors:ty_error(Loc,
+                "msg_type list: no receive found in body of ~w/~w",
+                [FunName, FunArity])
+    end.
+
+% Find the receive or receive_after at the end of a body expression list.
+-spec extract_recv_from_body([ast:exp()]) ->
+    error | {[ast:case_clause()],
+             simple | {after_expr, [ast:exp()], ast:exp()},
+             [ast:exp()]}.
+extract_recv_from_body([]) -> error;
+extract_recv_from_body(Body) ->
+    case lists:last(Body) of
+        {'receive', _Loc, Cases} ->
+            {Cases, simple, lists:droplast(Body)};
+        % With an escape annotation (added by the case-binding propagation pass).
+        % The annotation is dropped: the receive becomes a case whose clause patterns
+        % carry the bindings, so it is recomputed during case typing.
+        {'receive', _Loc, Cases, _Escape} ->
+            {Cases, simple, lists:droplast(Body)};
+        {receive_after, _Loc, Cases, TimerExp, AfterBody} ->
+            {Cases, {after_expr, AfterBody, TimerExp}, lists:droplast(Body)};
+        {receive_after, _Loc, Cases, TimerExp, AfterBody, _Escape} ->
+            {Cases, {after_expr, AfterBody, TimerExp}, lists:droplast(Body)};
+        _ ->
+            error
+    end.
+
+% Build a case expression from receive cases.
+% For Strategy A with after: the after clause is dropped (timer semantics not needed
+% for type checking the patterns).
+-spec mk_case_from_recv(simple | {after_expr, [ast:exp()], ast:exp()},
+    ast:loc(), ast:exp(), [ast:case_clause()]) -> ast:exp_case().
+mk_case_from_recv(simple, Loc, Scrutinee, Cases) ->
+    {'case', Loc, Scrutinee, Cases};
+mk_case_from_recv({after_expr, _AfterBody, _TimerExp}, Loc, Scrutinee, Cases) ->
+    {'case', Loc, Scrutinee, Cases}.
+
+% Build a list of N fresh parameter bindings starting at BaseToken.
+-spec mk_fresh_binds(ast:loc(), arity(), integer()) -> [ast:pat_var()].
+mk_fresh_binds(Loc, N, BaseToken) ->
+    [{var, Loc, {local_bind, {'__RecvP', BaseToken + I}}} || I <- lists:seq(0, N - 1)].
+
+% Build the helper function spec form.
+-spec mk_help_spec(ast:loc(), atom(), arity(), [ast:ty_full_fun()]) -> ast:fun_spec().
+mk_help_spec(Loc, HelpName, HelpArity, FunTys) ->
+    Ty = case FunTys of
+        [Single] -> Single;
+        _        -> {intersection, FunTys}
+    end,
+    {attribute, Loc, spec, HelpName, HelpArity, {ty_scheme, [], Ty}, without_mod}.
+
+% Convert function parameter patterns to fresh variable bindings + references.
+% Wildcards become fresh vars; existing var-binds are reused; complex patterns
+% get a compound match (VarBind = OrigPat) added.
+-spec collect_param_refs(ast:loc(), [ast:pat()], integer()) ->
+    {[ast:pat()], [ast:exp_var()]}.
+collect_param_refs(_Loc, Pats, BaseToken) ->
+    lists:unzip(
+        lists:zipwith(
+            fun(Pat, I) ->
+                Tok = BaseToken + I,
+                case Pat of
+                    {wildcard, PLoc} ->
+                        VName = {'__RecvP', Tok},
+                        {{var, PLoc, {local_bind, VName}},
+                         {var, PLoc, {local_ref,  VName}}};
+                    {var, PLoc, {local_bind, VName}} ->
+                        {Pat, {var, PLoc, {local_ref, VName}}};
+                    _ ->
+                        PLoc = element(2, Pat),
+                        VName = {'__RecvP', Tok},
+                        {{match, PLoc, {var, PLoc, {local_bind, VName}}, Pat},
+                         {var, PLoc, {local_ref, VName}}}
+                end
+            end,
+            Pats,
+            lists:seq(0, length(Pats) - 1))).
+
 % Checks all forms of a module
 -spec check_forms(ctx(), string(), ast:forms(), sets:set(string()), sets:set(string()), boolean()) -> [{atom(), arity()}].
 check_forms(Ctx, FileName, Forms, Only, Ignore, CheckExports) ->
@@ -64,10 +359,13 @@ check_forms(Ctx, FileName, Forms, Only, Ignore, CheckExports, {CliNoExhaustivene
         false ->
             ?LOG_DEBUG("Skipping check for exported functions in ~s", FileName)
     end,
-    ExtTab = symtab:extend_symtab(FileName, Forms, Ctx#ctx.symtab, Ctx#ctx.overlay_symtab),
-    DisableExhaustiveness = sets:union(resolve_disabled_funs(functions_exhaustive, Forms), CliNoExhaustiveness),
-    DisableRedundancy = sets:union(resolve_disabled_funs(functions_redundant, Forms), CliNoRedundancy),
-    ExtCtx = Ctx#ctx { symtab = ExtTab, disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy },
+    % Desugar list-form msg_type attributes into helper functions with intersection specs.
+    DesugaredForms = desugar_recv_funs(Forms),
+    ExtTab = symtab:extend_symtab(FileName, DesugaredForms, Ctx#ctx.symtab, Ctx#ctx.overlay_symtab),
+    DisableExhaustiveness = sets:union(resolve_disabled_funs(functions_exhaustive, DesugaredForms), CliNoExhaustiveness),
+    DisableRedundancy = sets:union(resolve_disabled_funs(functions_redundant, DesugaredForms), CliNoRedundancy),
+    RecvMsgTys = recv_msg_tys_from_forms(DesugaredForms),
+    ExtCtx = Ctx#ctx { symtab = ExtTab, disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy, recv_msg_tys = RecvMsgTys },
     ?LOG_DEBUG("Only: ~200p", sets:to_list(Only)),
     ?LOG_DEBUG("Ignore: ~200p", sets:to_list(Ignore)),
     % Split in functions with and without tyspec
@@ -119,7 +417,7 @@ check_forms(Ctx, FileName, Forms, Only, Ignore, CheckExports, {CliNoExhaustivene
             end
           end,
           {[], [], []},
-          Forms
+          DesugaredForms
          ),
     % Make sure that Only does not contain an unknown function
     AllKnown = lists:flatmap(fun({QRef, Ref, N, M}) -> [QRef, Ref, N, M] end, KnownFuns),

--- a/src/typing.hrl
+++ b/src/typing.hrl
@@ -11,7 +11,10 @@
           disable_exhaustiveness = sets:new() :: sets:set({atom(), arity()}),
           % functions where redundancy checking is disabled at the function clause level
           % via -etylizer({functions_redundant, off, [...]})
-          disable_redundancy = sets:new() :: sets:set({atom(), arity()})
+          disable_redundancy = sets:new() :: sets:set({atom(), arity()}),
+          % per-function receive message types from -etylizer({msg_type, ...})
+          % maps {FunName, Arity} to {declared message type, exhaustiveness flag}
+          recv_msg_tys = #{} :: #{{atom(), arity()} => {ast:ty(), exhaust | noexhaust}}
         }).
 
 -type ctx() :: #ctx{}.

--- a/src/typing_check.erl
+++ b/src/typing_check.erl
@@ -210,7 +210,8 @@ check_alt(Ctx, Decl = {function, Loc, Name, Arity, _}, FunTy, BranchMode, Fixed)
                FunStr, pretty:render_ty(FunTy)),
     DisableExhaustiveness = sets:is_element({Name, Arity}, Ctx#ctx.disable_exhaustiveness),
     DisableRedundancy = sets:is_element({Name, Arity}, Ctx#ctx.disable_redundancy),
-    Cs = constr_gen:gen_constrs_annotated_fun(Ctx#ctx.exhaustiveness_mode, Ctx#ctx.symtab, {DisableExhaustiveness, DisableRedundancy}, FunTy, Decl),
+    RecvMsgTyArg = maps:get({Name, Arity}, Ctx#ctx.recv_msg_tys, none),
+    Cs = constr_gen:gen_constrs_annotated_fun(Ctx#ctx.exhaustiveness_mode, Ctx#ctx.symtab, {DisableExhaustiveness, DisableRedundancy}, RecvMsgTyArg, FunTy, Decl),
     case Ctx#ctx.sanity of
         {ok, TyMap} -> constr_gen:sanity_check(Cs, TyMap);
         error -> ok

--- a/test/tycheck_simple_tests.erl
+++ b/test/tycheck_simple_tests.erl
@@ -8,12 +8,12 @@
 -include("parse.hrl").
 -include("typing.hrl").
 
--spec check_ok_fun(string(), symtab:t(), symtab:t(), sets:set({atom(), arity()}), sets:set({atom(), arity()}), ast:fun_decl(), ast:ty_scheme()) -> ok.
-check_ok_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, Decl = {function, L, Name, Arity, _}, Ty) ->
+-spec check_ok_fun(string(), symtab:t(), symtab:t(), sets:set({atom(), arity()}), sets:set({atom(), arity()}), #{{atom(), arity()} => {ast:ty(), exhaust | noexhaust}}, ast:fun_decl(), ast:ty_scheme()) -> ok.
+check_ok_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, RecvMsgTys, Decl = {function, L, Name, Arity, _}, Ty) ->
     Includes = ["include", "src", "src/erlang_types", "src/erlang_types/dnf", "src/erlang_types/utils"],
     SanityCheck = cm_check:perform_sanity_check(Filename, [Decl], true, Includes),
     Ctx0 = typing:new_ctx(Tab, OverlayTab, SanityCheck), % FIXME: perform sanity check!
-    Ctx = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy },
+    Ctx = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy, recv_msg_tys = RecvMsgTys },
     try
         typing_check:check(Ctx, Decl, Ty)
     catch
@@ -24,11 +24,11 @@ check_ok_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy
     end,
     ok.
 
--spec check_infer_ok_fun(string(), symtab:t(), symtab:t(), sets:set({atom(), arity()}), sets:set({atom(), arity()}), ast:fun_decl(), ast:ty_scheme()) -> ok.
-check_infer_ok_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, Decl = {function, L, Name, Arity, _}, Ty) ->
+-spec check_infer_ok_fun(string(), symtab:t(), symtab:t(), sets:set({atom(), arity()}), sets:set({atom(), arity()}), #{{atom(), arity()} => {ast:ty(), exhaust | noexhaust}}, ast:fun_decl(), ast:ty_scheme()) -> ok.
+check_infer_ok_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, RecvMsgTys, Decl = {function, L, Name, Arity, _}, Ty) ->
     % Check that the inferred type is more general then the type in the spec
     Ctx0 = typing:new_ctx(Tab, OverlayTab, error),
-    Ctx = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy },
+    Ctx = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy, recv_msg_tys = RecvMsgTys },
     Envs =
        try
            typing_infer:infer(Ctx, [Decl])
@@ -66,10 +66,10 @@ check_infer_ok_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedu
       end,
     ok.
 
--spec check_fail_fun(string(), symtab:t(), symtab:t(), sets:set({atom(), arity()}), sets:set({atom(), arity()}), ast:fun_decl(), ast:ty_scheme()) -> ok.
-check_fail_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, Decl = {function, L, Name, Arity, _}, Ty) ->
+-spec check_fail_fun(string(), symtab:t(), symtab:t(), sets:set({atom(), arity()}), sets:set({atom(), arity()}), #{{atom(), arity()} => {ast:ty(), exhaust | noexhaust}}, ast:fun_decl(), ast:ty_scheme()) -> ok.
+check_fail_fun(Filename, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, RecvMsgTys, Decl = {function, L, Name, Arity, _}, Ty) ->
     Ctx0 = typing:new_ctx(Tab, OverlayTab, error),
-    Ctx = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy },
+    Ctx = Ctx0#ctx{ disable_exhaustiveness = DisableExhaustiveness, disable_redundancy = DisableRedundancy, recv_msg_tys = RecvMsgTys },
     try
         typing_check:check(Ctx, Decl, Ty),
         io:format("~s: Type checking ~w/~w in ~s succeeded but should fail",
@@ -91,14 +91,18 @@ check_decls_in_file(F, What, NoInfer) ->
   {ok, RawForms} = parse:parse_file(F, #parse_opts{includes =
                                                    ["include", "src", "src/erlang_types",
                                                     "src/erlang_types/dnf", "src/erlang_types/utils"]}),
-  Forms = ast_transform:trans(F, RawForms),
+  Forms0 = ast_transform:trans(F, RawForms),
+  Forms = typing:desugar_recv_funs(Forms0),
   Opts = #opts{gradual_typing_mode = infer},
   SearchPath = paths:compute_search_path(Opts),
+
+  % Desugar list-form msg_type attributes into helper functions with intersection specs.
   OverlayTab = symtab:empty(),
   Tab0 = symtab:std_symtab(SearchPath, symtab:empty(), Opts#opts.gradual_typing_mode),
   Tab = symtab:extend_symtab(F, Forms, Tab0,symtab:empty()),
   DisableExhaustiveness = typing:resolve_disabled_funs(functions_exhaustive, Forms),
   DisableRedundancy = typing:resolve_disabled_funs(functions_redundant, Forms),
+  RecvMsgTys = typing:recv_msg_tys_from_forms(Forms),
 
   CollectDecls = fun(Decl, TestCases) ->
     case Decl of
@@ -112,9 +116,9 @@ check_decls_in_file(F, What, NoInfer) ->
                 ?LOG_NOTE("Type checking ~s from ~s", NameStr, F),
                 global_state:with_new_state(fun() ->
                   case ShouldFail of
-                    true -> check_fail_fun(F, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, Decl, Ty);
+                    true -> check_fail_fun(F, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, RecvMsgTys, Decl, Ty);
                     false ->
-                      check_ok_fun(F, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, Decl, Ty)
+                      check_ok_fun(F, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, RecvMsgTys, Decl, Ty)
                   end
                                             end)
               end}
@@ -123,7 +127,7 @@ check_decls_in_file(F, What, NoInfer) ->
           {timeout, 10, {FullNameStr ++ " (infer)", fun() ->
                 ?LOG_NOTE("Infering type for ~s from ~s", NameStr, F),
                 global_state:with_new_state(fun() ->
-                  check_infer_ok_fun(F, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, Decl, Ty)
+                  check_infer_ok_fun(F, Tab, OverlayTab, DisableExhaustiveness, DisableRedundancy, RecvMsgTys, Decl, Ty)
                 end),
                 ok
               end}

--- a/test_files/tycheck_simple/intersection.erl
+++ b/test_files/tycheck_simple/intersection.erl
@@ -200,3 +200,21 @@ branch_unmatched_in_nested_expression_fail(foo) ->
         _  -> false
     end;
 branch_unmatched_in_nested_expression_fail(_) -> true.
+
+% Calling an intersection-typed function preserves the intersection.
+% This is the mechanism the typed-receive desugar relies on: a helper function
+% with an intersection spec is called from the original function.
+-spec overlapping_04(1) -> ok; (any()) -> any().
+overlapping_04(Msg) ->
+    case_as_fun(Msg).
+
+-spec case_as_fun(1) -> ok; (any()) -> any().
+case_as_fun(1) -> ok;
+case_as_fun(Any) -> Any.
+
+-spec overlapping_05(1) -> ok; (atom()) -> any(); (any()) -> any().
+overlapping_05(Msg) ->
+    case Msg of
+        1 -> ok;
+        Any -> Any
+    end.

--- a/test_files/tycheck_simple/sendreceive.erl
+++ b/test_files/tycheck_simple/sendreceive.erl
@@ -3,10 +3,41 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+% Define pid(_T) as a type alias for pid() so Erlang accepts pid(T) in specs.
+% Etylizer gives pid(T) special semantics: T is the message type the process accepts.
+-type pid(_T) :: pid().
+
+% Declare per-function receive message types for typed receive checking.
+% Format: -etylizer({msg_type, FunName, Arity, "TypeString"}).
+% Must appear before function definitions (OTP 28+ requirement).
+-etylizer({msg_type, recv_inter_01, 1, ["fun((1) -> ok)", "fun((any()) -> any())"]}).
+-etylizer({msg_type, recv_open_01, 0, ["fun((integer()) -> atom())", "fun((term()) -> term())"]}).
+-etylizer({msg_type, recv_open_02_fail, 0, ["fun((integer()) -> atom())", "fun((term()) -> term())"]}).
+-etylizer({msg_type, recv_msg_01, 0, "integer()"}).
+-etylizer({msg_type, recv_msg_02, 0, "integer()"}).
+-etylizer({msg_type, recv_msg_03_fail, 0, "integer()"}).  % X gets integer(), but spec says atom()
+-etylizer({msg_type, recv_msg_04, 0, "{ok, integer()}"}).
+-etylizer({msg_type, recv_msg_05_fail, 0, "integer()"}).
+-etylizer({msg_type, recv_msg_06_fail, 0, "atom()"}).
+-etylizer({msg_type, recv_msg_07_fail, 0, "atom()"}).
+-etylizer({msg_type, recv_msg_08_fail, 0, "atom()"}).
+-etylizer({msg_type, recv_msg_09, 0, "integer() | atom()", noexhaustiveness}).
+-etylizer({msg_type, recv_msg_10, 0, "{ok, integer()} | {error, atom()}", noexhaustiveness}).
+-etylizer({msg_type, recv_msg_11_fail, 0, "atom()", noexhaustiveness}).
+-etylizer({msg_type, ping_pong, 2, "integer()"}).
+-etylizer({msg_type, stdlib_relay_01, 1, "integer()"}).
+-etylizer({msg_type, stdlib_relay_02_fail, 1, "atom()"}).
+-etylizer({msg_type, stdlib_sys_loop_01, 0, "{system, atom()} | {exit, atom()}"}).
+-etylizer({msg_type, stdlib_sys_loop_02_fail, 0, "{system, atom()} | {exit, atom()}"}).
+-etylizer({msg_type, stdlib_result_recv_01, 0, "{ok, integer()} | {error, atom()}"}).
+-etylizer({msg_type, stdlib_result_recv_02_fail, 0, "{ok, integer()} | {error, atom()}"}).
+-etylizer({msg_type, nested_relay_01, 1, "pid(integer())"}).
+-etylizer({msg_type, nested_relay_02_fail, 1, "integer()"}).
+
 % Each top-level definition of this module is typechecked in isolation
 % against its spec, inference is also tested.
 % If the name ends with _fail, the test must fail.
-
+%
 %%%%%%%%%%%%%%%%%%%%%%%% SEND %%%%%%%%%%%%%%%%%%%%%%%
 
 -spec send_01(pid(), integer()) -> integer().
@@ -172,3 +203,258 @@ send_recv_01(Pid) ->
     receive
         ok -> ok
     end.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%% TYPED PID (pid(T)) %%%%%%%%%%%%%%%%%%%%%%%
+
+% Send an integer to a pid(integer())
+-spec pid_send_01(pid(integer())) -> integer().
+pid_send_01(Pid) -> Pid ! 42.
+
+% Send an integer to a pid(atom())
+-spec pid_send_02_fail(pid(atom())) -> integer().
+pid_send_02_fail(Pid) -> Pid ! 42.
+
+% Send a tuple to a pid({atom(), integer()})
+-spec pid_send_04(pid({atom(), integer()})) -> {atom(), integer()}.
+pid_send_04(Pid) -> Pid ! {ok, 1}.
+
+%%%%%%%%%%%%%%%%%%%%%%%% TYPED RECEIVE (msg_type) %%%%%%%%%%%%%%%%%%%%%%%
+
+% integer messages, result integer
+%-etylizer({msg_type, recv_msg_01, 0, "integer()"}).
+-spec recv_msg_01() -> integer().
+recv_msg_01() ->
+    receive
+        X -> X
+    end.
+
+% redundant refinement guard
+%-etylizer({msg_type, recv_msg_02, 0, "integer()"}).
+-spec recv_msg_02() -> integer().
+recv_msg_02() ->
+    receive
+        X when is_integer(X) -> X
+    end.
+
+% message is integer but expected atom() return
+%-etylizer({msg_type, recv_msg_03_fail, 0, "integer()"}).
+-spec recv_msg_03_fail() -> atom().
+recv_msg_03_fail() ->
+    receive
+        X -> X
+    end.
+
+% extract integer from tuple type
+%-etylizer({msg_type, recv_msg_04, 0, "{ok, integer()}"}).
+-spec recv_msg_04() -> integer().
+recv_msg_04() ->
+    receive
+        {ok, N} -> N
+    end.
+
+% ok branch is redundant
+%-etylizer({msg_type, recv_msg_05_fail, 0, "integer()"}).
+-spec recv_msg_05_fail() -> ok.
+recv_msg_05_fail() ->
+    receive ok -> ok; _ -> ok end.
+
+% expects atom(), non-exhaustive
+%-etylizer({msg_type, recv_msg_06_fail, 0, "atom()"}).
+-spec recv_msg_06_fail() -> ok.
+recv_msg_06_fail() ->
+    receive ok -> ok end.
+
+% two-branch non-exhaustive
+%-etylizer({msg_type, recv_msg_07_fail, 0, "atom()"}).
+-spec recv_msg_07_fail() -> ok | two.
+recv_msg_07_fail() ->
+    receive ok -> ok; two -> two end.
+
+% redundant branch
+%-etylizer({msg_type, recv_msg_08_fail, 0, "atom()"}).
+-spec recv_msg_08_fail() -> ok.
+recv_msg_08_fail() ->
+    receive 42 -> ok; _ -> ok end.
+
+% partial receive with noexhaustiveness 
+% only handles integer(), atom() stays in mailbox.
+%-etylizer({msg_type, recv_msg_09, 0, "integer() | atom()", noexhaustiveness}).
+-spec recv_msg_09() -> integer().
+recv_msg_09() ->
+    receive X when is_integer(X) -> X end.
+
+% Handle only {ok,...}
+% {error,...} stays in mailbox
+%-etylizer({msg_type, recv_msg_10, 0, "{ok, integer()} | {error, atom()}", noexhaustiveness}).
+-spec recv_msg_10() -> integer().
+recv_msg_10() ->
+    receive {ok, N} -> N end.
+
+% Redundancy with noexhaustiveness 
+% 42 is not atom(), dead code
+%-etylizer({msg_type, recv_msg_11_fail, 0, "atom()", noexhaustiveness}).
+-spec recv_msg_11_fail() -> ok.
+recv_msg_11_fail() ->
+    receive 
+        42 -> ok; 
+        X when is_atom(X) -> ok 
+    end.
+
+% ping-pong protocol: typed send and receive
+%-etylizer({msg_type, ping_pong, 2, "integer()"}).
+-spec ping_pong(pid(integer()), integer()) -> integer().
+ping_pong(Caller, N) ->
+    Caller ! N,
+    receive
+        Reply -> Reply
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%% STDLIB-INSPIRED PATTERNS %%%%%%%%%%%%%%%%%%%%%%%
+
+% From slave:relay1
+
+% Receive integer(), forward to pid(integer())
+%-etylizer({msg_type, stdlib_relay_01, 1, "integer()"}).
+-spec stdlib_relay_01(pid(integer())) -> no_return().
+stdlib_relay_01(Pid) ->
+    receive X -> Pid ! X end,
+    stdlib_relay_01(Pid).
+
+% msg_type is atom() but Pid expects an integer()
+%-etylizer({msg_type, stdlib_relay_02_fail, 1, "atom()"}).
+-spec stdlib_relay_02_fail(pid(integer())) -> no_return().
+stdlib_relay_02_fail(Pid) ->
+    receive X -> Pid ! X end,
+    stdlib_relay_02_fail(Pid).
+
+% From sys:suspend_loop, exhaustive & not redundant
+%-etylizer({msg_type, stdlib_sys_loop_01, 0, "{system, atom()} | {exit, atom()}"}).
+-spec stdlib_sys_loop_01() -> ok.
+stdlib_sys_loop_01() ->
+    receive
+        {system, _} -> stdlib_sys_loop_01();
+        {exit,   _} -> ok
+    end.
+
+% {exit,...} branch missing, not exhaustive
+%-etylizer({msg_type, stdlib_sys_loop_02_fail, 0, "{system, atom()} | {exit, atom()}"}).
+-spec stdlib_sys_loop_02_fail() -> ok.
+stdlib_sys_loop_02_fail() ->
+    receive
+        {system, _} -> stdlib_sys_loop_02_fail()
+    end.
+
+% From gen.erl, receive result union
+%-etylizer({msg_type, stdlib_result_recv_01, 0, "{ok, integer()} | {error, atom()}"}).
+-spec stdlib_result_recv_01() -> ok.
+stdlib_result_recv_01() ->
+    receive
+        {ok,    _} -> ok;
+        {error, _} -> ok
+    end.
+
+% Same msg_type, but {ok, X} when is_atom(X) is always dead
+%-etylizer({msg_type, stdlib_result_recv_02_fail, 0, "{ok, integer()} | {error, atom()}"}).
+-spec stdlib_result_recv_02_fail() -> ok.
+stdlib_result_recv_02_fail() ->
+    receive
+        {ok, X} when is_atom(X) -> ok;
+        {error, _}              -> ok
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%% NESTED pid(T) %%%%%%%%%%%%%%%%%%%%%%%
+
+% Send a pid(integer()) to a pid(pid(integer()))
+-spec nested_pid_send_01(pid(pid(integer())), pid(integer())) -> pid(integer()).
+nested_pid_send_01(Relay, Worker) ->
+    Relay ! Worker.
+
+% Send an integer() to a pid(pid(integer()))
+-spec nested_pid_send_02_fail(pid(pid(integer())), integer()) -> integer().
+nested_pid_send_02_fail(Relay, N) ->
+    Relay ! N.
+
+% receive pid(integer()), forward to pid(pid(integer()))
+%-etylizer({msg_type, nested_relay_01, 1, "pid(integer())"}).
+-spec nested_relay_01(pid(pid(integer()))) -> no_return().
+nested_relay_01(Relay) ->
+    receive Worker -> Relay ! Worker end,
+    nested_relay_01(Relay).
+
+% receive integer(), forward to pid(pid(integer()))
+%-etylizer({msg_type, nested_relay_02_fail, 1, "integer()"}).
+-spec nested_relay_02_fail(pid(pid(integer()))) -> no_return().
+nested_relay_02_fail(Relay) ->
+    receive N -> Relay ! N end,
+    nested_relay_02_fail(Relay).
+
+%%%%%%%%%%%%%%%%%%%%%%%% INTERSECTION MSG_TYPE %%%%%%%%%%%%%%%%%%%%%%%
+
+% msg_type list arity = function arity.
+% Desugared to a helper expression with case body and intersection spec.
+% Component (1)->ok: case 1->ok active, Any->Any redundant (compare how intersections are handled in case_of.erl).
+% Component (any())->any(): both branches active, returns any().
+%-etylizer({msg_type, recv_inter_01, 1, [
+%                           "fun((1) -> ok)", 
+%                           "fun((any()) -> any())"
+%                        ]}).
+-spec recv_inter_01(1) -> ok; (any()) -> any().
+recv_inter_01(_) ->
+    receive 1 -> ok; Any -> Any end.
+
+
+%% DESUGARED INTO (only for typing)
+%% original function: receive replaced by direct call, params forwarded
+% -spec recv_inter_01(1) -> ok; (any()) -> any().
+% recv_inter_01(_RecvP_a) ->
+%   '__recv__recv_inter_01__0'(_RecvP_a).
+%
+%% helper: intersection spec lifted from the msg_type list, receive cases become a case
+% -spec '__recv__recv_inter_01__0'(1) -> ok; (any()) -> any().
+% '__recv__recv_inter_01__0'(_RecvP_b) ->
+%   case _RecvP_b of
+%       1   -> ok;
+%       Any -> Any
+%   end.
+
+
+% 0-arg function, 1-arg msg_type (open protocol).
+% Component (integer())->atom(): scrutinee integer(), guard is_integer holds, returns foo
+% Component (any())->any(): both branches active, returns atom()|any() = any()
+%-etylizer({msg_type, recv_open_01, 0, [
+%                           "fun((integer()) -> atom())", 
+%                           "fun((any()) -> any())"
+%                       ]}).
+-spec recv_open_01() -> any().
+recv_open_01() ->
+    receive 
+        X when is_integer(X) -> foo; 
+        Other -> Other 
+    end.
+
+
+%% DESUGARED INTO (only for typing)
+%% injected: pins the outer pass-through receive's message type to term() (top)
+%-etylizer({msg_type, recv_open_01, 0, term()}).
+%% original function: receive becomes an untyped pass-through that forwards the message
+% -spec recv_open_01() -> term().
+% recv_open_01() ->
+%   receive
+%       __RecvMsg -> '__recv__recv_open_01__0'(__RecvMsg)
+%   end.
+
+%% helper: takes the message as an extra param; receive cases become a case
+% -spec '__recv__recv_open_01__0'(integer()) -> atom(); (term()) -> term().
+% '__recv__recv_open_01__0'(__RecvP_c) ->
+%   case __RecvP_c of
+%       X when is_integer(X) -> foo;
+%       Other               -> Other
+%   end.
+
+% Missing is_integer guard: case Other->Other with scrutinee integer() returns integer(),
+% but component (integer())->atom() requires atom()
+%-etylizer({msg_type, recv_open_02_fail, 0, ["fun((integer()) -> atom())", "fun((term()) -> term())"]}).
+-spec recv_open_02_fail() -> atom().
+recv_open_02_fail() ->
+    receive Other -> Other end.


### PR DESCRIPTION
I tried implementing the future work from the IFL'22 paper (Wadler pid types), by itself it wasn't too useful. Naive implementation has conflicts (false positives) with set-theoretic types concerning redundancy and exhaustiveness checking.

The fix is to use function types. Because we can't invent new type syntax for Erlang, there are now two representations and this feels a bit hacky, but it works. 

The capabilities can be seen in `test_files/tycheck_simple/sendreceive.erl`