### PR TITLE
Improper lists

### DIFF
--- a/src/ast_transform.erl
+++ b/src/ast_transform.erl
@@ -378,12 +378,17 @@ trans_ty(Ctx, Env, Ty) ->
             Loc = to_loc(Ctx, Anno),
             NewArgTys = trans_tys(Ctx, Env, ArgTys),
             case {Name, NewArgTys} of
-                % There is a long discussion about improper lists here:
-                % https://github.com/josefs/Gradualizer/issues/110
-                % To keep things simple, we do not distinguish between an improper list
-                % and a maybe-improper list.
+                % we follow the semantics of Erlang:
+                % list_to_binary([2 | <<1>>])  -> <<2,1>>     % <<1>> termination OK
+                % list_to_binary(<<1>>)        -> badarg      % <<1>> top level: ERROR
+                % iolist_to_binary(<<1>>)      -> <<1>>
+                % A maybe_improper_list(T1, T2) is [] or a cons chain over T1
+                % whose final tail is in T2
+                % nonempty_maybe_improper_list and nonempty_improper_list:
+                % they differ only in their termination types
                 {nonempty_list, [T]} -> {nonempty_list, T};
-                {maybe_improper_list, [T1, T2]} -> {improper_list, T1, T2};
+                {maybe_improper_list, [T1, T2]} ->
+                    {union, [{empty_list}, {nonempty_improper_list, T1, T2}]};
                 {nonempty_maybe_improper_list, [T1, T2]} -> {nonempty_improper_list, T1, T2};
                 {nonempty_improper_list, [T1, T2]} -> {nonempty_improper_list, T1, T2};
                 {record, [{singleton, RecordName}]} when is_atom(RecordName) ->

