### PR TITLE
Fix type schemes of operators

### DIFF
--- a/src/stdtypes.erl
+++ b/src/stdtypes.erl
@@ -325,9 +325,10 @@ builtin_ops() ->
     DivOpTy = tyscm(tinter([tfun([tint(), tint()], tint()), tfun([tnon_neg_int(), tnon_neg_int()], tnon_neg_int())])),
     IntOpTy = tyscm(tinter([tfun([tnon_neg_int(), tnon_neg_int()], tnon_neg_int()), tfun([tint(), tint()], tint())])),
     BoolOpTy = tyscm(tfun([tbool(), tbool()], tbool())),
-    AndShortcutOpTy = tyscm(tinter([tfun([tatom(false), tany()], tatom(false)), tfun([tatom(true), tvar(a)], tvar(a))])),
-    OrShortcutOpTy = tyscm(tinter([tfun([tatom(true), tany()], tatom(true)), tfun([tatom(false), tvar(b)], tvar(b))])),
-    PolyOpTy = tyscm(tfun([tvar(aa), tvar(aa)], tbool())),
+    % These schemes for operators are polymorphic
+    AndShortcutOpTy = tyscm([a], tinter([tfun([tatom(false), tany()], tatom(false)), tfun([tatom(true), tvar(a)], tvar(a))])),
+    OrShortcutOpTy = tyscm([a], tinter([tfun([tatom(true), tany()], tatom(true)), tfun([tatom(false), tvar(a)], tvar(a))])),
+    PolyOpTy = tyscm([a], tfun([tvar(a), tvar(a)], tbool())),
     [
         {'+', 2, NumOpTy},
         {'-', 2, NumOpTy},

--- a/test_files/tycheck/issue_235_op_tyvars.erl
+++ b/test_files/tycheck/issue_235_op_tyvars.erl
@@ -1,0 +1,22 @@
+-module(issue_235_op_tyvars).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+% Regression test for issue #235
+
+-spec same() -> boolean().
+same() ->
+  true andalso true =/= ok.
+
+-spec two_andalso() -> {1, hello}.
+two_andalso() ->
+    X = true andalso 1,
+    Y = true andalso hello,
+    {X, Y}.
+
+-spec two_orelse() -> {1, hello}.
+two_orelse() ->
+    X = false orelse 1,
+    Y = false orelse hello,
+    {X, Y}.


### PR DESCRIPTION
Type schemes of operators are polymorphic. The type variable `a` must be quantified so that it is renamed to a fresh variable at every use site. Building them with `tyscm/1` (an empty binder) leaks `a` as a single shared variable across all applications, so two uses of the same operator get conflated. Fixes #235. Because each scheme now binds its own `a`, they can all reuse the same name safely.