### PR TITLE
Comprehension fixes

### DIFF
--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -515,7 +515,8 @@ process_qualifiers(Ctx, Loc, [Q | Qs], Env, Cs) ->
         % strict list generator: Pat <:- Exp
         {generate_strict, LGen, Pat, Exp} ->
             Alpha = fresh_tyvar(Ctx),
-            ExpCs = exp_constrs(Ctx, Exp, stdtypes:tlist(Alpha)),
+            ExpCs0 = exp_constrs(Ctx, Exp, stdtypes:tlist(Alpha)),
+            ExpCs = sets:from_list([{cdef, mk_locs("strict list generator source", LGen), Env, ExpCs0}]),
 
             % For strict generators, the list element type must be a subtype of the pattern type
             TyPat = ty_of_pat(Ctx#ctx.symtab, Env, Pat, upper),
@@ -531,7 +532,12 @@ process_qualifiers(Ctx, Loc, [Q | Qs], Env, Cs) ->
             Alpha = fresh_tyvar(Ctx), % list elements
             Beta = fresh_tyvar(Ctx), % pattern
 
-            ExpCs = exp_constrs(Ctx, Exp, stdtypes:tlist(Alpha)),
+            % The source expression is evaluated in the environment of the
+            % preceding qualifiers, so wrap its constraints in a cdef carrying
+            % Env. Without this, a source list referencing a variable bound by
+            % an earlier generator is unbound at simplification time.
+            ExpCs0 = exp_constrs(Ctx, Exp, stdtypes:tlist(Alpha)),
+            ExpCs = sets:from_list([{cdef, mk_locs("list generator source", LGen), Env, ExpCs0}]),
 
             TyPat = ty_of_pat(Ctx#ctx.symtab, Env, Pat, upper),
             {PatCs, PatEnv} = pat_env(Ctx, LGen, Beta, Pat),
@@ -555,7 +561,8 @@ process_qualifiers(Ctx, Loc, [Q | Qs], Env, Cs) ->
         {m_generate_strict, LGen, KeyPat, ValPat, Exp} ->
             KeyAlpha = fresh_tyvar(Ctx),
             ValAlpha = fresh_tyvar(Ctx),
-            ExpCs = exp_constrs(Ctx, Exp, stdtypes:tmap(KeyAlpha, ValAlpha)),
+            ExpCs0 = exp_constrs(Ctx, Exp, stdtypes:tmap(KeyAlpha, ValAlpha)),
+            ExpCs = sets:from_list([{cdef, mk_locs("strict map generator source", LGen), Env, ExpCs0}]),
 
             % For strict generators, the map element types must be subtypes of the pattern types
             TyKeyPat = ty_of_pat(Ctx#ctx.symtab, Env, KeyPat, upper),
@@ -577,7 +584,8 @@ process_qualifiers(Ctx, Loc, [Q | Qs], Env, Cs) ->
             KeyBeta = fresh_tyvar(Ctx), % key pattern type
             ValBeta = fresh_tyvar(Ctx), % value pattern type
 
-            ExpCs = exp_constrs(Ctx, Exp, stdtypes:tmap(KeyAlpha, ValAlpha)),
+            ExpCs0 = exp_constrs(Ctx, Exp, stdtypes:tmap(KeyAlpha, ValAlpha)),
+            ExpCs = sets:from_list([{cdef, mk_locs("map generator source", LGen), Env, ExpCs0}]),
 
             % Get upper bounds for filtering
             TyKeyPat = ty_of_pat(Ctx#ctx.symtab, Env, KeyPat, upper),

--- a/test_files/tycheck_simple/comprehension.erl
+++ b/test_files/tycheck_simple/comprehension.erl
@@ -120,3 +120,18 @@ zip_02_fail() ->
 -spec lc_15_fail(integer()) -> list().
 lc_15_fail(N) ->  [X || X <- N].
 
+% Nested generator whose source list is a variable bound by an earlier generator. 
+-spec lc_nested_gen([[integer()]]) -> [integer()].
+lc_nested_gen(L) -> [X || Xs <- L, X <- Xs].
+
+-spec lc_nested_gen_s([[integer()]]) -> [integer()].
+lc_nested_gen_s(L) -> [X || Xs <:- L, X <:- Xs].
+
+-spec lc_nested_gen_fail([[integer()]]) -> [atom()].
+lc_nested_gen_fail(L) -> [X || Xs <- L, X <- Xs]. % X is integer(), not atom()
+
+% Same scoping case for a map comprehension: the second generator iterates a
+% map bound by the first generator.
+-spec mc_nested_gen([#{atom() => integer()}]) -> #{atom() => integer()}.
+mc_nested_gen(Ms) -> #{K => V || M <- Ms, K := V <- M}.
+


### PR DESCRIPTION
Unbound variable in simplification bound for list comprehensions fix.

All five `Error -> Ok` changes are expected, a generator whose source expression references a variable bound by an earlier generator.