--- a/src/constr_gen.erl
+++ b/src/constr_gen.erl
@@ -1636,7 +1636,10 @@ var_test_env(FunExp, X, RestArgs) ->
                             is_function -> {#{XRef => {predef_alias, function}}, safe};
                             is_integer -> {#{XRef => {predef, integer}}, safe};
                             is_float -> {#{XRef => {predef, float}}, safe};
-                            is_list -> {#{XRef => {predef_alias, list}}, safe};
+                            % is_list/1 only checks the top constructor 
+                            % true for [] and for every cons cell (improper tails included)
+                            % so it must not narrow to the proper list type.
+                            is_list -> {#{XRef => {predef_alias, maybe_improper_list}}, safe};
                             is_map -> {#{XRef => {predef_alias, map}}, safe};
                             is_number -> {#{XRef => {predef_alias, number}}, safe};
                             is_pid -> {#{XRef => {predef, pid}}, safe};

--- a/src/erlang_types/ty_rec.erl
+++ b/src/erlang_types/ty_rec.erl
@@ -508,8 +508,11 @@ unparse_any_module(dnf_ty_atom, {predef, any}) -> {predef, atom};
 unparse_any_module(dnf_ty_atom, Result) -> ast_lib:mk_intersection([{predef, atom}, Result]);
 unparse_any_module(dnf_ty_interval, {predef, any}) -> {predef, integer};
 unparse_any_module(dnf_ty_interval, Result) -> ast_lib:mk_intersection([{predef, integer}, Result]);
-unparse_any_module(dnf_ty_list, {predef, any}) -> {improper_list, {predef, any}, {predef, any}};
-unparse_any_module(dnf_ty_list, Result) -> ast_lib:mk_intersection([{improper_list, {predef, any}, {predef, any}}, Result]);
+% The internal list component holds cons cells only ([] lives in
+% dnf_ty_predefined), so its top is cons(any(), any()), i.e. the nonempty
+% maybe-improper list. {improper_list, any, any} would re-parse to any().
+unparse_any_module(dnf_ty_list, {predef, any}) -> {nonempty_improper_list, {predef, any}, {predef, any}};
+unparse_any_module(dnf_ty_list, Result) -> ast_lib:mk_intersection([{nonempty_improper_list, {predef, any}, {predef, any}}, Result]);
 unparse_any_module(dnf_ty_bitstring, {predef, any}) -> {bitstring};
 unparse_any_module(dnf_ty_bitstring, Result) -> ast_lib:mk_intersection([{bitstring}, Result]);
 unparse_any_module(ty_tuples, {predef, any}) -> {tuple_any};

--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -217,9 +217,11 @@ tspecial_any() ->
         {predef, reference}
     ]).
 
+% All list values: [] or any cons cell
+% corresponds to elements for which is_list/1 returns true.
 -spec tlist_any() -> ast:ty().
 tlist_any() ->
-    {improper_list, {predef, any}, {predef, any}}.
+    {union, [{empty_list}, {nonempty_improper_list, {predef, any}, {predef, any}}]}.
 
 -spec tlist_improper(ast:ty(), ast:ty()) -> ast:ty().
 tlist_improper(A, B) ->
@@ -259,8 +261,10 @@ expand_predef_alias(number) -> {union, [{predef, float}, {predef, integer}]};
 expand_predef_alias(list) -> {list, {predef, any}};
 % also see code in ast_transform for expanding predefined aliases applied to arguments
 expand_predef_alias(nonempty_list) -> {nonempty_list, {predef, any}};
-expand_predef_alias(maybe_improper_list) -> {improper_list, {predef, any}, {predef, any}};
-expand_predef_alias(nonempty_maybe_improper_list) -> {nonempty_list, {predef, any}};
+expand_predef_alias(maybe_improper_list) ->
+    {union, [{empty_list}, {nonempty_improper_list, {predef, any}, {predef, any}}]};
+expand_predef_alias(nonempty_maybe_improper_list) ->
+    {nonempty_improper_list, {predef, any}, {predef, any}};
 expand_predef_alias(string) -> {list, expand_predef_alias(char)};
 expand_predef_alias(nonempty_string) -> {nonempty_list, expand_predef_alias(char)};
 expand_predef_alias(iodata) -> {union, [expand_predef_alias(iolist), expand_predef_alias(binary)]};
@@ -268,7 +272,12 @@ expand_predef_alias(iolist) ->
     % TODO fix variable IDs
     RecVarID = erlang:unique_integer(),
     Var = {mu_var, erlang:list_to_atom("mu" ++ integer_to_list(RecVarID))},
-    RecType = {improper_list, {union, [expand_predef_alias(byte), expand_predef_alias(binary), Var]}, {union, [expand_predef_alias(binary), tempty_list()]}},
+    Elem = {union, [expand_predef_alias(byte), expand_predef_alias(binary), Var]},
+    Term = {union, [expand_predef_alias(binary), tempty_list()]},
+    % iolist() = maybe_improper_list(byte() | binary() | iolist(), binary() | []).
+    % A bare binary() is iodata() but not an iolist(): list_to_binary/1 accepts
+    % [2 | <<1>>] and rejects <<1>>.
+    RecType = {union, [tempty_list(), {nonempty_improper_list, Elem, Term}]},
     {mu, Var, RecType};
 expand_predef_alias(map) -> {map, [{map_field_opt, {predef, any}, {predef, any}}]};
 expand_predef_alias(function) -> {fun_simple};


### PR DESCRIPTION
Until now the `is_list/1` guard refined its argument to a proper list (`list()`). That is unsound: `is_list/1` is not defined that way.

`is_list/1` is an O(1) runtime check that only inspects the top constructor. It returns `true` for `[]` and for every cons cell, including improper tails. So `is_list([1|2])` and `is_list([1,2|3])` are both `true`. The correct refinement is therefore `maybe_improper_list()`, exactly as the OTP documentation for `is_list/1` spells out.

Therefore, we let the `is_list` guard refine to  `maybe_improper_list()`.

From our case study:

```erlang
-spec is_set(Ordset) -> boolean() when Ordset :: term().
is_set([E|Es]) -> is_set(Es, E);
is_set([]) -> true;
is_set(_) -> false.

-spec is_set(list(term()), term()) -> boolean().
is_set([E2|Es], E1) when E1 < E2 -> is_set(Es, E2);
is_set([_|_], _) -> false;
is_set([], _) -> true.
```

Our previous "fix" was to add an `is_list` guard to the first clause of `is_set/1`. That stopped etylizer from complaining and made the function check as type-correct. The problem is, the function still crashes for example on `is_set([1,2|3])`. With the precise refinement, the type checker now (rightly) rejects it. To make this crash-free you have to adapt the implementation, e.g. widen `is_set/2` to accept `term()` and handle the improper case explicitly.

Our own `utils:everywhere`/`utils:everything`/`utils:sformat/2` are subject to the same problem as they crash on `[1,2|3]`, and the corrected versions need to handle improper lists explicitly. Anywhere a value is refined via `is_list` and then handed to a function defined only on `list()` (and might contain improper list values), the checker now flags a (justified) crash risk. 

`symtab:is_exported/3` is a bit more tricky:

```erlang
  ...
  {attribute, _, compile, Opts} when is_list(Opts) -> lists:member(export_all, Opts)
  ...
```

`lists:member` will crash if Opts contains an improper list values. An erlang module containing

```erlang
-compile([1|2]).
```

for example, can be parsed (but not compiled) by Erlang. So in theory, improper lists can reach `is_exported/3`. But improper lists are filtered out before in our pipeline, so the fix for us is to narrow our spec of our transformed AST.

A user who has never dealt with improper lists won't expect this. Erlang's syntax happily blurs proper and improper lists together. For now we take the precise, sound type: `is_list/1` refines to `maybe_improper_list()`. The type checker is correct, and we'd rather surface crash risks than hide them.

To accommodate codebases that, in practice, only ever use proper lists and don't want the extra friction, we plan to add an flag that reduces precision and treats `is_list/1` as refining to `list()` (the eqWAlizer behaviour). Maybe even emit a **warning** making the resulting unsoundness explicit. #365 